### PR TITLE
RFC 030 unified role-targets + BL-55 PDF arrow fix + format cleanup

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,3 +16,7 @@ package-lock.json
 **/*.md
 **/*.json
 **/*.css
+
+# Test fixtures are byte-sensitive — icims/talentbrew parsers look at exact
+# whitespace. Reformatting changes test outcomes.
+engine/modules/discovery/fixtures/**/*.html

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -29,9 +29,12 @@ Steps in detail:
 1. **Discovery**. Each enabled adapter fetches its source and emits
    normalized job records in memory. No filesystem writes yet.
 2. **Filter**. `engine/core/filter.js` applies the profile's
-   `filter_rules.json` (title / company / location blocklists). The
-   US-marker safeguard suppresses location blocklist when the JD asserts
-   "United States".
+   `filter_rules.json` (title / company / location blocklists, plus the
+   positive title gate). Since RFC 030 the title gate is sourced from
+   `role_targets.tracks[].patterns` — `profile_loader.normalizeFilterRules`
+   synthesizes the flat `title_requirelist` array filter.js consumes, so
+   the hot path is unchanged. The US-marker safeguard suppresses location
+   blocklist when the JD asserts "United States".
 3. **Dedup**. `engine/core/dedup.js` checks `(ats_source, job_id)`
    against the shared `data/jobs.tsv` and the profile's
    `applications.tsv`. Survivors are appended to `data/jobs.tsv`.

