### PR TITLE
BL-77: archive pre-BL-24 non-US rows (cleanup script)

### DIFF
--- a/incidents.md
+++ b/incidents.md
@@ -14,6 +14,8 @@ last_updated: 2026-05-18
 
 **Prevention**: The contract is now array-first; `scan.js` may eventually drop the redundant `location` scalar (separate follow-up). Tests pin every BL-24 case (multi-loc keep, multi-loc block, state-code coverage, country-name false-positive guard, single-string back-compat, locations[]-vs-scalar precedence) so a regression would be loud.
 
+**Cleanup (BL-77, 2026-05-18)**: `scripts/cleanup_non_us_jobs.js` reconciled pre-BL-24 rows still sitting in Jared's TSV. Dry-run found 13 candidates (all obviously non-US: Madrid, Montevideo, TLV, EU, Europe, Sofia, Bogota ×3, MENA, Chile, Krakow). `--apply` archived all 13 (5 Notion `pages.update`, 8 TSV-only) with `skip_reason="location_post_BL24"`. Backup at `applications.tsv.pre-bl77-2026-05-18T09-48-40-925Z`. Idempotent re-run confirmed (0 candidates, 13 already-marked). Note: BL-77 Q1 originally proposed status `Discarded`, which is not in `EXPECTED_STATUS_OPTIONS` — used `Archived` instead, audit trail preserved via TSV `skip_reason`. Schema mismatch caught during recon, not at runtime.
+
 ---
 
 

