### PR TITLE
BL-D: coverage matrix report on commit

### DIFF
--- a/engine/commands/prepare.js
+++ b/engine/commands/prepare.js
@@ -64,6 +64,7 @@ const {
   renderEscalationReport,
   renderEscalationStdout,
 } = require("../modules/tailor/escalation_report.js");
+const { buildMatrix: buildCoverageMatrix } = require("../core/coverage_matrix.js");
 const { planDedup } = require("../core/tsv_dedup.js");
 const notionSync = require("../core/notion_sync.js");
 const { makeCompanyResolver } = require("../core/company_resolver.js");
@@ -2213,6 +2214,52 @@ async function runCommit(ctx, deps) {
       }
     } else {
       stdout(`(dry-run) would write tailor escalation report (${escalations.length} record(s))`);
+    }
+  }
+
+  // BL-D — coverage matrix report.
+  //
+  // After all tailored rows have been processed, render a phrase × row_key
+  // matrix from the per-row `coverage_table` (carried inside
+  // `tailorEscalationDetail`, written by the resume-tailor-mirror subagent).
+  // The artifact gives the operator a cross-job view: which JD phrases
+  // matched across the batch, and which phrases never matched in any row
+  // (gaps in master_profile relative to this batch's JDs). Skipped when
+  // no tailored row carries a non-empty coverage_table.
+  const coverageRows = [];
+  for (const [rowKey, entry] of tailorPlan) {
+    const detail =
+      entry.row && entry.row.tailorEscalationDetail ? entry.row.tailorEscalationDetail : null;
+    const table = detail && Array.isArray(detail.coverage_table) ? detail.coverage_table : null;
+    if (table && table.length > 0) {
+      coverageRows.push({ row_key: rowKey, coverage_table: table });
+    }
+  }
+  if (coverageRows.length > 0) {
+    // Derive a stable batch timestamp from the results filename
+    // (`prepare_results_<YYYYMMDD_HHMMSS>.json`). Falls back to the same
+    // unix-ts used by the escalation report when the basename doesn't
+    // match the convention.
+    const resultsBase = path.basename(flags.resultsFile || "");
+    const tsMatch = resultsBase.match(/prepare_results_([0-9_]+)\.json$/);
+    const batchTs = tsMatch
+      ? tsMatch[1]
+      : String(Math.floor(new Date(now).getTime() / 1000));
+    const md = buildCoverageMatrix(coverageRows, { batchTs });
+    if (md) {
+      if (!flags.dryRun) {
+        try {
+          const stateDir = path.join(profile.paths.root, ".tailor-state");
+          const matrixPath = path.join(stateDir, `coverage-matrix-${batchTs}.md`);
+          deps.mkdirp(stateDir);
+          deps.writeFile(matrixPath, md);
+          stdout(`coverage matrix: wrote ${matrixPath}`);
+        } catch (err) {
+          stderr(`warn: failed to write coverage matrix report: ${err.message}`);
+        }
+      } else {
+        stdout(`(dry-run) would write coverage matrix (${coverageRows.length} tailored row(s))`);
+      }
     }
   }
 