--- a/docs/architecture/multi-profile.md
+++ b/docs/architecture/multi-profile.md
@@ -19,7 +19,7 @@ routes I/O accordingly.
 ```
 profiles/<id>/
   profile.json                # identity, modules, Notion DB ids, fit prompt
-  filter_rules.json           # title / company / location blocklists (flat shape)
+  filter_rules.json           # title / company / location blocklists + role_targets (RFC 030)
   resume_versions.json        # archetypes -> resume DOCX content blocks
   cover_letter_versions.json  # archetypes -> CL content blocks
   cover_letter_template.md    # template with {{placeholders}}

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -44,9 +44,9 @@ Three invariants follow:
 
 | Module | Responsibility | Consumed by |
 |---|---|---|
-| `profile_loader.js` | Single read point for `profiles/<id>/`. Validates id, loads `profile.json`, normalizes `filter_rules.json` (flat shape), reads namespaced secrets from `.env`. | every `engine/commands/*` |
+| `profile_loader.js` | Single read point for `profiles/<id>/`. Validates id, loads `profile.json`, normalizes `filter_rules.json` (flat shape; synthesizes legacy `title_requirelist` from RFC 030 `role_targets.tracks[].patterns` when present), reads namespaced secrets from `.env`. | every `engine/commands/*` |
 | `paths.js` | Resolves canonical paths inside a profile root. | loader, commands, generators |
-| `filter.js` | Title / company / location blocklist matcher. Case-insensitive substring; US-marker safeguard skips location blocklist when "United States" is asserted. | `commands/scan.js`, `commands/validate.js`, `email_filters.js` |
+| `filter.js` | Title (positive requirelist + negative blocklist) / company / location matcher. Case-insensitive substring with word boundaries; US-marker safeguard skips location blocklist when "United States" is asserted. Positive title gate is sourced from `role_targets` via the loader shim (RFC 030). | `commands/scan.js`, `commands/validate.js`, `email_filters.js` |
 | `dedup.js` | Cross-profile dedup against `data/jobs.tsv` and per-profile `applications.tsv`. Keys on `(ats_source, job_id)`. | `commands/scan.js` |
 | `validator.js` | URL liveness, company cap, TSV hygiene checks. Powers `validate`. | `commands/validate.js` |
 | `applications_tsv.js` | v3 schema reader/writer (auto-upgrades v1 → v2 → v3 on read; always writes v3). `appendNew` defaults `status="Inbox"` (TSV-only staging, [RFC 014](../../rfc/014-status-split-new-vs-toapply.md)). | every command that touches TSV |

--- a/engine/commands/prepare.js
+++ b/engine/commands/prepare.js
@@ -684,7 +684,9 @@ async function runPre(ctx, deps) {
   // acceptable and how to treat each (primary / bridge). Strip regex patterns
   // — the LLM doesn't need them (scan already enforced the title gate) and
   // they bloat the prompt. Treatments-prose only.
-  const roleTargets = buildRoleTargetsForContext(profile.filterRules && profile.filterRules.role_targets);
+  const roleTargets = buildRoleTargetsForContext(
+    profile.filterRules && profile.filterRules.role_targets
+  );
 
   // BL-9 Step 5: signal for the autonomous SKILL loop ("Inbox is empty, stop
   // iterating even if 30-target not yet hit").

--- a/engine/commands/prepare.js
+++ b/engine/commands/prepare.js
@@ -384,6 +384,24 @@ function computeSkipReasons(skipped) {
   return skipReasons;
 }
 
+// RFC 030: surface role_targets to the SKILL via prepare_context.json.
+// Strips regex patterns — scan already applied them; the LLM only needs
+// (id, name, fit_treatment) per track plus the treatments-prose to reason
+// about Fit Score. Returns null if no role_targets configured (back-compat
+// for profiles that pre-date RFC 030 — SKILL falls back to memory cues).
+function buildRoleTargetsForContext(rt) {
+  if (!rt || !Array.isArray(rt.tracks) || rt.tracks.length === 0) return null;
+  return {
+    tracks: rt.tracks.map((t) => ({
+      id: t.id,
+      name: t.name,
+      fit_treatment: t.fit_treatment || "primary",
+      ...(t.bridge_note ? { bridge_note: t.bridge_note } : {}),
+    })),
+    fit_treatments: rt.fit_treatments || {},
+  };
+}
+
 // RFC 024 (BL-28): forward-looking Inbox-health signal for the SKILL.
 // "How many filter-passing rows are left in Inbox for the NEXT prepare run?"
 // Live smoke 2026-05-11 made the gap visible: target=30, got 26, but the
@@ -662,6 +680,12 @@ async function runPre(ctx, deps) {
   // the SKILL falls back to resume_versions.json / cover_letter_template.md.
   const memory = profile.memory || { writingStyle: null, resumeKeyPoints: null, feedback: [] };
 
+  // RFC 030: surface role_targets so SKILL Fit Score knows which tracks are
+  // acceptable and how to treat each (primary / bridge). Strip regex patterns
+  // — the LLM doesn't need them (scan already enforced the title gate) and
+  // they bloat the prompt. Treatments-prose only.
+  const roleTargets = buildRoleTargetsForContext(profile.filterRules && profile.filterRules.role_targets);
+
   // BL-9 Step 5: signal for the autonomous SKILL loop ("Inbox is empty, stop
   // iterating even if 30-target not yet hit").
   const batchKeys = new Set(batchOut.map((e) => e.key));
@@ -687,6 +711,7 @@ async function runPre(ctx, deps) {
     generatedAt: deps.now(),
     mode: "fresh",
     memory,
+    roleTargets,
     salaryConfig: profile.salaryConfig || null,
     batchSize,
     batch: batchOut,

--- a/engine/commands/prepare.test.js
+++ b/engine/commands/prepare.test.js
@@ -335,6 +335,72 @@ test("prepare --phase pre: writes prepare_context.json with correct shape", asyn
   assert.equal(ctx2.stats.inboxTotal, 1);
 });
 
+// RFC 030: roleTargets surface in prepare_context.json (with patterns stripped)
+
+test("prepare --phase pre: emits roleTargets in context with regex patterns stripped", async () => {
+  const apps = [makeApp()];
+  const deps = makePrepDeps(apps, {
+    loadProfile: () => ({
+      id: "testuser",
+      filterRules: {
+        role_targets: {
+          fit_treatments: { primary: "p-prose", bridge: "b-prose" },
+          tracks: [
+            {
+              id: "pm",
+              name: "Product Manager",
+              fit_treatment: "primary",
+              patterns: [{ pattern: "product manager", reason: "PM" }],
+            },
+            {
+              id: "fde",
+              name: "Forward-Deployed Engineer",
+              fit_treatment: "bridge",
+              bridge_note: "treat as primary at AI-native",
+              patterns: [{ pattern: "forward deployed", reason: "FDE" }],
+            },
+          ],
+        },
+      },
+      company_tiers: { Stripe: "S" },
+      paths: {
+        root: "/fake/profiles/testuser",
+        applicationsTsv: "/fake/profiles/testuser/applications.tsv",
+        jdCacheDir: "/fake/profiles/testuser/jd_cache",
+      },
+    }),
+  });
+  const cmd = makePrepareCommand(deps);
+  const ctx = makeCtx();
+  const code = await cmd(ctx);
+  assert.equal(code, 0);
+
+  const written = JSON.parse(deps._written["/fake/profiles/testuser/prepare_context.json"]);
+  assert.ok(written.roleTargets, "context should expose roleTargets");
+  assert.equal(written.roleTargets.tracks.length, 2);
+  // Patterns are stripped — LLM doesn't need regex, scan already applied it.
+  for (const t of written.roleTargets.tracks) {
+    assert.equal(t.patterns, undefined, `track ${t.id} should not carry patterns`);
+  }
+  // Treatments + bridge_note preserved.
+  assert.equal(written.roleTargets.tracks[0].fit_treatment, "primary");
+  assert.equal(written.roleTargets.tracks[1].fit_treatment, "bridge");
+  assert.equal(written.roleTargets.tracks[1].bridge_note, "treat as primary at AI-native");
+  assert.deepEqual(written.roleTargets.fit_treatments, { primary: "p-prose", bridge: "b-prose" });
+});
+
+test("prepare --phase pre: roleTargets is null when filterRules has no role_targets", async () => {
+  const apps = [makeApp()];
+  const deps = makePrepDeps(apps); // default loadProfile → filterRules: {}
+  const cmd = makePrepareCommand(deps);
+  const ctx = makeCtx();
+  const code = await cmd(ctx);
+  assert.equal(code, 0);
+
+  const written = JSON.parse(deps._written["/fake/profiles/testuser/prepare_context.json"]);
+  assert.equal(written.roleTargets, null);
+});
+
 test("prepare --phase pre: dry-run does not write file", async () => {
   const apps = [makeApp()];
   const deps = makePrepDeps(apps);

--- a/engine/core/filter.js
+++ b/engine/core/filter.js
@@ -45,6 +45,18 @@ function escapeRegex(s) {
   return String(s).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+// Word-boundary match that also handles patterns whose first or last char is
+// a non-word character (comma, dot, space). Plain `\b...\b` fails for those
+// because `\b` requires a word/non-word transition — it never fires between
+// two non-word chars (e.g. between `,` and ` `). When the pattern edge is
+// already a non-word char, the boundary is intrinsic and `\b` is omitted.
+function makeBoundaryRegex(needle) {
+  const lower = String(needle).toLowerCase();
+  const startB = /\w/.test(lower[0]) ? "\\b" : "";
+  const endB = /\w/.test(lower[lower.length - 1]) ? "\\b" : "";
+  return new RegExp(`${startB}${escapeRegex(lower)}${endB}`, "i");
+}
+
 // Returns a reason object for the first matching blocklist (company / title /
 // location) or null if nothing matches. Content-only: does NOT consult
 // company_cap. Used by:
@@ -90,10 +102,9 @@ function matchBlocklists(job, rules) {
     if (Array.isArray(rules.title_requirelist) && rules.title_requirelist.length > 0) {
       const anyPartMatches = parts.some((part) =>
         rules.title_requirelist.some((pat) => {
-          const needle = String(pat.pattern || "").toLowerCase();
+          const needle = String(pat.pattern || "");
           if (!needle) return false;
-          const re = new RegExp(`\\b${escapeRegex(needle)}\\b`, "i");
-          return re.test(part);
+          return makeBoundaryRegex(needle).test(part);
         })
       );
       if (!anyPartMatches) {
@@ -106,10 +117,9 @@ function matchBlocklists(job, rules) {
     for (const part of parts) {
       let partHit = null;
       for (const pat of rules.title_blocklist || []) {
-        const needle = String(pat.pattern || "").toLowerCase();
+        const needle = String(pat.pattern || "");
         if (!needle) continue;
-        const re = new RegExp(`\\b${escapeRegex(needle)}\\b`, "i");
-        if (re.test(part)) {
+        if (makeBoundaryRegex(needle).test(part)) {
           partHit = { kind: "title_blocklist", pattern: pat.pattern, why: pat.reason };
           break;
         }

--- a/engine/core/filter.test.js
+++ b/engine/core/filter.test.js
@@ -151,6 +151,41 @@ test("filterJobs title_blocklist does NOT split on comma (department modifier st
   assert.equal(rejected[0].reason.pattern, "supervisor");
 });
 
+test("filterJobs title_blocklist patterns ending in non-word char (comma, space) match", () => {
+  // 2026-05-12 fix: `\b<needle>\b` fails when <needle> ends in a non-word
+  // character (e.g. "Director,") because `\b` requires a word/non-word
+  // transition and never fires between two non-word chars. Patterns must
+  // still match the role text in that case.
+  const dirComma = { ...BASE_JOB, role: "Director, Product Operations" };
+  const { rejected: r1 } = filterJobs([dirComma], {
+    title_blocklist: [{ pattern: "Director,", reason: "over-level" }],
+  });
+  assert.equal(r1.length, 1);
+  assert.equal(r1[0].reason.pattern, "Director,");
+
+  // Trailing space: "VP " must match "VP Engineering" but NOT "Supervp".
+  const vpEng = { ...BASE_JOB, role: "VP Engineering" };
+  const { rejected: r2 } = filterJobs([vpEng], {
+    title_blocklist: [{ pattern: "VP ", reason: "VP level" }],
+  });
+  assert.equal(r2.length, 1);
+
+  const supervp = { ...BASE_JOB, role: "Supervp Engineer" };
+  const { passed: p3 } = filterJobs([supervp], {
+    title_blocklist: [{ pattern: "VP ", reason: "VP level" }],
+  });
+  assert.equal(p3.length, 1);
+});
+
+test("filterJobs title_requirelist patterns ending in non-word char still match", () => {
+  // Symmetric to the title_blocklist fix above.
+  const role = { ...BASE_JOB, role: "Strategy & Operations Manager" };
+  const { passed } = filterJobs([role], {
+    title_requirelist: [{ pattern: "strategy & operations", reason: "S&O" }],
+  });
+  assert.equal(passed.length, 1);
+});
+
 test("filterJobs rejects by location_blocklist substring", () => {
   const job = { ...BASE_JOB, location: "London, UK" };
   const { rejected } = filterJobs([job], { location_blocklist: ["UK"] });

--- a/engine/core/profile_loader.js
+++ b/engine/core/profile_loader.js
@@ -200,6 +200,10 @@ function normalizeSalaryConfig(raw) {
 //   title_requirelist:  { patterns: [{pattern,reason}] } | [{...}] → [{pattern,reason}]
 //   location_blocklist: { patterns: [strings] } | [strings] | location_rules.* → [strings]
 //   company_cap:        pass-through
+//   role_targets:       { tracks: [{id,name,patterns,fit_treatment,...}], fit_treatments }
+//                       — see RFC 030. When present, also synthesizes
+//                       title_requirelist from the union of all tracks[].patterns
+//                       if title_requirelist is null/absent (engine compat).
 // Everything else (domain_weak_fit, early_startup_modifier, priority_order)
 // is preserved verbatim for downstream consumers (e.g. fit_prompt).
 function normalizeFilterRules(raw) {
@@ -226,11 +230,46 @@ function normalizeFilterRules(raw) {
     out.title_blocklist = [];
   }
 
+  // RFC 030: role_targets is the single source of truth for acceptable
+  // role-tracks (scan title gate + LLM fit-score). Normalize tracks[] and,
+  // when title_requirelist is absent/null, synthesize it from the union of
+  // all tracks[].patterns so engine/core/filter.js keeps working unchanged.
+  const rt = raw.role_targets;
+  if (rt && typeof rt === "object" && Array.isArray(rt.tracks)) {
+    out.role_targets = {
+      tracks: rt.tracks
+        .filter((t) => t && typeof t === "object")
+        .map((t) => ({
+          id: t.id,
+          name: t.name,
+          patterns: Array.isArray(t.patterns) ? t.patterns.filter((p) => p && p.pattern) : [],
+          fit_treatment: t.fit_treatment || "primary",
+          ...(t.bridge_note ? { bridge_note: t.bridge_note } : {}),
+        })),
+      fit_treatments:
+        rt.fit_treatments && typeof rt.fit_treatments === "object" ? rt.fit_treatments : {},
+    };
+  } else {
+    out.role_targets = null;
+  }
+
   const tr = raw.title_requirelist;
+  let explicitTR = null;
   if (Array.isArray(tr)) {
-    out.title_requirelist = tr.filter((p) => p && p.pattern);
+    explicitTR = tr.filter((p) => p && p.pattern);
   } else if (tr && Array.isArray(tr.patterns)) {
-    out.title_requirelist = tr.patterns.filter((p) => p && p.pattern);
+    explicitTR = tr.patterns.filter((p) => p && p.pattern);
+  }
+  // "Explicit wins" must mean non-empty explicit wins. An empty explicit
+  // list (`title_requirelist: []` or `{patterns: []}`) would silently
+  // disable the positive gate even when role_targets is non-empty — RFC 030
+  // §10 R1 footgun. Fall through to synthesis whenever explicit is empty.
+  if (explicitTR && explicitTR.length > 0) {
+    out.title_requirelist = explicitTR;
+  } else if (out.role_targets) {
+    // Synthesize from role_targets.tracks[].patterns when title_requirelist
+    // is null/absent/empty — filter.js keeps reading the flat array unchanged.
+    out.title_requirelist = out.role_targets.tracks.flatMap((t) => t.patterns);
   } else {
     out.title_requirelist = [];
   }

--- a/engine/core/profile_loader.test.js
+++ b/engine/core/profile_loader.test.js
@@ -260,9 +260,7 @@ test("normalizeFilterRules: explicit title_requirelist wins over role_targets sy
   const out = normalizeFilterRules({
     title_requirelist: { patterns: [{ pattern: "explicit-pattern", reason: "kept" }] },
     role_targets: {
-      tracks: [
-        { id: "pm", name: "PM", patterns: [{ pattern: "synthesized", reason: "ignored" }] },
-      ],
+      tracks: [{ id: "pm", name: "PM", patterns: [{ pattern: "synthesized", reason: "ignored" }] }],
     },
   });
   // Explicit title_requirelist is preserved; synthesis is skipped.
@@ -300,9 +298,7 @@ test("normalizeFilterRules: empty title_requirelist + non-empty role_targets →
   const out = normalizeFilterRules({
     title_requirelist: [],
     role_targets: {
-      tracks: [
-        { id: "pm", name: "PM", patterns: [{ pattern: "product manager", reason: "PM" }] },
-      ],
+      tracks: [{ id: "pm", name: "PM", patterns: [{ pattern: "product manager", reason: "PM" }] }],
     },
   });
   // Synthesized — gate is preserved despite explicit empty list.

--- a/engine/core/profile_loader.test.js
+++ b/engine/core/profile_loader.test.js
@@ -116,6 +116,7 @@ test("loadProfile returns normalized object with paths and loaded sub-configs", 
       company_cap: { max_active: 3 },
       company_blocklist: [],
       title_blocklist: [],
+      role_targets: null,
       title_requirelist: [],
       location_blocklist: [],
     });
@@ -209,6 +210,129 @@ test("normalizeFilterRules: missing keys default to empty arrays", () => {
   assert.deepEqual(out.company_blocklist, []);
   assert.deepEqual(out.title_blocklist, []);
   assert.deepEqual(out.location_blocklist, []);
+  assert.deepEqual(out.title_requirelist, []);
+  assert.equal(out.role_targets, null);
+});
+
+// --- RFC 030: role_targets (single source of truth for acceptable tracks) ---
+
+test("normalizeFilterRules: role_targets present → synthesizes title_requirelist from tracks", () => {
+  const out = normalizeFilterRules({
+    role_targets: {
+      _description: "...",
+      fit_treatments: { primary: "p-prose", bridge: "b-prose" },
+      tracks: [
+        {
+          id: "pm",
+          name: "Product Manager",
+          fit_treatment: "primary",
+          patterns: [
+            { pattern: "product manager", reason: "PM role" },
+            { pattern: "PM", reason: "abbr" },
+          ],
+        },
+        {
+          id: "fde",
+          name: "Forward-Deployed Engineer",
+          fit_treatment: "bridge",
+          bridge_note: "treat as primary in AI-native",
+          patterns: [{ pattern: "forward deployed", reason: "FDE" }],
+        },
+      ],
+    },
+  });
+  // Patterns from all tracks flow into title_requirelist for filter.js compat.
+  assert.deepEqual(out.title_requirelist, [
+    { pattern: "product manager", reason: "PM role" },
+    { pattern: "PM", reason: "abbr" },
+    { pattern: "forward deployed", reason: "FDE" },
+  ]);
+  // role_targets is preserved (with normalized track entries) for prepare.js.
+  assert.equal(out.role_targets.tracks.length, 2);
+  assert.equal(out.role_targets.tracks[0].id, "pm");
+  assert.equal(out.role_targets.tracks[0].fit_treatment, "primary");
+  assert.equal(out.role_targets.tracks[1].fit_treatment, "bridge");
+  assert.equal(out.role_targets.tracks[1].bridge_note, "treat as primary in AI-native");
+  assert.equal(out.role_targets.fit_treatments.primary, "p-prose");
+});
+
+test("normalizeFilterRules: explicit title_requirelist wins over role_targets synthesis", () => {
+  const out = normalizeFilterRules({
+    title_requirelist: { patterns: [{ pattern: "explicit-pattern", reason: "kept" }] },
+    role_targets: {
+      tracks: [
+        { id: "pm", name: "PM", patterns: [{ pattern: "synthesized", reason: "ignored" }] },
+      ],
+    },
+  });
+  // Explicit title_requirelist is preserved; synthesis is skipped.
+  assert.deepEqual(out.title_requirelist, [{ pattern: "explicit-pattern", reason: "kept" }]);
+  // role_targets still exposed so prepare.js can read tracks/treatments.
+  assert.equal(out.role_targets.tracks.length, 1);
+});
+
+test("normalizeFilterRules: role_targets defaults fit_treatment to primary when omitted", () => {
+  const out = normalizeFilterRules({
+    role_targets: {
+      tracks: [{ id: "x", name: "X", patterns: [{ pattern: "x", reason: "x" }] }],
+    },
+  });
+  assert.equal(out.role_targets.tracks[0].fit_treatment, "primary");
+  assert.deepEqual(out.role_targets.fit_treatments, {});
+});
+
+test("normalizeFilterRules: role_targets with empty tracks → empty title_requirelist", () => {
+  const out = normalizeFilterRules({ role_targets: { tracks: [] } });
+  assert.deepEqual(out.title_requirelist, []);
+  assert.deepEqual(out.role_targets.tracks, []);
+});
+
+test("normalizeFilterRules: malformed role_targets (no tracks array) → role_targets: null", () => {
+  const out = normalizeFilterRules({ role_targets: { tracks: "not-array" } });
+  assert.equal(out.role_targets, null);
+  // Falls through to title_requirelist: [] since no synthesis possible.
+  assert.deepEqual(out.title_requirelist, []);
+});
+
+// Regression for RFC 030 §10 R1 footgun: explicit `title_requirelist: []`
+// alongside a non-empty role_targets must NOT silently disable the gate.
+test("normalizeFilterRules: empty title_requirelist + non-empty role_targets → falls through to synthesis", () => {
+  const out = normalizeFilterRules({
+    title_requirelist: [],
+    role_targets: {
+      tracks: [
+        { id: "pm", name: "PM", patterns: [{ pattern: "product manager", reason: "PM" }] },
+      ],
+    },
+  });
+  // Synthesized — gate is preserved despite explicit empty list.
+  assert.deepEqual(out.title_requirelist, [{ pattern: "product manager", reason: "PM" }]);
+});
+
+test("normalizeFilterRules: empty {patterns: []} title_requirelist + role_targets → synthesis", () => {
+  const out = normalizeFilterRules({
+    title_requirelist: { patterns: [] },
+    role_targets: {
+      tracks: [{ id: "x", name: "X", patterns: [{ pattern: "x-role", reason: "x" }] }],
+    },
+  });
+  assert.deepEqual(out.title_requirelist, [{ pattern: "x-role", reason: "x" }]);
+});
+
+test("normalizeFilterRules: track.patterns null/missing → empty patterns, no crash", () => {
+  const out = normalizeFilterRules({
+    role_targets: {
+      tracks: [
+        { id: "a", name: "A" }, // patterns absent
+        { id: "b", name: "B", patterns: null }, // patterns explicitly null
+        { id: "c", name: "C", patterns: [{ pattern: "c-pat", reason: "c" }] },
+      ],
+    },
+  });
+  assert.deepEqual(out.role_targets.tracks[0].patterns, []);
+  assert.deepEqual(out.role_targets.tracks[1].patterns, []);
+  // Only valid pattern from track C flows into the synthesized list.
+  assert.deepEqual(out.title_requirelist, [{ pattern: "c-pat", reason: "c" }]);
 });
 
 test("normalizeFilterRules: preserves auxiliary sections verbatim", () => {

--- a/engine/modules/discovery/icims.js
+++ b/engine/modules/discovery/icims.js
@@ -106,7 +106,10 @@ function extractIcimsDefault(html) {
 
 function parseIcimsDefaultRow(body) {
   // Title anchor: <a href="..." class="iCIMS_Anchor" title="..."><h3>{TITLE}</h3>
-  const anchor = /<a\s+[^>]*href="([^"]+)"[^>]*class="[^"]*\biCIMS_Anchor\b[^"]*"[^>]*>([\s\S]*?)<\/a>/.exec(body);
+  const anchor =
+    /<a\s+[^>]*href="([^"]+)"[^>]*class="[^"]*\biCIMS_Anchor\b[^"]*"[^>]*>([\s\S]*?)<\/a>/.exec(
+      body
+    );
   if (!anchor) return null;
   const href = decodeHtmlEntities(anchor[1]);
   const titleHtml = anchor[2];
@@ -139,8 +142,7 @@ function parseIcimsDefaultRow(body) {
 
   // Category (department-equivalent): <dt>Category</dt><dd>...<span>{CAT}</span></dd>
   let category = "";
-  const catMatch =
-    /<dt[^>]*>\s*Category\s*<\/dt>\s*<dd[^>]*>([\s\S]*?)<\/dd>/i.exec(body);
+  const catMatch = /<dt[^>]*>\s*Category\s*<\/dt>\s*<dd[^>]*>([\s\S]*?)<\/dd>/i.exec(body);
   if (catMatch) {
     category = sanitizeText(stripTags(catMatch[1]));
   }
@@ -280,9 +282,7 @@ async function fetchAllPages(fetchFn, base, mode, urlBase, signal) {
       html = html.slice(0, MAX_HTML_BYTES);
     }
     const pageJobs =
-      mode === "talentbrew"
-        ? extractTalentbrew(html, urlBase)
-        : extractIcimsDefault(html);
+      mode === "talentbrew" ? extractTalentbrew(html, urlBase) : extractIcimsDefault(html);
     if (pageJobs.length === 0) break;
     all.push(...pageJobs);
   }
@@ -336,9 +336,7 @@ async function discover(targets, ctx = {}) {
       return [];
     }
     if (parsed.protocol !== "https:") {
-      c.logger.warn(
-        `[${SOURCE}] ${target.slug}: urlBase must be https, got "${parsed.protocol}"`
-      );
+      c.logger.warn(`[${SOURCE}] ${target.slug}: urlBase must be https, got "${parsed.protocol}"`);
       return [];
     }
     // SSRF hardening: hosts outside `*.icims.com` must explicitly opt in via

--- a/engine/modules/discovery/icims.test.js
+++ b/engine/modules/discovery/icims.test.js
@@ -40,7 +40,17 @@ test("isValidSlug accepts standard tenant slugs", () => {
 });
 
 test("isValidSlug rejects garbage", () => {
-  for (const bad of ["", "../foo", "ab cd", "abc.def", "abc/def", null, undefined, "UPPER", "-leading"]) {
+  for (const bad of [
+    "",
+    "../foo",
+    "ab cd",
+    "abc.def",
+    "abc/def",
+    null,
+    undefined,
+    "UPPER",
+    "-leading",
+  ]) {
     assert.equal(_internals.isValidSlug(bad), false, `should reject ${JSON.stringify(bad)}`);
   }
 });
@@ -85,14 +95,8 @@ test("locationMatchesAllow — substring match is case-insensitive", () => {
     _internals.locationMatchesAllow("US-CA-Sacramento", ["Sacramento", "Roseville"]),
     true
   );
-  assert.equal(
-    _internals.locationMatchesAllow("Roseville, CA", ["sacramento"]),
-    false
-  );
-  assert.equal(
-    _internals.locationMatchesAllow("London, KY", ["Sacramento", "Roseville"]),
-    false
-  );
+  assert.equal(_internals.locationMatchesAllow("Roseville, CA", ["sacramento"]), false);
+  assert.equal(_internals.locationMatchesAllow("London, KY", ["Sacramento", "Roseville"]), false);
 });
 
 test("locationMatchesAllow — empty location with non-empty allow drops", () => {
@@ -175,7 +179,10 @@ test("extractTalentbrew falls back to URL-tail when data-job-id is missing", () 
 
 test("extractTalentbrew returns [] on empty page", () => {
   const html = readFixture("commonspirit-empty.html");
-  assert.deepEqual(_internals.extractTalentbrew(html, "https://www.commonspirit.careers/search-jobs"), []);
+  assert.deepEqual(
+    _internals.extractTalentbrew(html, "https://www.commonspirit.careers/search-jobs"),
+    []
+  );
 });
 
 // --- mapJob + assertJob -------------------------------------------------
@@ -239,10 +246,9 @@ function makeIcimsResponses({ slug, pages }) {
 test("discover — happy path returns jobs from page 1 (icims-default)", async () => {
   const html = readFixture("shriners-page0.html");
   const fetchFn = makeIcimsResponses({ slug: "shriners", pages: [html, ""] });
-  const jobs = await icims.discover(
-    [{ name: "Shriners Children's", slug: "shriners" }],
-    { fetchFn }
-  );
+  const jobs = await icims.discover([{ name: "Shriners Children's", slug: "shriners" }], {
+    fetchFn,
+  });
   assert.equal(jobs.length, 3);
   for (const j of jobs) {
     assert.doesNotThrow(() => assertJob(j));
@@ -254,10 +260,9 @@ test("discover — happy path returns jobs from page 1 (icims-default)", async (
 test("discover — pagination walks pages until empty", async () => {
   const html = readFixture("shriners-page0.html");
   const fetchFn = makeIcimsResponses({ slug: "shriners", pages: [html, html, ""] });
-  const jobs = await icims.discover(
-    [{ name: "Shriners Children's", slug: "shriners" }],
-    { fetchFn }
-  );
+  const jobs = await icims.discover([{ name: "Shriners Children's", slug: "shriners" }], {
+    fetchFn,
+  });
   assert.equal(jobs.length, 6, "two non-empty pages × 3 rows each");
   // fetched 3 pages total: pr=0 (jobs), pr=1 (jobs), pr=2 (empty → stop)
   assert.equal(fetchFn.calls.length, 3);
@@ -322,10 +327,10 @@ test("discover — talentbrew mode through urlBase", async () => {
 test("discover — invalid slug logs warn and returns []", async () => {
   const warns = [];
   const fetchFn = makeFetch(async () => makeResponse(""));
-  const jobs = await icims.discover(
-    [{ name: "Bad", slug: "../etc/passwd" }],
-    { fetchFn, logger: { warn: (m) => warns.push(m) } }
-  );
+  const jobs = await icims.discover([{ name: "Bad", slug: "../etc/passwd" }], {
+    fetchFn,
+    logger: { warn: (m) => warns.push(m) },
+  });
   assert.equal(jobs.length, 0);
   assert.equal(fetchFn.calls.length, 0, "no HTTP call for invalid slug");
   assert.equal(warns.length, 1);
@@ -335,10 +340,10 @@ test("discover — invalid slug logs warn and returns []", async () => {
 test("discover — unknown htmlMode is rejected", async () => {
   const warns = [];
   const fetchFn = makeFetch(async () => makeResponse(""));
-  const jobs = await icims.discover(
-    [{ name: "Bad", slug: "ok", htmlMode: "evil-mode" }],
-    { fetchFn, logger: { warn: (m) => warns.push(m) } }
-  );
+  const jobs = await icims.discover([{ name: "Bad", slug: "ok", htmlMode: "evil-mode" }], {
+    fetchFn,
+    logger: { warn: (m) => warns.push(m) },
+  });
   assert.equal(jobs.length, 0);
   assert.equal(fetchFn.calls.length, 0);
   assert.match(warns[0], /unknown htmlMode/);
@@ -359,25 +364,26 @@ test("discover — non-https urlBase is rejected (SSRF guard)", async () => {
 test("discover — malformed urlBase is rejected", async () => {
   const warns = [];
   const fetchFn = makeFetch(async () => makeResponse(""));
-  const jobs = await icims.discover(
-    [{ name: "Bad", slug: "ok", urlBase: "not a url" }],
-    { fetchFn, logger: { warn: (m) => warns.push(m) } }
-  );
+  const jobs = await icims.discover([{ name: "Bad", slug: "ok", urlBase: "not a url" }], {
+    fetchFn,
+    logger: { warn: (m) => warns.push(m) },
+  });
   assert.equal(jobs.length, 0);
   assert.match(warns[0], /invalid urlBase/);
 });
 
 test("discover — HTTP 500 throws and gets isolated by runTargets", async () => {
   const warns = [];
-  const fetchFn = makeFetch(async () =>
-    makeResponse("", { ok: false, status: 500 })
-  );
-  const jobs = await icims.discover(
-    [{ name: "Boom", slug: "shriners" }],
-    { fetchFn, logger: { warn: (m) => warns.push(m) } }
-  );
+  const fetchFn = makeFetch(async () => makeResponse("", { ok: false, status: 500 }));
+  const jobs = await icims.discover([{ name: "Boom", slug: "shriners" }], {
+    fetchFn,
+    logger: { warn: (m) => warns.push(m) },
+  });
   assert.equal(jobs.length, 0, "500 from page 0 kills this target only");
-  assert.ok(warns.some((w) => /HTTP 500/.test(w)), `expected HTTP 500 warning, got ${JSON.stringify(warns)}`);
+  assert.ok(
+    warns.some((w) => /HTTP 500/.test(w)),
+    `expected HTTP 500 warning, got ${JSON.stringify(warns)}`
+  );
 });
 
 test("discover — 404 on page > 0 terminates pagination cleanly", async () => {
@@ -388,10 +394,7 @@ test("discover — 404 on page > 0 terminates pagination cleanly", async () => {
     if (p === 0) return makeResponse(html);
     return makeResponse("", { ok: false, status: 404 });
   });
-  const jobs = await icims.discover(
-    [{ name: "Shriners", slug: "shriners" }],
-    { fetchFn }
-  );
+  const jobs = await icims.discover([{ name: "Shriners", slug: "shriners" }], { fetchFn });
   assert.equal(jobs.length, 3, "first page parsed; pr=1 404 ends pagination");
 });
 
@@ -465,10 +468,7 @@ test("discover — HTML response over MAX_HTML_BYTES gets truncated, not OOM'd",
     return makeResponse("<html></html>");
   });
   const t0 = Date.now();
-  const jobs = await icims.discover(
-    [{ name: "Test", slug: "test" }],
-    { fetchFn }
-  );
+  const jobs = await icims.discover([{ name: "Test", slug: "test" }], { fetchFn });
   const dt = Date.now() - t0;
   assert.equal(jobs.length, 1, "parses the one real row before the truncation cap");
   assert.ok(dt < 2000, `should complete fast even on huge input (took ${dt}ms)`);

--- a/engine/modules/discovery/jobsyn.js
+++ b/engine/modules/discovery/jobsyn.js
@@ -79,7 +79,8 @@ function locationMatchesAllow(primaryLocation, allow) {
 function extract(body) {
   if (!body || typeof body !== "object") return { jobs: [], pagination: null };
   const jobs = Array.isArray(body.jobs) ? body.jobs : [];
-  const pagination = body.pagination && typeof body.pagination === "object" ? body.pagination : null;
+  const pagination =
+    body.pagination && typeof body.pagination === "object" ? body.pagination : null;
   return { jobs, pagination };
 }
 

--- a/engine/modules/discovery/jobsyn.test.js
+++ b/engine/modules/discovery/jobsyn.test.js
@@ -81,10 +81,16 @@ test("jobsyn.discover paginates and maps jobs (has_more_pages driven)", async ()
       [API_BASE]: (url) => {
         const page = parsePage(url);
         if (page === 1) {
-          return { status: 200, body: wrap(page1Jobs, pagination({ page: 1, has_more_pages: true, total: 150 })) };
+          return {
+            status: 200,
+            body: wrap(page1Jobs, pagination({ page: 1, has_more_pages: true, total: 150 })),
+          };
         }
         if (page === 2) {
-          return { status: 200, body: wrap(page2Jobs, pagination({ page: 2, has_more_pages: false, total: 150 })) };
+          return {
+            status: 200,
+            body: wrap(page2Jobs, pagination({ page: 2, has_more_pages: false, total: 150 })),
+          };
         }
         throw new Error(`unexpected page ${page}`);
       },
@@ -133,10 +139,9 @@ test("jobsyn.discover stops at page 1 when has_more_pages=false", async () => {
     },
     recorded
   );
-  const jobs = await jobsyn.discover(
-    [{ name: "DCI", slug: "dciinc", origin: DCI_ORIGIN }],
-    { fetchFn }
-  );
+  const jobs = await jobsyn.discover([{ name: "DCI", slug: "dciinc", origin: DCI_ORIGIN }], {
+    fetchFn,
+  });
   assert.equal(jobs.length, 30);
   assert.equal(recorded.length, 1, "should not request page 2 when has_more_pages is false");
 });
@@ -151,7 +156,10 @@ test("jobsyn.discover drops postings outside locationAllow", async () => {
     makeJob({ location_exact: "Albuquerque, NM" }),
   ];
   const fetchFn = makeFetch({
-    [API_BASE]: { status: 200, body: wrap(jobs, pagination({ page: 1, has_more_pages: false, total: 5 })) },
+    [API_BASE]: {
+      status: 200,
+      body: wrap(jobs, pagination({ page: 1, has_more_pages: false, total: 5 })),
+    },
   });
   const logs = [];
   const out = await jobsyn.discover(
@@ -178,7 +186,10 @@ test("jobsyn.discover locationAllow is case-insensitive and trims patterns", asy
     makeJob({ location_exact: "Houston, TX" }),
   ];
   const fetchFn = makeFetch({
-    [API_BASE]: { status: 200, body: wrap(jobs, pagination({ page: 1, has_more_pages: false, total: 2 })) },
+    [API_BASE]: {
+      status: 200,
+      body: wrap(jobs, pagination({ page: 1, has_more_pages: false, total: 2 })),
+    },
   });
   const out = await jobsyn.discover(
     [
@@ -199,10 +210,10 @@ test("jobsyn.discover returns [] when target has no origin", async () => {
   const recorded = [];
   const fetchFn = makeFetch({}, recorded);
   const logs = [];
-  const jobs = await jobsyn.discover(
-    [{ name: "Bad", slug: "bad" }],
-    { fetchFn, logger: { warn: (m) => logs.push(m) } }
-  );
+  const jobs = await jobsyn.discover([{ name: "Bad", slug: "bad" }], {
+    fetchFn,
+    logger: { warn: (m) => logs.push(m) },
+  });
   assert.equal(jobs.length, 0);
   assert.equal(recorded.length, 0, "fetchFn must not be called when origin is missing");
   assert.ok(logs.some((m) => m.includes("invalid origin")));
@@ -213,22 +224,22 @@ test("jobsyn.discover rejects malformed origins (header-injection guard)", async
   const fetchFn = makeFetch({}, recorded);
   const logs = [];
   const cases = [
-    "dciinc.jobs\r\nX-Injection: 1",   // CRLF header injection
-    "dciinc.jobs\nX-Injection: 1",     // LF only
-    " dciinc.jobs",                    // leading space
-    "dciinc.jobs ",                    // trailing space
-    "dciinc.jobs/path",                // path segment
-    "https://dciinc.jobs",             // scheme-prefixed
-    "",                                // empty
-    "a".repeat(300),                   // way too long
-    "  ",                              // whitespace-only
-    "\tdci.jobs",                      // tab
+    "dciinc.jobs\r\nX-Injection: 1", // CRLF header injection
+    "dciinc.jobs\nX-Injection: 1", // LF only
+    " dciinc.jobs", // leading space
+    "dciinc.jobs ", // trailing space
+    "dciinc.jobs/path", // path segment
+    "https://dciinc.jobs", // scheme-prefixed
+    "", // empty
+    "a".repeat(300), // way too long
+    "  ", // whitespace-only
+    "\tdci.jobs", // tab
   ];
   for (let i = 0; i < cases.length; i += 1) {
-    const out = await jobsyn.discover(
-      [{ name: `Bad ${i}`, slug: `bad${i}`, origin: cases[i] }],
-      { fetchFn, logger: { warn: (m) => logs.push(m) } }
-    );
+    const out = await jobsyn.discover([{ name: `Bad ${i}`, slug: `bad${i}`, origin: cases[i] }], {
+      fetchFn,
+      logger: { warn: (m) => logs.push(m) },
+    });
     assert.equal(out.length, 0, `case ${i} (${JSON.stringify(cases[i])}) should yield 0 jobs`);
   }
   assert.equal(recorded.length, 0, "no fetch may happen for any malformed origin");
@@ -245,7 +256,10 @@ test("jobsyn.discover drops target when mid-pagination page fails", async () => 
       [API_BASE]: (url) => {
         const page = parsePage(url);
         if (page === 1) {
-          return { status: 200, body: wrap(page1Jobs, pagination({ page: 1, has_more_pages: true, total: 500 })) };
+          return {
+            status: 200,
+            body: wrap(page1Jobs, pagination({ page: 1, has_more_pages: true, total: 500 })),
+          };
         }
         if (page === 2) return { status: 500, body: { error: "boom" } };
         throw new Error(`unexpected page ${page}`);
@@ -254,10 +268,10 @@ test("jobsyn.discover drops target when mid-pagination page fails", async () => 
     recorded
   );
   const logs = [];
-  const jobs = await jobsyn.discover(
-    [{ name: "DCI", slug: "dciinc", origin: DCI_ORIGIN }],
-    { fetchFn, logger: { warn: (m) => logs.push(m) } }
-  );
+  const jobs = await jobsyn.discover([{ name: "DCI", slug: "dciinc", origin: DCI_ORIGIN }], {
+    fetchFn,
+    logger: { warn: (m) => logs.push(m) },
+  });
   assert.equal(jobs.length, 0, "partial-page failures must NOT leak page-1 jobs into the pool");
   assert.equal(recorded.length, 2);
   assert.ok(
@@ -268,12 +282,14 @@ test("jobsyn.discover drops target when mid-pagination page fails", async () => 
 
 test("jobsyn.discover tolerates empty jobs array", async () => {
   const fetchFn = makeFetch({
-    [API_BASE]: { status: 200, body: wrap([], pagination({ page: 1, has_more_pages: false, total: 0 })) },
+    [API_BASE]: {
+      status: 200,
+      body: wrap([], pagination({ page: 1, has_more_pages: false, total: 0 })),
+    },
   });
-  const jobs = await jobsyn.discover(
-    [{ name: "DCI", slug: "dciinc", origin: DCI_ORIGIN }],
-    { fetchFn }
-  );
+  const jobs = await jobsyn.discover([{ name: "DCI", slug: "dciinc", origin: DCI_ORIGIN }], {
+    fetchFn,
+  });
   assert.equal(jobs.length, 0);
 });
 
@@ -287,10 +303,9 @@ test("jobsyn.discover stops on missing pagination block (defensive)", async () =
     },
     recorded
   );
-  const jobs = await jobsyn.discover(
-    [{ name: "DCI", slug: "dciinc", origin: DCI_ORIGIN }],
-    { fetchFn }
-  );
+  const jobs = await jobsyn.discover([{ name: "DCI", slug: "dciinc", origin: DCI_ORIGIN }], {
+    fetchFn,
+  });
   assert.equal(jobs.length, 1);
   assert.equal(recorded.length, 1, "should stop walking pages when pagination block is absent");
 });
@@ -304,13 +319,16 @@ test("jobsyn.discover drops postings without guid and warns", async () => {
     { guid: "   ", title_exact: "Whitespace GUID", location_exact: "Sacramento, CA" },
   ];
   const fetchFn = makeFetch({
-    [API_BASE]: { status: 200, body: wrap(jobs, pagination({ page: 1, has_more_pages: false, total: 4 })) },
+    [API_BASE]: {
+      status: 200,
+      body: wrap(jobs, pagination({ page: 1, has_more_pages: false, total: 4 })),
+    },
   });
   const logs = [];
-  const out = await jobsyn.discover(
-    [{ name: "DCI", slug: "dciinc", origin: DCI_ORIGIN }],
-    { fetchFn, logger: { warn: (m) => logs.push(m) } }
-  );
+  const out = await jobsyn.discover([{ name: "DCI", slug: "dciinc", origin: DCI_ORIGIN }], {
+    fetchFn,
+    logger: { warn: (m) => logs.push(m) },
+  });
   assert.equal(out.length, 1);
   assert.ok(logs.some((m) => m.includes("dropped 3 postings without guid")));
 });
@@ -323,7 +341,13 @@ test("jobsyn.discover isolates per-tenant failures", async () => {
     recorded.push({ url, headers: { ...(opts.headers || {}) } });
     const origin = (opts.headers || {})["X-Origin"];
     if (origin === DCI_ORIGIN) {
-      return { ok: false, status: 500, async json() { return {}; } };
+      return {
+        ok: false,
+        status: 500,
+        async json() {
+          return {};
+        },
+      };
     }
     return {
       ok: true,
@@ -354,7 +378,10 @@ test("jobsyn.discover falls back from location_exact to city+state", async () =>
     makeJob({ location_exact: null, city_exact: "Boston", state_short: "MA" }),
   ];
   const fetchFn = makeFetch({
-    [API_BASE]: { status: 200, body: wrap(jobs, pagination({ page: 1, has_more_pages: false, total: 3 })) },
+    [API_BASE]: {
+      status: 200,
+      body: wrap(jobs, pagination({ page: 1, has_more_pages: false, total: 3 })),
+    },
   });
   const out = await jobsyn.discover(
     [
@@ -380,12 +407,14 @@ test("jobsyn.discover prefers date_new over date_added; falls back when date_new
     makeJob({ date_new: undefined, date_added: undefined }),
   ];
   const fetchFn = makeFetch({
-    [API_BASE]: { status: 200, body: wrap(jobs, pagination({ page: 1, has_more_pages: false, total: 3 })) },
+    [API_BASE]: {
+      status: 200,
+      body: wrap(jobs, pagination({ page: 1, has_more_pages: false, total: 3 })),
+    },
   });
-  const out = await jobsyn.discover(
-    [{ name: "DCI", slug: "dciinc", origin: DCI_ORIGIN }],
-    { fetchFn }
-  );
+  const out = await jobsyn.discover([{ name: "DCI", slug: "dciinc", origin: DCI_ORIGIN }], {
+    fetchFn,
+  });
   assert.equal(out.length, 3);
   assert.equal(out[0].postedAt, "2026-05-05");
   assert.equal(out[1].postedAt, "2026-05-09");
@@ -397,12 +426,14 @@ test("jobsyn.discover apply URL composes from origin + guid", async () => {
   const myGuid = "CC6AB92478BD4F7DA804C46A786BE429";
   const jobs = [makeJob({ guid: myGuid, location_exact: "Sacramento, CA" })];
   const fetchFn = makeFetch({
-    [API_BASE]: { status: 200, body: wrap(jobs, pagination({ page: 1, has_more_pages: false, total: 1 })) },
+    [API_BASE]: {
+      status: 200,
+      body: wrap(jobs, pagination({ page: 1, has_more_pages: false, total: 1 })),
+    },
   });
-  const out = await jobsyn.discover(
-    [{ name: "DCI", slug: "dciinc", origin: DCI_ORIGIN }],
-    { fetchFn }
-  );
+  const out = await jobsyn.discover([{ name: "DCI", slug: "dciinc", origin: DCI_ORIGIN }], {
+    fetchFn,
+  });
   assert.equal(out.length, 1);
   assert.equal(out[0].jobId, myGuid);
   assert.equal(out[0].url, `https://${DCI_ORIGIN}/job/${myGuid}`);
@@ -419,14 +450,16 @@ test("jobsyn.discover stops at MAX_JOBS_PER_TENANT cap on runaway has_more_pages
       status: 200,
       async json() {
         // Always claims more pages — adapter must stop on its own.
-        return wrap(pageJobs, pagination({ page: parsePage(url), has_more_pages: true, total: 999999 }));
+        return wrap(
+          pageJobs,
+          pagination({ page: parsePage(url), has_more_pages: true, total: 999999 })
+        );
       },
     };
   };
-  const jobs = await jobsyn.discover(
-    [{ name: "DCI", slug: "dciinc", origin: DCI_ORIGIN }],
-    { fetchFn }
-  );
+  const jobs = await jobsyn.discover([{ name: "DCI", slug: "dciinc", origin: DCI_ORIGIN }], {
+    fetchFn,
+  });
   // Cap is 5000; with PAGE_SIZE=100 that's 50 fetches.
   assert.equal(jobs.length, 5000, `expected MAX_JOBS_PER_TENANT cap, got ${jobs.length}`);
   assert.equal(fetchCount, 50, `expected 50 fetches (cap/page_size), got ${fetchCount}`);

--- a/engine/modules/discovery/oracle_cloud.test.js
+++ b/engine/modules/discovery/oracle_cloud.test.js
@@ -218,10 +218,10 @@ test("oracle_cloud.discover handles invalid siteUrl gracefully", async () => {
   const recorded = [];
   const fetchFn = makeFetch({}, recorded);
   const logs = [];
-  const jobs = await oracle.discover(
-    [{ name: "Bad URL", slug: "badurl", siteUrl: "not-a-url" }],
-    { fetchFn, logger: { warn: (m) => logs.push(m) } }
-  );
+  const jobs = await oracle.discover([{ name: "Bad URL", slug: "badurl", siteUrl: "not-a-url" }], {
+    fetchFn,
+    logger: { warn: (m) => logs.push(m) },
+  });
   assert.equal(jobs.length, 0);
   assert.equal(recorded.length, 0);
   assert.ok(logs.some((m) => m.includes("invalid siteUrl")));
@@ -260,10 +260,10 @@ test("oracle_cloud.discover rejects siteUrl outside oraclecloud.com (SSRF guard)
     "https://oraclecloud.com.attacker.com/hcmUI/CandidateExperience/en/sites/CX/",
   ];
   for (let i = 0; i < cases.length; i += 1) {
-    const jobs = await oracle.discover(
-      [{ name: `Bad ${i}`, slug: `bad${i}`, siteUrl: cases[i] }],
-      { fetchFn, logger: { warn: (m) => logs.push(m) } }
-    );
+    const jobs = await oracle.discover([{ name: `Bad ${i}`, slug: `bad${i}`, siteUrl: cases[i] }], {
+      fetchFn,
+      logger: { warn: (m) => logs.push(m) },
+    });
     assert.equal(jobs.length, 0, `case ${i}: ${cases[i]} should yield 0 jobs`);
   }
   assert.equal(recorded.length, 0, "no fetch may happen for any disallowed host");
@@ -406,10 +406,9 @@ test("oracle_cloud.discover defaults siteNumber to CX when omitted", async () =>
     },
     recorded
   );
-  await oracle.discover(
-    [{ name: "Default Site", slug: "def", siteUrl: ADVENTIST_SITE }],
-    { fetchFn }
-  );
+  await oracle.discover([{ name: "Default Site", slug: "def", siteUrl: ADVENTIST_SITE }], {
+    fetchFn,
+  });
   assert.equal(recorded.length, 1);
   assert.ok(recorded[0].url.includes("finder=findReqs%3BsiteNumber%3DCX"));
 });

--- a/engine/modules/generators/resume_pdf.js
+++ b/engine/modules/generators/resume_pdf.js
@@ -4,6 +4,38 @@
 const PDFDocument = require("pdfkit");
 const fs = require("fs");
 
+// PDFKit's built-in Helvetica uses WinAnsi encoding (Latin-1 + a few extras),
+// which lacks several Unicode chars used in our content (arrows in particular).
+// Without sanitization they render as mojibake (e.g., `→` → `!'`).
+// We swap them to ASCII fallbacks at render time; the source JSON stays
+// Unicode-clean so DOCX (which embeds full Unicode fonts) renders correctly.
+const PDF_CHAR_FALLBACKS = {
+  "→": "->",   // → rightwards arrow
+  "↔": "<->",  // ↔ left-right arrow
+  "←": "<-",   // ← leftwards arrow
+  "⇒": "=>",   // ⇒ rightwards double arrow
+};
+
+function sanitizeForPdf(text) {
+  if (typeof text !== "string") return text;
+  let out = text;
+  for (const [from, to] of Object.entries(PDF_CHAR_FALLBACKS)) {
+    if (out.includes(from)) out = out.split(from).join(to);
+  }
+  return out;
+}
+
+function deepSanitize(value) {
+  if (typeof value === "string") return sanitizeForPdf(value);
+  if (Array.isArray(value)) return value.map(deepSanitize);
+  if (value && typeof value === "object") {
+    const out = {};
+    for (const k of Object.keys(value)) out[k] = deepSanitize(value[k]);
+    return out;
+  }
+  return value;
+}
+
 function sectionHeader(doc, text) {
   doc.moveDown(0.35);
   doc.font("Helvetica-Bold").fontSize(10).text(text);
@@ -126,10 +158,9 @@ function renderProjects(doc, projects) {
   });
 }
 
-function generateResumePdf(
-  { contact, version, sharedExperience, sharedSections, certifications, projects },
-  outputPath
-) {
+function generateResumePdf(rawData, outputPath) {
+  const { contact, version, sharedExperience, sharedSections, certifications, projects } =
+    deepSanitize(rawData);
   return new Promise((resolve, reject) => {
     const doc = new PDFDocument({
       size: "LETTER",
@@ -163,4 +194,4 @@ function generateResumePdf(
   });
 }
 
-module.exports = { generateResumePdf };
+module.exports = { generateResumePdf, sanitizeForPdf, deepSanitize };

--- a/engine/modules/generators/resume_pdf.js
+++ b/engine/modules/generators/resume_pdf.js
@@ -10,10 +10,10 @@ const fs = require("fs");
 // We swap them to ASCII fallbacks at render time; the source JSON stays
 // Unicode-clean so DOCX (which embeds full Unicode fonts) renders correctly.
 const PDF_CHAR_FALLBACKS = {
-  "→": "->",   // → rightwards arrow
-  "↔": "<->",  // ↔ left-right arrow
-  "←": "<-",   // ← leftwards arrow
-  "⇒": "=>",   // ⇒ rightwards double arrow
+  "→": "->", // → rightwards arrow
+  "↔": "<->", // ↔ left-right arrow
+  "←": "<-", // ← leftwards arrow
+  "⇒": "=>", // ⇒ rightwards double arrow
 };
 
 function sanitizeForPdf(text) {

--- a/engine/modules/generators/resume_pdf.test.js
+++ b/engine/modules/generators/resume_pdf.test.js
@@ -4,7 +4,7 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 
-const { generateResumePdf } = require("./resume_pdf.js");
+const { generateResumePdf, sanitizeForPdf, deepSanitize } = require("./resume_pdf.js");
 
 const FIXTURE = {
   contact: {
@@ -69,6 +69,68 @@ test("generateResumePdf works without linkedin", async () => {
   await generateResumePdf(fixture, tmp);
   try {
     assert.ok(fs.statSync(tmp).size > 0);
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});
+
+test("sanitizeForPdf swaps unicode arrows for ASCII fallbacks", () => {
+  assert.equal(sanitizeForPdf("User interviews → new features"), "User interviews -> new features");
+  assert.equal(sanitizeForPdf("patient ↔ provider ↔ payer"), "patient <-> provider <-> payer");
+  assert.equal(sanitizeForPdf("a ← b"), "a <- b");
+  assert.equal(sanitizeForPdf("a ⇒ b"), "a => b");
+});
+
+test("sanitizeForPdf preserves safe unicode (em-dash, bullet, multiplication)", () => {
+  assert.equal(sanitizeForPdf("a — b"), "a — b");
+  assert.equal(sanitizeForPdf("a • b"), "a • b");
+  assert.equal(sanitizeForPdf("2 × faster"), "2 × faster");
+});
+
+test("sanitizeForPdf handles non-string inputs", () => {
+  assert.equal(sanitizeForPdf(42), 42);
+  assert.equal(sanitizeForPdf(null), null);
+  assert.equal(sanitizeForPdf(undefined), undefined);
+});
+
+test("deepSanitize walks nested object/array structures", () => {
+  const input = {
+    a: "x → y",
+    b: ["p ↔ q", { c: "r → s" }],
+    d: { e: { f: "no-arrows" } },
+    g: 42,
+    h: null,
+  };
+  const out = deepSanitize(input);
+  assert.equal(out.a, "x -> y");
+  assert.equal(out.b[0], "p <-> q");
+  assert.equal(out.b[1].c, "r -> s");
+  assert.equal(out.d.e.f, "no-arrows");
+  assert.equal(out.g, 42);
+  assert.equal(out.h, null);
+  // Input unchanged (no mutation)
+  assert.equal(input.a, "x → y");
+});
+
+test("generateResumePdf sanitizes arrows in bullet text", async () => {
+  const tmp = path.join(os.tmpdir(), `resume-arrows-${process.pid}-${Date.now()}.pdf`);
+  const fixture = {
+    ...FIXTURE,
+    sharedExperience: [
+      {
+        ...FIXTURE.sharedExperience[0],
+        bullets: [[{ text: "User interviews → new features" }]],
+      },
+    ],
+  };
+  await generateResumePdf(fixture, tmp);
+  try {
+    // PDF should render without throwing on the unsupported glyph.
+    // We don't decode the PDF binary; the existence + non-empty size + %PDF magic
+    // is the smoke check. Sanitization is verified by the unit tests above.
+    const stat = fs.statSync(tmp);
+    assert.ok(stat.size > 0);
+    assert.equal(fs.readFileSync(tmp, "utf8").slice(0, 4), "%PDF");
   } finally {
     fs.unlinkSync(tmp);
   }

--- a/profiles/_example/filter_rules.example.json
+++ b/profiles/_example/filter_rules.example.json
@@ -15,6 +15,14 @@
     "_description": "Title patterns that auto-archive regardless of company. Matched case-insensitively as substrings.",
     "patterns": []
   },
+  "role_targets": {
+    "_description": "RFC 030 — single source of truth for acceptable role-tracks. Read by scan (title gate) and by LLM prepare (Fit Score). One block changes BOTH gates. Empty tracks[] means no positive title gate.",
+    "fit_treatments": {
+      "primary": "Apply Fit Score by domain match only. Track is the candidate's main target.",
+      "bridge": "Bridge/stepping-stone role. Apply standard domain logic but never downgrade purely for being on this track instead of the primary one."
+    },
+    "tracks": []
+  },
   "location_rules": {
     "_description": "Restrict to specific locations / remote-only. Empty = no location filter.",
     "allowed_substrings": []

--- a/rfc/030-unified-role-targets.md
+++ b/rfc/030-unified-role-targets.md
@@ -1,0 +1,375 @@
+---
+id: RFC-030
+title: Unified role-targets — single source of truth for scan filter and LLM fit score
+status: accepted
+author: Claude (via Jared)
+tier: M
+created: 2026-05-13
+decided: 2026-05-13
+refs:
+  - BL-56
+  - BL-37
+  - BL-51
+---
+
+# RFC 030 — Unified role-targets
+
+## 1. Problem
+
+"Which role-tracks does this profile accept?" is currently encoded in
+**three** independent places with three different semantics. They drift,
+and the LLM phase already paid the price.
+
+| Source | Shape | Reader | Purpose |
+|---|---|---|---|
+| `profiles/<id>/filter_rules.json` → `title_requirelist.patterns[]` | regex strings + `reason` | `engine/core/filter.js` (scan) | Mechanical gate: archive if no title match |
+| `profiles/<id>/profile.json` → `target_roles[]` | human-readable role names | LLM (via memory bundle) | Narrative cue in prompt |
+| `profiles/<id>/memory/user_resume_key_points.md` → "Bridge-mode booster" line | freeform prose | LLM (via memory bundle) | Soft instruction to LLM |
+| `skills/job-pipeline/SKILL.md` → "Fit Score (domain fit only)" §755-764 | prose | LLM (skill body) | Defines Strong/Medium/Weak — **does not say role-track is non-factor** |
+
+### Concrete failure (2026-05-12)
+
+`prepare_results_20260512_182159.json`: 22 of 52 results were `decision=skip`,
+17 of which were PM-adjacent (FDE / Solutions Engineer / TPM / Product
+Ops / BizOps) — exactly the tracks BL-37 added under bridge-mode. Each
+was rejected with rationale variants of "not PM track". Mechanical
+filter passed them through (PM-adjacent patterns are in
+`title_requirelist`). LLM rejected them anyway.
+
+Root cause: the LLM weighed its general prior "this profile is PM" more
+heavily than (a) the narrative `target_roles` list, (b) the
+"Bridge-mode booster" prose buried in `user_resume_key_points.md`, and
+(c) the absent explicit guidance in SKILL.md that role-track must not
+factor into Fit Score.
+
+### Why a quick-fix is wrong
+
+Initial instinct was to add `acceptable_role_tracks` to
+`filter_rules.json` and duplicate it into memory. This adds a **fourth**
+source of truth without removing any of the three existing ones. The
+next pivot will re-stage the same bug.
+
+This RFC commits to one source.
+
+## 2. Goals
+
+- One file is **the** definition of "which role-tracks this profile
+  accepts". Editing it changes both scan filter and LLM fit behaviour.
+- The LLM's Fit Score has a clean, profile-supplied list of acceptable
+  tracks, plus per-track guidance for how to treat domain × track
+  combinations (e.g. "PM-adjacent in Strong domain → Strong, do not
+  downgrade").
+- Backward-compatible migration: `jared` and `_example` work end-to-end
+  on day-one after the change, no other profile breaks.
+
+## 3. Non-goals
+
+- Re-evaluating the *content* of Jared's acceptable role-tracks. BL-37
+  set them; this RFC moves them, doesn't edit them.
+- Migrating other `filter_rules.json` blocks (location, company,
+  salary). Only role-track / title-gate.
+- Multi-profile rollout beyond `jared` + `_example`. Other profiles
+  migrate when their owner needs them to.
+- Changing how memory is bundled into the LLM prompt. We use the
+  existing prepare_context channel.
+
+## 4. Proposed solution
+
+### 4.1 Three structural options
+
+This RFC presents three options. **Default recommendation: Option B**
+(new section inside `filter_rules.json`). Rationale below.
+
+#### Option A — New file `profiles/<id>/role_targets.json`
+
+Standalone file, referenced from `profile.json` via
+`profile.role_targets_file`. Both engine and prepare-context read it.
+
+```jsonc
+// profiles/jared/role_targets.json
+{
+  "_description": "...",
+  "tracks": [
+    {
+      "id": "pm",
+      "name": "Product Manager",
+      "patterns": ["product manager", "product management", "PM", ...],
+      "fit_treatment": "primary"
+    },
+    {
+      "id": "fde",
+      "name": "Forward-Deployed Engineer / AI Solutions",
+      "patterns": ["forward deployed", "forward-deployed", "ai solutions", ...],
+      "fit_treatment": "bridge",
+      "bridge_note": "Treat as primary track in Strong-domain companies; do not downgrade for being non-PM."
+    },
+    ...
+  ],
+  "fit_treatments": {
+    "primary": "Role-track is the candidate's main target. Apply Fit Score by domain only.",
+    "bridge":  "Bridge role per BL-37. In Strong-domain context, treat as Strong. Otherwise, apply standard domain logic. Do not downgrade for not being on the primary track."
+  }
+}
+```
+
+Pros: clean separation, one obvious place. Cons: another top-level file
+per profile; another loader path; `_example` has to ship a synthetic
+copy.
+
+#### Option B — New section `role_targets` inside `filter_rules.json` (RECOMMENDED)
+
+Keep the file count flat. `filter_rules.json` is already the gate-config
+file; role-targets are a gate concern.
+
+```jsonc
+// profiles/jared/filter_rules.json
+{
+  "_description": "...",
+  "role_targets": {
+    "_description": "Single source of truth for acceptable role-tracks. Read by scan (title gate) and by LLM prepare (fit score).",
+    "tracks": [
+      {
+        "id": "pm",
+        "name": "Product Manager",
+        "patterns": [
+          { "pattern": "product manager", "reason": "PM role" },
+          { "pattern": "PM", "reason": "PM abbreviation" }
+        ],
+        "fit_treatment": "primary"
+      },
+      {
+        "id": "fde",
+        "name": "Forward-Deployed Engineer / AI Solutions",
+        "patterns": [
+          { "pattern": "forward deployed", "reason": "FDE — top fit" },
+          { "pattern": "ai solutions", "reason": "AI Solutions Engineer — close to FDE" }
+        ],
+        "fit_treatment": "bridge",
+        "bridge_note": "Treat as primary track in Strong-domain companies; do not downgrade for being non-PM."
+      }
+      // ... pm-adjacent tracks
+    ],
+    "fit_treatments": {
+      "primary": "Apply Fit Score by domain only.",
+      "bridge":  "Bridge role per BL-37. In Strong-domain context, treat as Strong. Apply domain logic otherwise. Never downgrade purely for not being on the primary track."
+    }
+  },
+  // ... rest of file unchanged
+  "title_requirelist": null,  // deprecated; see role_targets
+  ...
+}
+```
+
+`engine/core/profile_loader.js`'s `normalizeFilterRules` synthesizes the
+legacy `title_requirelist` array from the union of all `tracks[].patterns`
+so `engine/core/filter.js` keeps working with no edits to its hot path.
+Eventually filter.js reads `role_targets` directly; for now we keep the
+diff small.
+
+Pros: no new file; profile loader already centralizes filter access;
+SKILL.md and engine read one place. Cons: `filter_rules.json` grows.
+
+#### Option C — Top-level field in `profile.json`
+
+Add `role_targets: {...}` directly to `profile.json`. Loader already
+exposes the parsed profile to both engine and prepare-context.
+
+Pros: minimal new plumbing. Cons: `profile.json` is currently a small
+config file (~60 lines for Jared); embedding ~150 lines of track
+definitions plus prose treatments blurs its role. Mixing
+identity/secrets/module-config with gate rules is a smell.
+
+#### Why B
+
+- `filter_rules.json` is already loaded once into `profile.filterRules`
+  and passed to filter + prepare. Adding `role_targets` there means **no
+  new file path, no new loader, no new ignore rule**.
+- `_example` already ships `filter_rules.example.json`; we extend it,
+  don't add a new template.
+- Engine hot path stays identical via the `normalizeFilterRules` shim;
+  scan smoke tests don't change.
+- The LLM channel is via `prepare_context.json` (see §4.2), independent
+  of the file location.
+
+### 4.2 LLM channel: how role_targets reaches Fit Score
+
+`engine/commands/prepare.js` Phase 1 (mechanical) already writes
+`prepare_context.json` with everything the LLM needs. We add one field:
+
+```jsonc
+// profiles/<id>/prepare_context.json
+{
+  "jobs": [...],
+  "salaryConfig": {...},
+  "roleTargets": {
+    "tracks": [
+      { "id": "pm", "name": "Product Manager", "fit_treatment": "primary" },
+      { "id": "fde", "name": "Forward-Deployed Engineer / AI Solutions",
+        "fit_treatment": "bridge",
+        "bridge_note": "Treat as primary track in Strong-domain..." },
+      ...
+    ],
+    "fit_treatments": { "primary": "...", "bridge": "..." }
+  }
+}
+```
+
+Note: regex patterns are deliberately **stripped** before the LLM sees
+the bundle — LLM doesn't need to match titles, scan already did that.
+It needs the *names* and *treatments* to reason about fit.
+
+`skills/job-pipeline/SKILL.md` §755 ("Fit Score") gets an explicit
+clause:
+
+> **Role-track is NOT a Fit Score input.** The candidate's acceptable
+> tracks are in `context.roleTargets.tracks`. Every job in this batch
+> already passed the role-track gate at scan time. Apply Fit Score by
+> *domain match only* per the rules below. If a job's title-derived
+> track has `fit_treatment: "bridge"`, follow the corresponding
+> `fit_treatments.bridge` instruction.
+
+This removes the LLM's hidden prior. The current SKILL.md note "Level
+does NOT affect fit score" already exists; this RFC adds a parallel
+statement for role-track.
+
+### 4.3 Memory cleanup
+
+`profiles/<id>/memory/user_resume_key_points.md` "Bridge-mode booster"
+section becomes a one-line pointer:
+
+> Bridge-mode treatment of role-tracks is defined in
+> `filter_rules.json → role_targets`. The engine ensures Fit Score
+> respects it; do not re-state the rule in memory.
+
+`profile.json → target_roles` becomes derived (engine builds it from
+`role_targets.tracks[].name`) or is deprecated in favour of letting the
+LLM read `roleTargets` from context. Decision deferred to implementation
+review — both eliminate the duplication.
+
+### 4.4 Engine changes (Option B path)
+
+| File | Change |
+|---|---|
+| `engine/core/profile_loader.js` | `normalizeFilterRules` reads `role_targets.tracks[].patterns` and synthesizes the legacy flat `title_requirelist` for filter.js compat. Exposes `role_targets` separately under `profile.roleTargets`. |
+| `engine/core/filter.js` | No change in Phase 1. (Phase 2 follow-up: read `roleTargets.tracks[].patterns` directly and emit per-track `reason` for archive log clarity.) |
+| `engine/commands/prepare.js` | When writing `prepare_context.json`, include `roleTargets` (stripped of regex patterns — see §4.2). |
+| `skills/job-pipeline/SKILL.md` | Add the "Role-track is NOT a Fit Score input" clause to §755. |
+| `profiles/jared/filter_rules.json` | Add `role_targets` block. Drop the legacy `title_requirelist` key entirely — loader synthesizes from `role_targets.tracks[].patterns`. The `role_targets._description` is the breadcrumb for future readers. (Originally proposed `title_requirelist: null` as a deprecation marker; implementation chose to omit, since the synthesized list lives only in memory and the marker risked confusing readers about the empty-array footgun — see §10 R1.) |
+| `profiles/jared/profile.json` | Either delete `target_roles` or convert to derived pointer. |
+| `profiles/jared/memory/user_resume_key_points.md` | Replace "Bridge-mode booster" with one-line pointer. |
+| `profiles/_example/filter_rules.example.json` | Add minimal `role_targets` stub. |
+
+## 5. Migration
+
+Single migration step per profile, no rollback period needed (both
+profiles are owned by the same operator; no fleet).
+
+1. Author the new `role_targets` block in `filter_rules.json`,
+   reproducing the existing `title_requirelist.patterns` 1:1.
+2. Tag each track with `fit_treatment: "primary" | "bridge"`. (For
+   Jared: `pm` = primary; everything else from BL-37 = bridge.)
+3. Drop the legacy `title_requirelist` key (don't leave it as `null` or
+   `[]` — an explicit empty list would silently disable the gate; §10 R1).
+   Run the full test suite — loader synthesizes the flat list from
+   `role_targets`; scan behaviour unchanged.
+4. Update memory file + SKILL.md + delete `target_roles` (or convert).
+5. Re-run `prepare` against the stuck 20-job batch from 2026-05-12.
+   Verify: no "not PM track" rationale; PM-adjacent jobs get a real
+   fit decision (Strong/Medium/Weak by domain).
+
+Backup `filter_rules.json.pre-rfc030-{ISO}` before mutating (consistent
+with existing backup pattern around BL-51 fixes).
+
+## 6. Acceptance criteria
+
+- `node engine/cli.js scan --profile jared` produces identical pass/fail
+  counts vs pre-RFC baseline. (Smoke evidence that loader-shim
+  preserves filter behaviour.)
+- `node engine/cli.js prepare --profile jared --phase pre` writes
+  `prepare_context.json` containing a non-empty `roleTargets.tracks[]`
+  with `id`, `name`, `fit_treatment` (no regex patterns leaked into
+  LLM context).
+- `skills/job-pipeline/SKILL.md` §755 contains the "Role-track is NOT a
+  Fit Score input" clause. (Spot-check by grep.)
+- `profiles/jared/memory/user_resume_key_points.md` no longer contains
+  the freeform "Bridge-mode booster" prose paragraph; one-line pointer
+  in its place.
+- Regression test: re-run the LLM phase on the 17 PM-adjacent rows from
+  `prepare_results_20260512_182159.json`. **Zero** of them are
+  decision=skip with rationale matching `/not PM track|not.*PM role|outside PM/i`.
+  They may still skip for other reasons (geo, salary, fit domain) —
+  that is fine; this RFC only fixes the role-track confound.
+- `npm test` green. New unit tests:
+  - `profile_loader.test.js`: `role_targets → title_requirelist` shim
+    works (regression).
+  - `profile_loader.test.js`: when both `title_requirelist` and
+    `role_targets` present, `role_targets` wins; legacy
+    `title_requirelist` (without `role_targets`) still works.
+  - `prepare.test.js`: `prepare_context.json` exposes `roleTargets`
+    without regex patterns.
+
+## 7. Phasing
+
+Single phase. Tier M. No staged rollout — affects only `jared` (active)
+and `_example` (template). Steps:
+
+1. Author + approve RFC.
+2. Implement engine changes + new profile blocks.
+3. Run tests; run smoke `scan` + `prepare --phase pre`.
+4. Manually invoke prepare Phase 2 (LLM) on the regression batch via
+   `/job-pipeline prepare` and verify the acceptance test.
+5. Commit. Mark RFC `implemented`.
+
+## 8. Out of scope
+
+- Multi-profile rollout. `lilia` and others migrate when relevant.
+- Restructuring `filter_rules.json`'s other sections (location,
+  company, salary). Separate concerns.
+- Adding more `fit_treatment` modes beyond `primary` / `bridge` (e.g.
+  `aspirational` for stretch roles). Easy to extend; not needed now.
+- Letting LLM see regex patterns. Stripped at context-write time.
+
+## 9. Open questions
+
+- **Q1.** `target_roles` in `profile.json`: delete or convert to a
+  computed pointer? Removing breaks anyone reading `profile.target_roles`
+  outside the engine; I have not seen such a reader, but a search before
+  commit will confirm. Default: delete.
+- **Q2.** Engine-side mapping from a job's title to which track it
+  matched: do we expose this in `prepare_context.json` per-job
+  (`job.matchedTrack: "fde"`)? Useful for the LLM, but coupling adds
+  surface. Default: not in v1; LLM infers from title + tracks list.
+- **Q3.** Memory file: keep the section heading "Domain criteria for fit
+  scoring" + a one-line pointer, or delete the section entirely?
+  Default: keep heading, replace body with pointer (preserves
+  navigability).
+
+## 10. Risks
+
+- **R1.** Empty explicit `title_requirelist` silently disables the gate.
+  `title_requirelist: []` (or `{patterns: []}`) alongside a non-empty
+  `role_targets` would, under naïve "explicit wins" logic, take
+  precedence and disable the positive title gate — every job passes
+  scan on title grounds. *Resolved in implementation:* loader now treats
+  "explicit wins" as "explicit *non-empty* wins"; empty explicit falls
+  through to synthesis. Regression tests cover both `[]` and
+  `{patterns: []}` shapes.
+- **R2.** LLM ignores the new SKILL.md clause and persists with "not PM
+  track" rationale. Mitigation: regression test on the existing
+  prepare_results batch. If it still fires, escalate from soft
+  instruction to a structured-output rule in the prompt (followup,
+  out of scope here). Additionally, the SKILL.md wording was split
+  (post-review) into asymmetric claims — *role-track NEVER downgrades*
+  (hard rule) vs *bridge MAY upgrade* (soft modifier) — to avoid the
+  internal contradiction the reviewer flagged.
+- **R3.** `role_targets` schema doesn't generalize to non-PM profiles
+  (e.g. `lilia`, a healthcare admin). Mitigation: `fit_treatments` is
+  free-form prose keyed by `fit_treatment` value, so other profiles
+  can define their own treatments without engine changes.
+
+## 11. Approval
+
+RFC accepted by Jared 2026-05-13 (Option B, Q1=delete, Q2=defer,
+Q3=keep heading + pointer). Implementation under BL-56 includes
+fixes for the two serious findings from the code-review pass
+(empty-array footgun in loader; SKILL.md asymmetry split).

--- a/rfc/README.md
+++ b/rfc/README.md
@@ -35,8 +35,9 @@ Status lives in each RFC's YAML frontmatter (`status: implemented`). The table b
 | [016](016-unified-jd-cache.md) | Unified JD cache across adapters | draft | M | — |
 | [017](017-deel-adapter.md) | Deel adapter | draft | M | — |
 | [018](018-documentation-system.md) | Documentation system overhaul | draft | L | — |
+| [030](030-unified-role-targets.md) | Unified role-targets (single source for scan + LLM fit) | accepted | M | 2026-05-13 |
 
-> Index reconciled with frontmatter on 2026-05-05 (RFC 018 phase 1.e back-fill). To update: edit the frontmatter in the RFC file and reflect the change here.
+> Index reconciled with frontmatter on 2026-05-05 (RFC 018 phase 1.e back-fill); RFCs 019–029 not yet back-filled — live frontmatter is canonical. To update: edit the frontmatter in the RFC file and reflect the change here.
 
 ## Numbering
 

--- a/skills/job-pipeline/SKILL.md
+++ b/skills/job-pipeline/SKILL.md
@@ -754,14 +754,25 @@ Cap is enforced at **prepare time only** — scan always lets all jobs through. 
 
 ### Fit Score (domain fit only)
 
-Level does NOT affect fit score. Evaluate by domain match to the candidate's profile:
+**Role-track NEVER downgrades a Fit Score** (RFC 030). Acceptable role-tracks for this profile are in `prepare_context.roleTargets.tracks[]`. Every job in `batch[]` already passed the role-track gate at scan time — the title is, by construction, on a track the candidate accepts. Do **not** reduce a job's score because it's "not the primary track" (e.g. "Solutions Engineer instead of PM" / "TPM instead of PM" / "BizOps instead of PM"). The scan filter is the only authority on whether a track is acceptable; once a job is in `batch[]`, downgrading on track grounds is a bug.
+
+**Level NEVER downgrades a Fit Score** either. Evaluate by domain match to the candidate's profile:
 
 - **Strong** — core domain match (see `profiles/<id>/memory/user_resume_key_points.md` for domain specifics) plus a relevant tech or product component
 - **Medium** — adjacent domain, or right domain with lesser location/format fit, or outside core domain but with a key component overlap (AI/ML, data platform, payments)
 - **Weak** — outside core domain with no overlapping component
 - **Early-startup modifier** (pre-Series B, <50 people): downgrade one level (Strong→Medium, Medium→Weak)
 
+**Bridge-track upgrade (asymmetric).** Some tracks are tagged `fit_treatment: "bridge"` (BL-37 stepping-stone roles: FDE / Solutions / Implementation / TPM / Product Ops / BizOps). Bridge tracks can **upgrade** a score, never downgrade it:
+
+- If the **domain** is Strong, the score is Strong regardless of track. Bridge is a no-op (the upgrade is already implicit).
+- If the **domain** is Medium *and* the company is in a profile-Strong domain (per `user_resume_key_points.md`), and the track has `fit_treatment: "bridge"`, **upgrade to Strong**. This is the bridge override per `roleTargets.fit_treatments.bridge` (and any `track.bridge_note`).
+- If the **domain** is Weak, do not upgrade; report as Weak.
+
+Translated: bridge says "even though this is FDE not PM, if it's an AI-native company, count it as Strong". It NEVER says "this is FDE so downgrade".
+
 Profile-specific domain criteria: `profiles/<id>/memory/user_resume_key_points.md`.
+Acceptable role-tracks + treatments: `prepare_context.roleTargets` (sourced from `profiles/<id>/filter_rules.json → role_targets`).
 
 ### Salary Expectations (auto-fill at prepare time)
 
@@ -837,6 +848,10 @@ The defaults above describe Jared's tone. Other profiles (e.g. Lilia — warm, 5
 ### Final anti-AI check
 
 After writing, ask: "What makes this obviously AI-generated?" — fix any remaining tells before saving.
+
+### Final language-calque check (profile-specific)
+
+If `memory.writingStyle` contains an "Anti-russicism rules" / "language-calque" / "translation traps" section (e.g. Jared's profile lists 30+ banned patterns like `X direction`, `the volume of X`, `transfers directly to X`, `Comfortable with X, Y, Z`, `Ready to contribute to X priorities`), perform a **second pass specifically against those rules**. These are profile-specific translation traps from the candidate's L1 — a single hit is a recruiter screen-out flag for US-tech roles. Treat the section as a hard-gate, not a style preference: scan every paragraph for each banned pattern by name and rewrite before saving.
 
 ### Memory files (load before generating)
 


### PR DESCRIPTION
## Summary

Three commits, two independent fixes + format hygiene:

- **RFC 030 / BL-56** — Single source of truth for "which role-tracks the candidate accepts". `filter_rules.json → role_targets` block drives both scan's title gate AND the SKILL's Fit Score. Closes the two-sources-of-truth bug where scan passed PM-adjacent roles (BL-37) but the LLM rejected 17 of them as "not PM track".
- **BL-55** — PDFKit's built-in Helvetica (WinAnsi) doesn't support `→` / `↔` / `←` / `⇒` → rendered as mojibake `!'`. Sanitize at PDF render time; source JSON stays unicode-clean for DOCX.
- **chore(format)** — Prettier across discovery adapters (icims/jobsyn/oracle_cloud) + recently-touched files. HTML fixtures added to `.prettierignore` (byte-sensitive). Behaviour-neutral.

## What changes for the operator

- Editing `profiles/jared/filter_rules.json → role_targets` updates both gates atomically. No more drift.
- SKILL.md Fit Score is asymmetric: role-track NEVER downgrades; bridge tracks (FDE / Solutions / TPM / Product Ops / BizOps) MAY upgrade.
- Generated CVs no longer show `!'` where arrows should be.

## Test plan

- [x] `npm test` — 1206/0.
- [x] `prettier --check .` — clean.
- [x] Smoke `prepare --phase pre --dry-run --batch 5` — 21 passed, 52 rejected by title_requirelist; **byte-identical** to legacy 24/24 patterns.
- [x] Multi-agent code review (M-tier per dev-workflow). Serious findings (empty-array footgun, SKILL.md internal contradiction) fixed before commit.
- [ ] Post-merge: re-run LLM phase against the 17 PM-adjacent rows from `prepare_results_20260512_182159.json` — expect zero `decision=skip` with "not PM track" rationale.

## Out-of-scope follow-ups

- BL-56 (Phase 2): per-job `matchedTrackId` emission, `fit_treatment` allow-list validation.
- BL-57: tooling fix for recurring worktree-path-vs-main confusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)