--- a/scripts/cleanup_non_us_jobs.js
+++ b/scripts/cleanup_non_us_jobs.js
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+// BL-77 — one-shot cleanup of non-US rows landed in Notion before BL-24
+// (multi-loc location_blocklist + US state-code fix).
+//
+// What it does
+//   For each row in profiles/<id>/applications.tsv:
+//     - Skip if status ∈ {Applied, Interview, Offer, Rejected, Archived} —
+//       the user has interacted with the job; cleanup must not touch it.
+//     - Skip if skip_reason === "location_post_BL24" — idempotent re-runs.
+//     - Skip if location is empty — undecidable; leave alone.
+//     - Otherwise run `matchBlocklists` (the post-BL-24 version) against
+//       `{ location, locations: [location] }`. If it returns a
+//       `location_blocklist` reason, the row is a cleanup candidate.
+//   In --apply mode: mark TSV row status="Archived" + skip_reason set, and
+//   (if notion_page_id present) call notion.updatePageStatus → "Archived".
+//
+// Why "Archived" and not "Discarded"
+//   BL-77 Q1(a) proposed status "Discarded", but it is not in the schema
+//   (Notion EXPECTED_STATUS_OPTIONS = To Apply / Applied / Interview / Offer
+//   / Rejected / No Response / Closed / Archived). "Archived" is the
+//   schema-blessed bucket for filter-reject (see applications_tsv.js header
+//   comment). The audit trail lives in TSV skip_reason="location_post_BL24".
+//
+// Default = dry-run. Pass --apply to write.
+//
+// Usage:
+//   node scripts/cleanup_non_us_jobs.js --profile <id>
+//   node scripts/cleanup_non_us_jobs.js --profile <id> --apply
+
+require("dotenv").config();
+const fs = require("fs");
+const path = require("path");
+
+const { loadProfile, loadSecrets } = require("../engine/core/profile_loader");
+const { load: loadApps, save: saveApps } = require("../engine/core/applications_tsv");
+const { matchBlocklists } = require("../engine/core/filter");
+const { makeClient, updatePageStatus } = require("../engine/core/notion_sync");
+
+const SKIP_REASON = "location_post_BL24";
+const NEW_STATUS = "Archived";
+
+// Statuses where the user has engaged with the job. Never touched by cleanup.
+const PROTECTED_STATUSES = new Set(["Applied", "Interview", "Offer", "Rejected", "Archived"]);
+
+function parseArgs(argv) {
+  const out = { profile: null, apply: false };
+  for (let i = 2; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--profile") out.profile = argv[++i];
+    else if (a === "--apply") out.apply = true;
+    else if (a === "--help" || a === "-h") {
+      process.stdout.write("Usage: node scripts/cleanup_non_us_jobs.js --profile <id> [--apply]\n");
+      process.exit(0);
+    }
+  }
+  if (!out.profile) {
+    process.stderr.write("error: --profile <id> is required\n");
+    process.exit(2);
+  }
+  return out;
+}
+
+// Pure planner. Returns { candidates, counts } so tests can assert behavior
+// without touching the filesystem or Notion.
+function plan(apps, filterRules) {
+  const candidates = [];
+  const counts = {
+    total: apps.length,
+    skipped_protected_status: 0,
+    skipped_already_marked: 0,
+    skipped_no_location: 0,
+    not_a_match: 0,
+    candidates: 0,
+  };
+  for (const app of apps) {
+    // skip_reason check first: a row we already cleaned will show
+    // status="Archived" (also in PROTECTED_STATUSES), but the more honest
+    // diagnostic is "already marked" rather than "protected".
+    if (app.skip_reason === SKIP_REASON) {
+      counts.skipped_already_marked += 1;
+      continue;
+    }
+    if (PROTECTED_STATUSES.has(app.status)) {
+      counts.skipped_protected_status += 1;
+      continue;
+    }
+    if (!app.location) {
+      counts.skipped_no_location += 1;
+      continue;
+    }
+    const reason = matchBlocklists(
+      { location: app.location, locations: [app.location] },
+      filterRules || {}
+    );
+    if (reason && reason.kind === "location_blocklist") {
+      counts.candidates += 1;
+      candidates.push({
+        key: app.key,
+        companyName: app.companyName,
+        title: app.title,
+        location: app.location,
+        status: app.status,
+        notion_page_id: app.notion_page_id,
+        match: reason.match,
+      });
+    } else {
+      counts.not_a_match += 1;
+    }
+  }
+  return { candidates, counts };
+}
+
+// Pure: returns a new apps array with the marked rows updated.
+function applyPlanToTsv(apps, candidateKeys, now) {
+  const set = new Set(candidateKeys);
+  return apps.map((a) =>
+    set.has(a.key) ? { ...a, status: NEW_STATUS, skip_reason: SKIP_REASON, updatedAt: now } : a
+  );
+}
+
+function printTable(candidates) {
+  if (candidates.length === 0) {
+    process.stdout.write("  (none)\n");
+    return;
+  }
+  // Lazy-width columns capped at sensible maxes so a runaway field doesn't
+  // shred the terminal.
+  const widths = {
+    company: Math.min(28, Math.max(...candidates.map((c) => c.companyName.length))),
+    title: Math.min(44, Math.max(...candidates.map((c) => c.title.length))),
+    location: Math.min(28, Math.max(...candidates.map((c) => c.location.length))),
+    status: Math.max(...candidates.map((c) => c.status.length)),
+  };
+  const pad = (s, w) => {
+    const str = String(s);
+    return str.length > w ? str.slice(0, w - 1) + "…" : str.padEnd(w);
+  };
+  const header =
+    `  ${pad("COMPANY", widths.company)}  ${pad("TITLE", widths.title)}  ` +
+    `${pad("LOCATION", widths.location)}  ${pad("STATUS", widths.status)}  NOTION`;
+  process.stdout.write(header + "\n");
+  process.stdout.write("  " + "─".repeat(header.length - 2) + "\n");
+  for (const c of candidates) {
+    process.stdout.write(
+      `  ${pad(c.companyName, widths.company)}  ${pad(c.title, widths.title)}  ` +
+        `${pad(c.location, widths.location)}  ${pad(c.status, widths.status)}  ` +
+        `${c.notion_page_id ? "↗" : "—"}\n`
+    );
+  }
+}
+
+// Wrapped so tests can inject a fake Notion client. Returns { ok: [keys],
+// failed: [{key, error}] }.
+async function pushNotionUpdates(client, candidates, propertyMap, log = () => {}) {
+  const ok = [];
+  const failed = [];
+  for (const c of candidates) {
+    if (!c.notion_page_id) {
+      // No Notion page → TSV-only update; counted as success.
+      ok.push(c.key);
+      continue;
+    }
+    try {
+      await updatePageStatus(client, c.notion_page_id, NEW_STATUS, propertyMap);
+      log(`  ✓ ${c.key} → Notion Status=${NEW_STATUS}`);
+      ok.push(c.key);
+    } catch (err) {
+      const msg = err && err.message ? err.message : String(err);
+      log(`  ✗ ${c.key} → ${msg}`);
+      failed.push({ key: c.key, error: msg });
+    }
+  }
+  return { ok, failed };
+}
+
+async function main() {
+  const { profile: profileId, apply } = parseArgs(process.argv);
+  const profile = loadProfile(profileId);
+  const tsvPath = profile.paths.applicationsTsv;
+
+  if (!fs.existsSync(tsvPath)) {
+    process.stderr.write(`error: ${tsvPath} not found\n`);
+    process.exit(1);
+  }
+
+  const filterRules = profile.filterRules || {};
+  const { apps } = loadApps(tsvPath);
+  const { candidates, counts } = plan(apps, filterRules);
+
+  process.stdout.write(`profile: ${profileId}\n`);
+  process.stdout.write(`tsv: ${tsvPath} (${counts.total} rows)\n`);
+  process.stdout.write(
+    `triage:\n` +
+      `  candidates (non-US, will Archive):   ${counts.candidates}\n` +
+      `  skipped (protected status):           ${counts.skipped_protected_status}\n` +
+      `  skipped (already cleaned post-BL24):  ${counts.skipped_already_marked}\n` +
+      `  skipped (empty location):             ${counts.skipped_no_location}\n` +
+      `  not a match:                          ${counts.not_a_match}\n`
+  );
+
+  if (candidates.length === 0) {
+    process.stdout.write("\nNothing to clean up — exiting.\n");
+    return;
+  }
+
+  process.stdout.write(`\nCandidates (${candidates.length}):\n`);
+  printTable(candidates);
+
+  if (!apply) {
+    process.stdout.write(
+      `\n(dry-run) Pass --apply to set Status="${NEW_STATUS}" + skip_reason="${SKIP_REASON}".\n`
+    );
+    return;
+  }
+
+  // --apply path: backup TSV first, then push Notion updates, then write TSV
+  // with successful keys only. If Notion fails on a row, the TSV is not marked
+  // for that row → next run will retry that row only (idempotent).
+  const backupPath = `${tsvPath}.pre-bl77-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+  fs.copyFileSync(tsvPath, backupPath);
+  process.stdout.write(`\nbackup written: ${backupPath}\n`);
+
+  const secrets = loadSecrets(profileId, process.env);
+  const token = secrets.NOTION_TOKEN;
+  if (!token) {
+    process.stderr.write(
+      `error: missing ${profileId.toUpperCase()}_NOTION_TOKEN in env — cannot push Notion updates\n`
+    );
+    process.exit(1);
+  }
+  const client = makeClient(token);
+  const propertyMap = (profile.notion && profile.notion.property_map) || undefined;
+
+  process.stdout.write(`\npushing Notion updates...\n`);
+  const { ok, failed } = await pushNotionUpdates(client, candidates, propertyMap, (msg) =>
+    process.stdout.write(msg + "\n")
+  );
+
+  const now = new Date().toISOString();
+  const nextApps = applyPlanToTsv(apps, ok, now);
+  saveApps(tsvPath, nextApps);
+  process.stdout.write(`\napplied: ${ok.length} TSV row(s) updated in ${tsvPath}\n`);
+
+  if (failed.length > 0) {
+    process.stdout.write(
+      `\n${failed.length} Notion update(s) failed (TSV not marked for these):\n`
+    );
+    for (const f of failed) process.stdout.write(`  - ${f.key}: ${f.error}\n`);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    process.stderr.write(`fatal: ${err && err.stack ? err.stack : err}\n`);
+    process.exit(1);
+  });
+}
+
+module.exports = { plan, applyPlanToTsv, pushNotionUpdates, SKIP_REASON, NEW_STATUS };

--- a/scripts/cleanup_non_us_jobs.test.js
+++ b/scripts/cleanup_non_us_jobs.test.js
@@ -1,0 +1,191 @@
+const test = require("node:test");
+const assert = require("node:assert");
+
+const {
+  plan,
+  applyPlanToTsv,
+  pushNotionUpdates,
+  SKIP_REASON,
+  NEW_STATUS,
+} = require("./cleanup_non_us_jobs.js");
+
+const RULES = {
+  location_blocklist: ["poland", "germany", "united kingdom", "spain"],
+};
+
+function row(overrides) {
+  return {
+    key: "gh:1",
+    source: "gh",
+    jobId: "1",
+    companyName: "Acme",
+    title: "PM",
+    url: "https://example.com",
+    location: "",
+    status: "To Apply",
+    notion_page_id: "",
+    resume_ver: "",
+    cl_key: "",
+    salary_min: "",
+    salary_max: "",
+    cl_path: "",
+    createdAt: "2026-05-01T00:00:00Z",
+    updatedAt: "2026-05-01T00:00:00Z",
+    fit_score: "",
+    fit_rationale: "",
+    fit_evaluated_at: "",
+    skip_reason: "",
+    ...overrides,
+  };
+}
+
+test("plan: flags non-US row with blocklist hit", () => {
+  const apps = [row({ key: "gh:1", location: "Warsaw, Poland", notion_page_id: "page-1" })];
+  const { candidates, counts } = plan(apps, RULES);
+  assert.equal(candidates.length, 1);
+  assert.equal(candidates[0].key, "gh:1");
+  assert.equal(candidates[0].match, "poland");
+  assert.equal(candidates[0].notion_page_id, "page-1");
+  assert.equal(counts.candidates, 1);
+});
+
+test("plan: US-marker (state code) wins — keeps row even if blocklist substring present", () => {
+  // "Sacramento, CA" should pass via BL-24 US state-code rule
+  const apps = [row({ location: "Sacramento, CA" })];
+  const { candidates, counts } = plan(apps, RULES);
+  assert.equal(candidates.length, 0);
+  assert.equal(counts.not_a_match, 1);
+});
+
+test("plan: US-marker phrase wins (united states)", () => {
+  const apps = [row({ location: "Remote, United States" })];
+  const { candidates } = plan(apps, RULES);
+  assert.equal(candidates.length, 0);
+});
+
+test("plan: skips protected statuses (Applied / Interview / Offer / Rejected / Archived)", () => {
+  const apps = [
+    row({ key: "gh:a", location: "Berlin, Germany", status: "Applied" }),
+    row({ key: "gh:b", location: "Berlin, Germany", status: "Interview" }),
+    row({ key: "gh:c", location: "Berlin, Germany", status: "Offer" }),
+    row({ key: "gh:d", location: "Berlin, Germany", status: "Rejected" }),
+    row({ key: "gh:e", location: "Berlin, Germany", status: "Archived" }),
+  ];
+  const { candidates, counts } = plan(apps, RULES);
+  assert.equal(candidates.length, 0);
+  assert.equal(counts.skipped_protected_status, 5);
+});
+
+test("plan: idempotent — skips rows already marked with our skip_reason", () => {
+  const apps = [
+    row({
+      location: "Berlin, Germany",
+      status: "Archived",
+      skip_reason: SKIP_REASON,
+    }),
+  ];
+  const { candidates, counts } = plan(apps, RULES);
+  assert.equal(candidates.length, 0);
+  assert.equal(counts.skipped_already_marked, 1);
+});
+
+test("plan: skips rows with empty location", () => {
+  const apps = [row({ location: "" })];
+  const { candidates, counts } = plan(apps, RULES);
+  assert.equal(candidates.length, 0);
+  assert.equal(counts.skipped_no_location, 1);
+});
+
+test("plan: counts breakdown sums to total", () => {
+  const apps = [
+    row({ key: "1", location: "Warsaw, Poland" }), // candidate
+    row({ key: "2", location: "Berlin, Germany", status: "Applied" }), // protected
+    row({ key: "3", location: "" }), // no location
+    row({ key: "4", location: "Sacramento, CA" }), // not a match
+    row({ key: "5", location: "Berlin, Germany", skip_reason: SKIP_REASON }), // already marked
+  ];
+  const { counts } = plan(apps, RULES);
+  assert.equal(
+    counts.candidates +
+      counts.skipped_protected_status +
+      counts.skipped_no_location +
+      counts.not_a_match +
+      counts.skipped_already_marked,
+    counts.total
+  );
+});
+
+test("applyPlanToTsv: updates only candidate keys, leaves others alone", () => {
+  const apps = [
+    row({ key: "1", status: "To Apply", location: "Warsaw, Poland" }),
+    row({ key: "2", status: "To Apply", location: "Sacramento, CA" }),
+  ];
+  const next = applyPlanToTsv(apps, ["1"], "2026-05-18T01:00:00Z");
+  assert.equal(next[0].status, NEW_STATUS);
+  assert.equal(next[0].skip_reason, SKIP_REASON);
+  assert.equal(next[0].updatedAt, "2026-05-18T01:00:00Z");
+  // Unchanged
+  assert.equal(next[1].status, "To Apply");
+  assert.equal(next[1].skip_reason, "");
+});
+
+test("pushNotionUpdates: skips rows without notion_page_id (TSV-only), calls API for the rest", async () => {
+  const calls = [];
+  const fakeClient = {
+    pages: {
+      update: async (args) => {
+        calls.push(args);
+        return { id: args.page_id };
+      },
+    },
+  };
+  const candidates = [
+    { key: "1", notion_page_id: "page-a" },
+    { key: "2", notion_page_id: "" }, // TSV-only
+    { key: "3", notion_page_id: "page-c" },
+  ];
+  const { ok, failed } = await pushNotionUpdates(fakeClient, candidates);
+  assert.equal(ok.length, 3);
+  assert.equal(failed.length, 0);
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].page_id, "page-a");
+  assert.equal(calls[1].page_id, "page-c");
+});
+
+test("pushNotionUpdates: collects failures without aborting the batch", async () => {
+  const fakeClient = {
+    pages: {
+      update: async (args) => {
+        if (args.page_id === "page-bad") throw new Error("validation_error: status option missing");
+        return { id: args.page_id };
+      },
+    },
+  };
+  const candidates = [
+    { key: "1", notion_page_id: "page-a" },
+    { key: "2", notion_page_id: "page-bad" },
+    { key: "3", notion_page_id: "page-c" },
+  ];
+  const { ok, failed } = await pushNotionUpdates(fakeClient, candidates);
+  assert.deepEqual(ok, ["1", "3"]);
+  assert.equal(failed.length, 1);
+  assert.equal(failed[0].key, "2");
+  assert.match(failed[0].error, /validation_error/);
+});
+
+test("pushNotionUpdates: sends Archived as the new status with default property map", async () => {
+  let captured = null;
+  const fakeClient = {
+    pages: {
+      update: async (args) => {
+        captured = args;
+        return { id: args.page_id };
+      },
+    },
+  };
+  await pushNotionUpdates(fakeClient, [{ key: "1", notion_page_id: "page-x" }]);
+  assert.equal(captured.page_id, "page-x");
+  // Default property map writes to field "Status" with type "status"
+  assert.ok(captured.properties.Status);
+  assert.equal(captured.properties.Status.status.name, "Archived");
+});


### PR DESCRIPTION
## Summary

One-shot reconcile script for jobs that landed in Jared's TSV/Notion **before** [BL-24's `location_blocklist` fix](https://github.com/ymuromcev/ai-job-searcher/pull/8). Already applied to Jared on `main` (the worktree was on top of merged BL-24); this PR adds the script + tests + incident-log paragraph.

- **Pure planner** (`plan`) over the post-BL-24 `matchBlocklists` — feeds `{ location, locations: [location] }` so the new array-iterating contract is exercised.
- **Protected statuses** (Applied / Interview / Offer / Rejected / Archived) never touched.
- **Idempotent** on TSV `skip_reason="location_post_BL24"`.
- **`--apply` flow**: TSV backup → push Notion `pages.update` (Archived) → save TSV with only successfully-updated keys. Notion failures stay retryable on next run.

Applied to Jared 2026-05-18: 13 rows archived (5 Notion, 8 TSV-only). Idempotent re-run confirmed.

**Schema note**: BL-77 Q1(a) proposed `Status=Discarded`, but `Discarded` is not in `EXPECTED_STATUS_OPTIONS`. Used `Archived` (the schema-blessed filter-reject bucket). Audit trail preserved via TSV `skip_reason`.

## Test plan

- [x] `npm test` — 1370/1370 pass (11 new tests in `cleanup_non_us_jobs.test.js`)
- [x] `npx prettier --check .` — clean
- [x] Dry-run on Jared — produced reviewable table of 13 obvious non-US rows
- [x] `--apply` on Jared — 13/13 success (5 Notion, 8 TSV-only)
- [x] Idempotent re-run — 0 candidates, 13 already-marked