### PR TITLE
BL-A + BL-C: drop calcareers from prepare; ban markdown literals in resume-tailor-mirror

### DIFF
--- a/.claude/agents/resume-tailor-mirror.md
+++ b/.claude/agents/resume-tailor-mirror.md
@@ -247,6 +247,41 @@ Your entire response is a single JSON object. Examples of what to **NOT** emit:
 
 The orchestrator will `JSON.parse(stdout)` and fail loudly on anything else.
 
+### NO markdown literals inside string values — hard rule (BL-C)
+
+The renderer prints every string value verbatim. It does **not** parse markdown. So markdown syntax inside any string in `resume_data` shows up literally in the PDF.
+
+This applies to **every** string field: `version.summary`, `version.title`, role `description`, every bullet segment's `text:`, project descriptions, skill `value`s. No exceptions.
+
+**Forbidden inside string values:**
+
+- `**bold**` / `__bold__` — bold pairs.
+- `*italic*` / `_italic_` — italic pairs.
+- `` `code` `` — backticks.
+- `[label](url)` — markdown links.
+- `#`, `##`, `###` — headings.
+- `-`, `*` at line start — list markers.
+
+**To make text bold inside a bullet** — split the bullet into segments and set `bold:true` on the bold segment. The bullet is an array of `{text, bold}` objects, not one string. Example:
+
+DON'T:
+```json
+{"text": "Drove **30% conversion lift** through 40+ A/B experiments.", "bold": false}
+```
+
+DO:
+```json
+[
+  {"text": "Drove ", "bold": false},
+  {"text": "30% conversion lift", "bold": true},
+  {"text": " through 40+ A/B experiments.", "bold": false}
+]
+```
+
+**`version.summary` is a single string** — it cannot carry bold. Write it as flat prose. If you feel a phrase deserves emphasis, lead with it or restructure the sentence; do not wrap it in `**...**`.
+
+Real bug this rule prevents (Perplexity PM Builder, 2026-05-25): subagent emitted `"summary": "...Perplexity, where **Computer** has the strongest enterprise wedge... **40+ A/B experiments, 30% CR lift, $500k/mo** new revenue..."`. The asterisks printed literally in the PDF.
+
 ## What to do if you can't produce a coherent draft
 
 If the master profile is empty / unreadable, or the JD is too thin to extract significant phrases, or your inputs are otherwise malformed, return:

--- a/engine/commands/prepare.js
+++ b/engine/commands/prepare.js
@@ -190,6 +190,13 @@ function jobFromTsv(app) {
   };
 }
 
+// BL-A (2026-05-25): sources excluded from prepare entirely.
+// Rows from these sources are ingested by scan (kept in TSV as a triage
+// pool) but never surface to the SKILL — the format requires a different
+// application flow that lives outside the standard prepare pipeline.
+// A separate command will handle them later.
+const PREPARE_SOURCE_EXCLUDE = new Set(["calcareers"]);
+
 function applyPrepareFilter(apps, rules, activeCounts) {
   const counts = { ...activeCounts };
   const passed = [];
@@ -206,6 +213,19 @@ function applyPrepareFilter(apps, rules, activeCounts) {
   delete rulesNoGeo.geo;
 
   for (const app of apps) {
+    // BL-A: source-level exclude (runs before evaluateJob — sources in
+    // PREPARE_SOURCE_EXCLUDE never enter the SKILL pipeline regardless of
+    // profile config).
+    if (PREPARE_SOURCE_EXCLUDE.has(String(app.source || "").toLowerCase())) {
+      skipped.push({
+        key: app.key,
+        reason: "source_excluded_from_prepare",
+        source: app.source,
+        url: app.url,
+      });
+      continue;
+    }
+
     const evalJob = jobFromTsv(app);
 
     // Pass 1: blocklists + requirelist + cap + location_blocklist

--- a/engine/commands/prepare.test.js
+++ b/engine/commands/prepare.test.js
@@ -105,6 +105,28 @@ test("applyPrepareFilter: passes clean jobs", () => {
   assert.equal(skipped.length, 0);
 });
 
+// BL-A (2026-05-25): `calcareers` source is excluded from prepare entirely —
+// rows reach TSV via scan but never enter the SKILL pipeline. Format requires
+// a different application flow (separate command, future work).
+test("applyPrepareFilter: excludes calcareers source from prepare", () => {
+  const apps = [
+    makeApp({
+      key: "calcareers:518107",
+      source: "calcareers",
+      jobId: "518107",
+      companyName: "High Desert State Prison",
+      title: "Plant Operations Analyst",
+    }),
+    makeApp({ key: "greenhouse:2", companyName: "Stripe", title: "PM" }),
+  ];
+  const { passed, skipped } = applyPrepareFilter(apps, {}, {});
+  assert.equal(passed.length, 1);
+  assert.equal(passed[0].source, "greenhouse");
+  assert.equal(skipped.length, 1);
+  assert.equal(skipped[0].reason, "source_excluded_from_prepare");
+  assert.equal(skipped[0].source, "calcareers");
+});
+
 test("applyPrepareFilter: blocks company_blocklist", () => {
   const apps = [
     makeApp({ companyName: "BadCo", title: "PM" }),

--- a/engine/core/skip_reasons.js
+++ b/engine/core/skip_reasons.js
@@ -52,6 +52,12 @@ const ENGINE_SKIP_REASONS = Object.freeze(
     "geo_title_excluded",
     // URL liveness (checkUrls)
     "url_dead",
+    // BL-A (2026-05-25): sources excluded from prepare engine-wide.
+    // `calcareers` rows reach TSV via scan but are not routed through the
+    // SKILL — the format requires a different application flow (separate
+    // command, future work). Set lives in `PREPARE_SOURCE_EXCLUDE` in
+    // `commands/prepare.js`.
+    "source_excluded_from_prepare",
   ])
 );
 


### PR DESCRIPTION
## Summary

Two small fixes from the 2026-05-25 Perplexity prepare run.

- **BL-A** — `calcareers` source is now excluded from `prepare` engine-wide. Rows still ingest via `scan` (kept as triage pool), but never enter the SKILL pipeline. New skip reason `source_excluded_from_prepare`. CalCareers uses a state-specific SOQ flow that doesn't match the ATS pipeline; future work = separate command.
- **BL-C** — `resume-tailor-mirror` subagent prompt forbids markdown literals inside any string value (`**bold**`, `__bold__`, backticks, links, headings, list markers). Renderer prints text verbatim; bold must use `{text, bold:true}` segmentation. Caught after PM Builder PDF printed `**Computer**` / `**4+ years**` literally.

## Test plan

- [x] `npm test` → 160/160 green (added smoke test `applyPrepareFilter: excludes calcareers source from prepare`)
- [ ] After merge, re-run prepare on Jared: verify calcareers rows land in `prepare_context.skipped[]` with `reason="source_excluded_from_prepare"`, never in `batch[]`
- [ ] After merge, regenerate Perplexity PM Builder resume: verify no markdown literals in `version.summary` / bullet text

🤖 Generated with [Claude Code](https://claude.com/claude-code)