### PR TITLE
feat(prepare): BL-F — role slug in tailored CV filename

### DIFF
--- a/engine/commands/prepare.js
+++ b/engine/commands/prepare.js
@@ -54,6 +54,7 @@ const { evaluateJob } = require("../core/evaluate_job.js");
 const { defaultFetch } = require("../modules/discovery/_http.js");
 const { resolveProfilesDir } = require("../core/paths.js");
 const { slugifyCompany } = require("../core/company_slug.js");
+const { slugifyRole } = require("../core/role_slug.js");
 const { pickClBase } = require("../core/cl_base_matcher.js");
 const { generateCoverLetterPdf } = require("../modules/generators/cover_letter_pdf.js");
 const { generateResumeDocx } = require("../modules/generators/resume_docx.js");
@@ -743,6 +744,7 @@ function makeDefaultDeps() {
     generateResumeDocx,
     generateResumePdf,
     slugifyCompany,
+    slugifyRole,
     // RFC 022: per-row Notion push in commit phase. All Notion deps are
     // injectable so unit / integration tests can swap in a mock client +
     // resolver without hitting the network.
@@ -1846,14 +1848,16 @@ async function runCommit(ctx, deps) {
   // by the loop above — i.e. the SKILL's resumeVer if it sent one).
   // Other rows in the batch continue.
   const dateStr = String(now).slice(0, 10);
+  const dateStamp = dateStr.replace(/-/g, ""); // YYYYMMDD for BL-F filename format
   const tailoredStats = { generated: 0, failed: 0, dryRun: 0 };
   for (const [rowKey, entry] of tailorPlan) {
     if (entry.classification !== "tailored") continue;
     const app = byKey[rowKey];
     if (!app) continue; // defensive — applyFitFields earlier would have warned
     const slug = deps.slugifyCompany(app.companyName);
-    const docxRel = tailoredResumePath(profileId, slug, dateStr);
-    const pdfRel = tailoredResumePathPdf(profileId, slug, dateStr);
+    const roleSlug = deps.slugifyRole(app.title);
+    const docxRel = tailoredResumePath(profileId, slug, roleSlug, dateStamp);
+    const pdfRel = tailoredResumePathPdf(profileId, slug, roleSlug, dateStamp);
     const docxAbs = path.join(profile.paths.root, docxRel);
     const pdfAbs = path.join(profile.paths.root, pdfRel);
 

--- a/engine/commands/prepare.test.js
+++ b/engine/commands/prepare.test.js
@@ -4216,18 +4216,18 @@ test("prepare --phase commit (BL-123): tailored row generates DOCX and pushes wi
   assert.ok(docxCalled, "generateResumeDocx must be called");
   assert.deepEqual(docxCalled.data, tailoredResume);
   // company_slug.js preserves case ("Stripe" not "stripe").
-  assert.match(docxCalled.outPath, /resumes\/tailored\/Stripe-2026-04-20\.docx$/);
+  assert.match(docxCalled.outPath, /resumes\/tailored\/Stripe_senior-product-manager_20260420\.docx$/);
 
   // BL-126 Block A: resume_ver on the TSV row is the tailored PDF path
   // (DOCX stays as side artifact). Notion's resumeVersion also picks up
   // the PDF via r.resumeVer mutation.
   const saved = deps._getSaved();
-  assert.equal(saved[0].resume_ver, "resumes/tailored/Stripe-2026-04-20.pdf");
+  assert.equal(saved[0].resume_ver, "resumes/tailored/Stripe_senior-product-manager_20260420.pdf");
   assert.equal(saved[0].status, "To Apply");
 
   // Notion push received the PDF path as resumeVersion.
   assert.equal(pushCalls.length, 1);
-  assert.equal(pushCalls[0].resumeVersion, "resumes/tailored/Stripe-2026-04-20.pdf");
+  assert.equal(pushCalls[0].resumeVersion, "resumes/tailored/Stripe_senior-product-manager_20260420.pdf");
 
   // stdout reports tailored count.
   assert.ok(ctx._lines.some((l) => /tailored resumes:.*1 generated/.test(l)));
@@ -4280,12 +4280,12 @@ test("prepare --phase commit (BL-126 Block A): tailored row emits PDF + DOCX, re
   assert.ok(docxCalled, "DOCX generator must be called");
   assert.ok(pdfCalled, "PDF generator must be called");
   assert.deepEqual(pdfCalled.data, tailoredResume);
-  assert.match(docxCalled.outPath, /resumes\/tailored\/Stripe-2026-04-20\.docx$/);
-  assert.match(pdfCalled.outPath, /resumes\/tailored\/Stripe-2026-04-20\.pdf$/);
+  assert.match(docxCalled.outPath, /resumes\/tailored\/Stripe_senior-product-manager_20260420\.docx$/);
+  assert.match(pdfCalled.outPath, /resumes\/tailored\/Stripe_senior-product-manager_20260420\.pdf$/);
 
   // resume_ver written to TSV is the PDF path (not DOCX, not archetype).
   const saved = deps._getSaved();
-  assert.equal(saved[0].resume_ver, "resumes/tailored/Stripe-2026-04-20.pdf");
+  assert.equal(saved[0].resume_ver, "resumes/tailored/Stripe_senior-product-manager_20260420.pdf");
 
   // Page-overflow warning fired with compression hints.
   assert.ok(
@@ -4359,7 +4359,7 @@ test("prepare --phase commit (BL-126 Block A): unknown pageCount (legacy rendere
   assert.ok(!ctx._errLines.some((l) => /tailored PDF for.*pages/.test(l)));
   // resume_ver still set to PDF path even when renderer returns undefined.
   const saved = deps._getSaved();
-  assert.equal(saved[0].resume_ver, "resumes/tailored/Stripe-2026-04-20.pdf");
+  assert.equal(saved[0].resume_ver, "resumes/tailored/Stripe_senior-product-manager_20260420.pdf");
 });
 
 test("prepare --phase commit (BL-123): escalated row stays Inbox, writes MD report, no Notion push", async () => {

--- a/engine/core/role_slug.js
+++ b/engine/core/role_slug.js
@@ -1,0 +1,29 @@
+// engine/core/role_slug.js
+//
+// Pure helper for normalizing a job-role title into a filename-safe slug.
+// Used by `engine/modules/tailor/dispatcher.js` when computing per-row
+// tailored resume paths so that multiple roles at the same company on the
+// same day don't collide (BL-F).
+//
+// Shape: lowercase, non-alphanumeric → "-", strip leading/trailing dashes,
+// slice to `maxLen` (default 40). Empty / null / non-string input falls back
+// to the literal string "role" so callers always get a usable segment.
+//
+// Symmetry with the cover-letter `clKey` convention
+// (`<Company>_<role-slug>_<YYYYMMDD>`) is intentional — the resume PDF for
+// a given row mirrors its CL filename pattern.
+
+function slugifyRole(title, maxLen = 40) {
+  if (typeof maxLen !== "number" || !Number.isFinite(maxLen) || maxLen <= 0) {
+    maxLen = 40;
+  }
+  const raw = String(title == null ? "" : title)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, maxLen)
+    .replace(/-+$/g, ""); // re-trim if slice landed mid-separator
+  return raw || "role";
+}
+
+module.exports = { slugifyRole };

--- a/engine/core/role_slug.test.js
+++ b/engine/core/role_slug.test.js
@@ -1,0 +1,43 @@
+// engine/core/role_slug.test.js — BL-F
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { slugifyRole } = require("./role_slug.js");
+
+test("slugifyRole: simple title → lowercase dash-joined", () => {
+  assert.equal(slugifyRole("Product Manager"), "product-manager");
+});
+
+test("slugifyRole: punctuation and parentheses collapsed to dashes", () => {
+  assert.equal(slugifyRole("Product Manager (Builder)"), "product-manager-builder");
+  assert.equal(
+    slugifyRole("Senior PM, Ads & Measurement"),
+    "senior-pm-ads-measurement"
+  );
+});
+
+test("slugifyRole: caps to default maxLen=40 and re-trims trailing dash", () => {
+  const long =
+    "Member of Technical Staff (Forward Deployed Engineer, Applied AI)";
+  const out = slugifyRole(long);
+  assert.ok(out.length <= 40, `length=${out.length}: ${out}`);
+  assert.ok(!out.endsWith("-"), `ends with dash: ${out}`);
+  // First segment preserved
+  assert.ok(out.startsWith("member-of-technical-staff"));
+});
+
+test("slugifyRole: empty / null / undefined → 'role' fallback", () => {
+  assert.equal(slugifyRole(""), "role");
+  assert.equal(slugifyRole(null), "role");
+  assert.equal(slugifyRole(undefined), "role");
+  assert.equal(slugifyRole("   "), "role");
+});
+
+test("slugifyRole: custom maxLen respected, never returns empty", () => {
+  assert.equal(slugifyRole("Product Manager", 7), "product");
+  // Edge case: tiny cap that lands on a dash — still trim, still non-empty
+  assert.equal(slugifyRole("AB CD", 3), "ab");
+  // Invalid maxLen falls back to default 40
+  assert.equal(slugifyRole("Product Manager", 0), "product-manager");
+  assert.equal(slugifyRole("Product Manager", -5), "product-manager");
+});

--- a/engine/modules/tailor/dispatcher.js
+++ b/engine/modules/tailor/dispatcher.js
@@ -122,19 +122,29 @@ function buildEscalationRecord(row) {
  * profile root). Returned as a forward-slash POSIX path so it matches
  * the convention used by `applications.tsv` (e.g. `cl_path`).
  *
- *   resumes/tailored/<slug>-<YYYY-MM-DD>.docx
+ *   resumes/tailored/<companySlug>_<roleSlug>_<YYYYMMDD>.docx
  *
- * @param {string} profileId — unused in the path itself but kept in the
+ * BL-F: the filename includes the role slug so multiple Strong rows at
+ * the same company on the same day don't overwrite each other. Underscore
+ * separators + compact YYYYMMDD mirror the `clKey` convention used by
+ * cover-letter files (e.g. `Perplexity_pm-builder_20260525`).
+ *
+ * @param {string} profileId   — unused in the path itself but kept in the
  *   signature so callers can swap to an absolute-path variant later
  *   without touching call sites.
- * @param {string} slug      — company slug (caller computes via slugifyCompany)
- * @param {string} date      — YYYY-MM-DD string (caller computes from `now`)
+ * @param {string} companySlug — company slug (caller computes via slugifyCompany)
+ * @param {string} roleSlug    — role slug (caller computes via slugifyRole)
+ * @param {string} dateStamp   — YYYYMMDD string, no separators
  * @returns {string} relative POSIX path
  */
-function tailoredResumePath(profileId, slug, date) {
+function tailoredResumePath(profileId, companySlug, roleSlug, dateStamp) {
   // path.posix.join keeps the separator stable across macOS / Linux /
   // (hypothetical) Windows callers; tsv consumers split on "/".
-  return path.posix.join("resumes", "tailored", `${slug}-${date}.docx`);
+  return path.posix.join(
+    "resumes",
+    "tailored",
+    `${companySlug}_${roleSlug}_${dateStamp}.docx`
+  );
 }
 
 /**
@@ -144,15 +154,20 @@ function tailoredResumePath(profileId, slug, date) {
  * becomes the canonical `resume_ver` (TSV / Notion) — recruiters expect
  * PDF; DOCX stays as a side artifact for archive / re-edit.
  *
- *   resumes/tailored/<slug>-<YYYY-MM-DD>.pdf
+ *   resumes/tailored/<companySlug>_<roleSlug>_<YYYYMMDD>.pdf
  *
- * @param {string} profileId — unused in the path itself (parity with DOCX helper)
- * @param {string} slug      — company slug (caller computes via slugifyCompany)
- * @param {string} date      — YYYY-MM-DD string (caller computes from `now`)
+ * @param {string} profileId   — unused in the path itself (parity with DOCX helper)
+ * @param {string} companySlug — company slug (caller computes via slugifyCompany)
+ * @param {string} roleSlug    — role slug (caller computes via slugifyRole)
+ * @param {string} dateStamp   — YYYYMMDD string, no separators
  * @returns {string} relative POSIX path
  */
-function tailoredResumePathPdf(profileId, slug, date) {
-  return path.posix.join("resumes", "tailored", `${slug}-${date}.pdf`);
+function tailoredResumePathPdf(profileId, companySlug, roleSlug, dateStamp) {
+  return path.posix.join(
+    "resumes",
+    "tailored",
+    `${companySlug}_${roleSlug}_${dateStamp}.pdf`
+  );
 }
 
 module.exports = {

--- a/engine/modules/tailor/dispatcher.test.js
+++ b/engine/modules/tailor/dispatcher.test.js
@@ -142,34 +142,36 @@ test("buildEscalationRecord: explicit missing_high_priority wins over last iter"
 
 // --- tailoredResumePath ------------------------------------------------------
 
-test("tailoredResumePath: formats relative POSIX path with slug + date", () => {
-  const p = tailoredResumePath("jared", "stripe", "2026-05-24");
-  assert.equal(p, "resumes/tailored/stripe-2026-05-24.docx");
+test("tailoredResumePath: formats relative POSIX path with company + role + YYYYMMDD", () => {
+  // BL-F: filename is `<companySlug>_<roleSlug>_<YYYYMMDD>` so multiple Strong
+  // rows at the same company on the same day don't collide.
+  const p = tailoredResumePath("jared", "stripe", "senior-pm-ads", "20260524");
+  assert.equal(p, "resumes/tailored/stripe_senior-pm-ads_20260524.docx");
 });
 
 test("tailoredResumePath: profile id does not leak into the path", () => {
   // Path is relative to profile root, so profileId is intentionally unused
   // in the output. This guards against an accidental change to embed it.
-  const p = tailoredResumePath("anyone", "acme-inc", "2026-01-01");
-  assert.equal(p, "resumes/tailored/acme-inc-2026-01-01.docx");
+  const p = tailoredResumePath("anyone", "acme-inc", "product-manager", "20260101");
+  assert.equal(p, "resumes/tailored/acme-inc_product-manager_20260101.docx");
 });
 
 // --- tailoredResumePathPdf (BL-126 Block A) ---------------------------------
 
 test("tailoredResumePathPdf: formats relative POSIX path with .pdf extension", () => {
-  const p = tailoredResumePathPdf("jared", "stripe", "2026-05-24");
-  assert.equal(p, "resumes/tailored/stripe-2026-05-24.pdf");
+  const p = tailoredResumePathPdf("jared", "stripe", "senior-pm-ads", "20260524");
+  assert.equal(p, "resumes/tailored/stripe_senior-pm-ads_20260524.pdf");
 });
 
 test("tailoredResumePathPdf: mirrors DOCX path under the same directory", () => {
   // The PDF and DOCX must land side-by-side so a regen / archive sweep
   // doesn't have to know about two output trees.
-  const docx = tailoredResumePath("jared", "acme-inc", "2026-01-01");
-  const pdf = tailoredResumePathPdf("jared", "acme-inc", "2026-01-01");
+  const docx = tailoredResumePath("jared", "acme-inc", "product-manager", "20260101");
+  const pdf = tailoredResumePathPdf("jared", "acme-inc", "product-manager", "20260101");
   assert.equal(docx.replace(/\.docx$/, ".pdf"), pdf);
 });
 
 test("tailoredResumePathPdf: profile id does not leak into the path", () => {
-  const p = tailoredResumePathPdf("anyone", "brex", "2026-01-01");
-  assert.equal(p, "resumes/tailored/brex-2026-01-01.pdf");
+  const p = tailoredResumePathPdf("anyone", "brex", "head-of-product", "20260101");
+  assert.equal(p, "resumes/tailored/brex_head-of-product_20260101.pdf");
 });


### PR DESCRIPTION
## Summary
- New filename format: `<companySlug>_<roleSlug>_<YYYYMMDD>.{pdf,docx}` (mirrors `clKey`).
- Fixes collision when multiple Strong roles at same company on same day overwrite each other.
- New helper `engine/core/role_slug.js` (`slugifyRole`).

## Test plan
- [x] `npm test` 1809/1809 green.
- [ ] On next prepare run: Perplexity PM Builder writes `Perplexity_product-manager-builder_<ts>.pdf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)