### PR TITLE
fix(url-check): follow redirects on HEAD to catch 410/404 behind 3xx hops (BL-22)

### DIFF
--- a/engine/core/url_check.js
+++ b/engine/core/url_check.js
@@ -123,11 +123,13 @@ async function checkOne(row, fetchFn, opts = {}) {
   let finalUrl = url;
   let error = null;
 
-  // HEAD first: minimal data transfer, sufficient for liveness.
+  // HEAD first: minimal data transfer, sufficient for liveness. Follow
+  // redirects so a 3xx hop (e.g. trailing-slash normalization) doesn't
+  // mask a 410/404 on the real destination, and so finalUrl reflects
+  // the actual landing page for board-root detection below.
   try {
-    const res = await fetchFn(url, { method: "HEAD", timeoutMs, retries: 0, redirect: "manual" });
+    const res = await fetchFn(url, { method: "HEAD", timeoutMs, retries: 0, redirect: "follow" });
     status = res.status || 0;
-    // When redirect: "manual", res.url stays at the original; use it as-is.
     finalUrl = res.url || url;
   } catch (err) {
     error = err.message;

--- a/engine/core/url_check.test.js
+++ b/engine/core/url_check.test.js
@@ -148,6 +148,31 @@ test("checkOne marks alive=false when GET redirects to board root", async () => 
   assert.equal(result.finalUrl, boardRootUrl);
 });
 
+test("checkOne marks alive=false when HEAD follows redirects to 410 Gone (BL-22)", async () => {
+  // SumUp-style case: 308 trailing-slash normalization → final 410.
+  // With redirect: "follow" the HEAD fetch lands at the 410 directly.
+  const finalUrl = "https://www.sumup.com/en-us/careers/positions/123/?gh_jid=123";
+  const fetchFn = makeFetch({
+    [`HEAD:${JOB_URL}`]: { status: 410, finalUrl },
+    [`GET:${JOB_URL}`]: { status: 410, finalUrl },
+  });
+  const result = await checkOne({ url: JOB_URL }, fetchFn);
+  assert.equal(result.alive, false);
+  assert.equal(result.status, 410);
+});
+
+test("checkOne marks alive=false when HEAD follows redirects to 404 (BL-22)", async () => {
+  // Ripple-style case: 308 trailing-slash normalization → final 404.
+  const finalUrl = "https://ripple.com/careers/all-jobs/job/123/?gh_jid=123";
+  const fetchFn = makeFetch({
+    [`HEAD:${JOB_URL}`]: { status: 404, finalUrl },
+    [`GET:${JOB_URL}`]: { status: 404, finalUrl },
+  });
+  const result = await checkOne({ url: JOB_URL }, fetchFn);
+  assert.equal(result.alive, false);
+  assert.equal(result.status, 404);
+});
+
 test("checkOne does NOT flag as board-root when job id appears in final URL", async () => {
   // finalUrl contains the original job id (12345) → redirect is fine
   const finalUrl = "https://boards.greenhouse.io/affirm/jobs/12345/apply";


### PR DESCRIPTION
## Summary

- URL-check на этапе `prepare` пропускал мёртвые вакансии (410/404), которые отвечали 308/301-редиректом первым хопом (trailing-slash normalization, локализация и т.п.). Так в Notion попадали карточки на удалённые SumUp / Ripple вакансии.
- Фикс: HEAD теперь следует за редиректами (`redirect: "follow"`), что даёт реальный статус финальной страницы и обновляет `finalUrl` для board-root детекции.
- 2 smoke-теста на 308→410 и 308→404 цепочки.

Эффект — общесистемный, не точечный: работает для всех источников, которые проходят URL-check (greenhouse, lever, ashby, workday, smartrecruiters, oracle cloud и т.д.).

**Out of scope:** антибот-403 (Dropbox-кейс) — нужен content-based детект на JD-fetch, отдельная задача (BL-42, M-тир, требует RFC).

## Test plan

- [x] `node --test engine/core/url_check.test.js` — 25/25 зелёные, включая 2 новых BL-22 кейса
- [x] `npm test` — 1122/1122 без регрессий
- [x] `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)