--- a/engine/core/coverage_matrix.js
+++ b/engine/core/coverage_matrix.js
@@ -1,0 +1,127 @@
+// Coverage matrix renderer (BL-D).
+//
+// Pure helper that takes the tailored rows from a prepare commit batch and
+// returns a markdown report cross-tabulating JD phrases × row_keys. Each
+// cell shows the JD-coverage status (exact / partial / missing / "—" when
+// the phrase didn't appear in that row's JD at all). A "Gaps" section
+// underneath lists phrases that never matched in any row — these surface
+// gaps in master_profile relative to the batch's JDs.
+//
+// Input: `tailoredResults` — array of objects
+//   {
+//     row_key: string,               // applications.tsv key (e.g. "greenhouse:1234")
+//     coverage_table: Array<{
+//       jd_phrase: string,
+//       status: "exact_match" | "partial" | "missing",
+//       category?: string,
+//       priority?: string,
+//       where?: string | null,
+//     }>,
+//   }
+//
+// Output: a markdown string. Empty input → empty string (caller decides
+// whether to write the file).
+
+const STATUS_GLYPH = {
+  exact_match: "✓ exact",
+  partial: "partial",
+  missing: "missing",
+};
+
+function statusCell(status) {
+  if (!status) return "—";
+  return STATUS_GLYPH[status] || status;
+}
+
+function escapeCell(s) {
+  // Pipes break markdown tables; the rest is fine inside a single-line cell.
+  return String(s).replace(/\|/g, "\\|");
+}
+
+/**
+ * Build a phrase × row_key coverage matrix as a markdown string.
+ *
+ * @param {Array<{row_key: string, coverage_table: Array<object>}>} tailoredResults
+ * @param {object} [opts]
+ * @param {string} [opts.batchTs] - optional batch timestamp string for the heading.
+ * @returns {string} markdown, empty string when input has no usable coverage data.
+ */
+function buildMatrix(tailoredResults, opts = {}) {
+  const rows = Array.isArray(tailoredResults) ? tailoredResults : [];
+
+  // Keep rows that actually carry a non-empty coverage_table; ignore the rest
+  // (escalations without detail, malformed shapes, etc).
+  const usable = rows.filter(
+    (r) =>
+      r &&
+      typeof r.row_key === "string" &&
+      Array.isArray(r.coverage_table) &&
+      r.coverage_table.length > 0
+  );
+  if (usable.length === 0) return "";
+
+  // Preserve row_key order as given (caller decides ordering — engine emits
+  // tailorPlan insertion order, which mirrors results[] order).
+  const rowKeys = usable.map((r) => r.row_key);
+
+  // phrase -> { rowKey -> status }. Use Map to preserve first-seen phrase
+  // order across rows, which keeps the report stable across runs given the
+  // same input.
+  const phraseMap = new Map();
+  for (const r of usable) {
+    for (const entry of r.coverage_table) {
+      if (!entry || typeof entry.jd_phrase !== "string") continue;
+      const phrase = entry.jd_phrase;
+      if (!phraseMap.has(phrase)) phraseMap.set(phrase, {});
+      phraseMap.get(phrase)[r.row_key] = entry.status;
+    }
+  }
+
+  const lines = [];
+  const heading = opts.batchTs ? `# Coverage Matrix — batch ${opts.batchTs}` : `# Coverage Matrix`;
+  lines.push(heading);
+  lines.push("");
+
+  // Header row.
+  lines.push(`| JD phrase | ${rowKeys.map(escapeCell).join(" | ")} |`);
+  lines.push(`|${"---|".repeat(rowKeys.length + 1)}`);
+
+  // Body. A cell is "—" when the phrase never appeared in that row's JD
+  // (different JDs share phrase coverage but rarely have the exact same
+  // phrase set). Phrases the row DID see show the matcher's verdict.
+  for (const [phrase, byRow] of phraseMap) {
+    const cells = rowKeys.map((rk) => {
+      if (!(rk in byRow)) return "—";
+      return statusCell(byRow[rk]);
+    });
+    lines.push(`| "${escapeCell(phrase)}" | ${cells.join(" | ")} |`);
+  }
+
+  // Gaps section: phrases where no row matched (every cell is either
+  // "missing" or "—"). The list also shows where the phrase came from so
+  // the operator can decide whether to add a candidate fact to master.
+  const gaps = [];
+  for (const [phrase, byRow] of phraseMap) {
+    const matchedSomewhere = Object.values(byRow).some(
+      (s) => s === "exact_match" || s === "partial"
+    );
+    if (matchedSomewhere) continue;
+    const sources = rowKeys.filter((rk) => byRow[rk] === "missing");
+    gaps.push({ phrase, sources });
+  }
+
+  if (gaps.length > 0) {
+    lines.push("");
+    lines.push("## Gaps (phrases never matched in any row)");
+    lines.push("");
+    for (const g of gaps) {
+      const suffix = g.sources.length > 0 ? ` — ${g.sources.join(", ")} JD only` : "";
+      lines.push(`- "${g.phrase}"${suffix}`);
+    }
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+module.exports = { buildMatrix };

--- a/engine/core/coverage_matrix.test.js
+++ b/engine/core/coverage_matrix.test.js
@@ -1,0 +1,123 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { buildMatrix } = require("./coverage_matrix.js");
+
+test("buildMatrix returns empty string when no tailored results", () => {
+  assert.equal(buildMatrix([]), "");
+  assert.equal(buildMatrix(null), "");
+  assert.equal(buildMatrix(undefined), "");
+  // Rows present but no usable coverage_table → empty.
+  assert.equal(buildMatrix([{ row_key: "a", coverage_table: [] }]), "");
+  assert.equal(buildMatrix([{ row_key: "a" }]), "");
+});
+
+test("buildMatrix renders a single-row matrix with all status glyphs", () => {
+  const md = buildMatrix(
+    [
+      {
+        row_key: "greenhouse:1",
+        coverage_table: [
+          { jd_phrase: "agent workflow", status: "exact_match" },
+          { jd_phrase: "regulated industries", status: "partial" },
+          { jd_phrase: "Capitol Hill", status: "missing" },
+        ],
+      },
+    ],
+    { batchTs: "20260525_120000" }
+  );
+
+  assert.match(md, /# Coverage Matrix — batch 20260525_120000/);
+  assert.match(md, /\| JD phrase \| greenhouse:1 \|/);
+  assert.match(md, /\| "agent workflow" \| ✓ exact \|/);
+  assert.match(md, /\| "regulated industries" \| partial \|/);
+  // "Capitol Hill" is missing in the only row → goes into Gaps.
+  assert.match(md, /## Gaps \(phrases never matched in any row\)/);
+  assert.match(md, /- "Capitol Hill" — greenhouse:1 JD only/);
+});
+
+test("buildMatrix unions phrases across rows and fills '—' for absent phrases", () => {
+  const md = buildMatrix([
+    {
+      row_key: "greenhouse:1",
+      coverage_table: [
+        { jd_phrase: "agent workflow", status: "exact_match" },
+        { jd_phrase: "open finance", status: "partial" },
+      ],
+    },
+    {
+      row_key: "lever:99",
+      coverage_table: [
+        { jd_phrase: "agent workflow", status: "exact_match" },
+        { jd_phrase: "developer network", status: "exact_match" },
+      ],
+    },
+  ]);
+
+  // Three columns in header (JD phrase + 2 row_keys).
+  assert.match(md, /\| JD phrase \| greenhouse:1 \| lever:99 \|/);
+  // "open finance" appears only in row 1, so row 2 cell is "—".
+  assert.match(md, /\| "open finance" \| partial \| — \|/);
+  // "developer network" appears only in row 2, so row 1 cell is "—".
+  assert.match(md, /\| "developer network" \| — \| ✓ exact \|/);
+  // "agent workflow" appears in both.
+  assert.match(md, /\| "agent workflow" \| ✓ exact \| ✓ exact \|/);
+  // No phrase was missing-everywhere → no Gaps section.
+  assert.equal(md.includes("## Gaps"), false);
+});
+
+test("buildMatrix Gaps section lists phrases never matched anywhere", () => {
+  const md = buildMatrix([
+    {
+      row_key: "greenhouse:1",
+      coverage_table: [
+        { jd_phrase: "ML platform", status: "exact_match" },
+        { jd_phrase: "U.S. federal court", status: "missing" },
+      ],
+    },
+    {
+      row_key: "lever:99",
+      coverage_table: [
+        { jd_phrase: "ML platform", status: "partial" },
+        { jd_phrase: "policy work", status: "missing" },
+      ],
+    },
+  ]);
+
+  assert.match(md, /## Gaps \(phrases never matched in any row\)/);
+  // "U.S. federal court" only seen by row 1 — gap, attributed.
+  assert.match(md, /- "U\.S\. federal court" — greenhouse:1 JD only/);
+  // "policy work" only seen by row 2 — gap, attributed.
+  assert.match(md, /- "policy work" — lever:99 JD only/);
+  // "ML platform" matched somewhere (partial counts) → NOT in gaps.
+  assert.equal(md.includes('"ML platform"' + " — "), false);
+});
+
+test("buildMatrix ignores malformed coverage_table entries", () => {
+  const md = buildMatrix([
+    {
+      row_key: "greenhouse:1",
+      coverage_table: [
+        { jd_phrase: "valid", status: "exact_match" },
+        { jd_phrase: 42, status: "exact_match" }, // non-string phrase → dropped
+        null, // null entry → dropped
+        { status: "missing" }, // missing jd_phrase → dropped
+      ],
+    },
+  ]);
+  // Only the "valid" row should appear; output is a one-row table.
+  assert.match(md, /\| "valid" \| ✓ exact \|/);
+  assert.equal(md.includes("42"), false);
+});
+
+test("buildMatrix escapes pipe characters in phrases and row keys", () => {
+  const md = buildMatrix([
+    {
+      row_key: "greenhouse:weird|key",
+      coverage_table: [{ jd_phrase: "a|b phrase", status: "exact_match" }],
+    },
+  ]);
+  // Pipes escaped to keep the table well-formed.
+  assert.match(md, /greenhouse:weird\\\|key/);
+  assert.match(md, /"a\\\|b phrase"/);
+});

--- a/skills/job-pipeline/SKILL.md
+++ b/skills/job-pipeline/SKILL.md
@@ -437,7 +437,7 @@ Per-row schema (`results[]` entry):
   - `tailorCoverage: number | null` — final coverage score, 0-100.
   - `tailorEscalated: boolean` — true when the loop exited without auto-ship (see escalation decision in Step 6.5).
   - `tailorEscalationReason: "no_growth_below_threshold" | "iteration_cap_below_threshold" | "uncertain_about_fact" | null`.
-  - `tailorEscalationDetail: object | null` — `{ iterations, uncertain_facts, coverage_table }` capturing the loop's final state for operator review in Notion.
+  - `tailorEscalationDetail: object | null` — `{ iterations, uncertain_facts, coverage_table }` capturing the loop's final state for operator review in Notion. Engine's commit phase (BL-D) also consumes `coverage_table` to render a cross-job coverage matrix at `profiles/<id>/.tailor-state/coverage-matrix-<batchTs>.md`; keep the array intact (per-entry shape `{jd_phrase, status, ...}` from the subagent).
   - For Weak / Medium rows these five fields are **absent or `null`** — the engine falls back to the archetype-pick path (`resumeVer`).
 
 Do **not** emit `decision` or `skipReason` — engines built against RFC 034 ignore the field with a warning; older engines may misroute the row. Do **not** include `clPath` (engine derives it) or `notionPageId` (engine creates the page itself).


### PR DESCRIPTION
## Summary
- After `prepare --phase commit`, writes a per-batch markdown coverage matrix to `profiles/<id>/.tailor-state/coverage-matrix-<batchTs>.md`
- Surfaces `coverage_table[]` data that subagents already return but engine previously discarded
- New pure helper `engine/core/coverage_matrix.js` (`buildMatrix`) — cross-tab JD phrases × row_keys with exact/partial/— cells + Gaps section
- 4 unit tests, SKILL.md Step 10 updated
- All 1793 tests green

Closes BL-D.

## Test plan
- [x] npm test → 1793/1793 green in worktree
- [ ] Manual: next prepare run writes coverage-matrix-*.md with non-empty content

🤖 Generated with [Claude Code](https://claude.com/claude-code)