### PR TITLE
feat(prepare): BL-G — canonicalize tailored CV contact from profile.identity

### DIFF
--- a/engine/commands/prepare.js
+++ b/engine/commands/prepare.js
@@ -1850,10 +1850,35 @@ async function runCommit(ctx, deps) {
   const dateStr = String(now).slice(0, 10);
   const dateStamp = dateStr.replace(/-/g, ""); // YYYYMMDD for BL-F filename format
   const tailoredStats = { generated: 0, failed: 0, dryRun: 0 };
+  // BL-G: contact is single-sourced from profile.identity at render time.
+  // The resume-tailor-mirror subagent has been observed silently mangling
+  // contact fields (phone digit groups dropped, name casing changed). Even
+  // if the SKILL prompt forbids it, the renderer must not trust the
+  // subagent for identity. Built lazily on first tailored row so commit
+  // runs with no Strong rows don't require `profile.identity` to be present
+  // (validator enforces it in production, but tests skip it freely).
+  let canonicalContact = null;
   for (const [rowKey, entry] of tailorPlan) {
     if (entry.classification !== "tailored") continue;
     const app = byKey[rowKey];
     if (!app) continue; // defensive — applyFitFields earlier would have warned
+    if (canonicalContact === null) {
+      const ident = profile.identity || {};
+      canonicalContact = {
+        name: ident.name,
+        phone: ident.phone,
+        email: ident.email,
+        location: ident.location,
+        linkedin: ident.linkedin,
+      };
+    }
+    // BL-G: force the canonical contact onto the resume data before
+    // either generator sees it. We mutate `entry.row.tailoredResume`
+    // so any downstream consumer (e.g. retro-tailor archive) also sees
+    // the corrected contact, not just the rendered file.
+    if (entry.row && entry.row.tailoredResume) {
+      entry.row.tailoredResume.contact = { ...canonicalContact };
+    }
     const slug = deps.slugifyCompany(app.companyName);
     const roleSlug = deps.slugifyRole(app.title);
     const docxRel = tailoredResumePath(profileId, slug, roleSlug, dateStamp);

--- a/engine/commands/prepare.test.js
+++ b/engine/commands/prepare.test.js
@@ -1076,6 +1076,16 @@ function makeCommitDeps(apps, overrides = {}) {
     id: "testuser",
     filterRules: {},
     company_tiers: {},
+    // BL-G: canonical contact for tailored-resume render override. Validator
+    // guarantees this block is populated in production; default it here so
+    // commit-phase tests don't crash on `profile.identity.name`.
+    identity: {
+      name: "JARED MOORE",
+      phone: "+1 (916) 261-261-9",
+      email: "ymuromcev@gmail.com",
+      location: "Sacramento, CA",
+      linkedin: "linkedin.com/in/ymuromcev",
+    },
     // RFC 022: runCommit needs jobs_pipeline_db_id + companies_db_id to push.
     // Tests that don't care about Notion still get the happy-path mocks below,
     // so to_apply rows survive the push pass and tests assert post-push state.
@@ -4214,7 +4224,11 @@ test("prepare --phase commit (BL-123): tailored row generates DOCX and pushes wi
 
   // DOCX was generated from the tailored data, written under resumes/tailored/.
   assert.ok(docxCalled, "generateResumeDocx must be called");
-  assert.deepEqual(docxCalled.data, tailoredResume);
+  // BL-G: contact is overridden from profile.identity at render time so we
+  // assert the non-contact payload survives + the contact is canonical.
+  assert.deepEqual(docxCalled.data.version, tailoredResume.version);
+  assert.equal(docxCalled.data.contact.phone, "+1 (916) 261-261-9");
+  assert.equal(docxCalled.data.contact.email, "ymuromcev@gmail.com");
   // company_slug.js preserves case ("Stripe" not "stripe").
   assert.match(docxCalled.outPath, /resumes\/tailored\/Stripe_senior-product-manager_20260420\.docx$/);
 
@@ -4231,6 +4245,76 @@ test("prepare --phase commit (BL-123): tailored row generates DOCX and pushes wi
 
   // stdout reports tailored count.
   assert.ok(ctx._lines.some((l) => /tailored resumes:.*1 generated/.test(l)));
+});
+
+// --- BL-G: contact override from profile.identity ---------------------------
+//
+// The resume-tailor-mirror subagent has been observed silently mangling
+// contact fields (e.g. phone digit groups dropped, name casing changed).
+// The renderer must NEVER trust the subagent for identity — contact is
+// single-sourced from profile.identity at render time.
+
+test("prepare --phase commit (BL-G): mangled subagent contact is overridden by profile.identity", async () => {
+  const apps = [makeApp({ key: "gh:1", status: "Inbox" })];
+  // Simulate the bug: subagent emitted a phone with the middle group dropped,
+  // wrong name casing, and a junk linkedin. All five contact fields should
+  // come back as profile.identity values.
+  const tailoredResume = {
+    contact: {
+      name: "jared moore",
+      phone: "+1 (916) 261-9",
+      email: "wrong@example.com",
+      location: "Mountain View, CA",
+      linkedin: "linkedin.com/in/wrong",
+    },
+    version: { summary: "tailored summary" },
+  };
+  const results = {
+    profileId: "testuser",
+    results: [
+      {
+        key: "gh:1",
+        fitScore: "Strong",
+        clKey: "stripe_pm_20260420",
+        clParagraphs: ["Hi.", "Bye."],
+        tailoredResume,
+        tailorEscalated: false,
+      },
+    ],
+  };
+  let docxData = null;
+  let pdfData = null;
+  const deps = makeCommitDeps(apps, {
+    readFile: () => JSON.stringify(results),
+    generateResumeDocx: async (data) => {
+      docxData = data;
+    },
+    generateResumePdf: async (data) => {
+      pdfData = data;
+      return { pageCount: 1 };
+    },
+    generateCoverLetterPdf: async () => {},
+    fileExists: () => false,
+    mkdirp: () => {},
+    writeFile: () => {},
+  });
+  const cmd = makePrepareCommand(deps);
+  const ctx = makeCtx({ flags: { phase: "commit", resultsFile: "/r.json" } });
+  await cmd(ctx);
+
+  // Both renderers received canonical contact from profile.identity, not
+  // the subagent's mangled values.
+  const expected = {
+    name: "JARED MOORE",
+    phone: "+1 (916) 261-261-9",
+    email: "ymuromcev@gmail.com",
+    location: "Sacramento, CA",
+    linkedin: "linkedin.com/in/ymuromcev",
+  };
+  assert.deepEqual(docxData.contact, expected);
+  assert.deepEqual(pdfData.contact, expected);
+  // Non-contact payload preserved.
+  assert.equal(docxData.version.summary, "tailored summary");
 });
 
 // --- BL-126 Block A: PDF emit + page-overflow warning -----------------------
@@ -4279,7 +4363,9 @@ test("prepare --phase commit (BL-126 Block A): tailored row emits PDF + DOCX, re
   // Both generators called with same tailoredResume.
   assert.ok(docxCalled, "DOCX generator must be called");
   assert.ok(pdfCalled, "PDF generator must be called");
-  assert.deepEqual(pdfCalled.data, tailoredResume);
+  // BL-G: contact is canonicalized from profile.identity; rest of payload identical.
+  assert.deepEqual(pdfCalled.data.version, tailoredResume.version);
+  assert.equal(pdfCalled.data.contact.phone, "+1 (916) 261-261-9");
   assert.match(docxCalled.outPath, /resumes\/tailored\/Stripe_senior-product-manager_20260420\.docx$/);
   assert.match(pdfCalled.outPath, /resumes\/tailored\/Stripe_senior-product-manager_20260420\.pdf$/);
 


### PR DESCRIPTION
## Summary
- Override `tailoredResume.contact` from `profile.identity` at render time so subagent contact-mangling (mangled phone digit groups, wrong name casing, junk linkedin) can't reach the PDF/DOCX.
- Built lazily on first tailored row — commit phases without Strong rows still work.
- 1 new unit test + 2 existing tests updated to assert canonical contact, regardless of subagent input.

## Why
On 2026-05-26 batch, 4 of 5 tailored CVs went out with `+1 (916) 261-9` (canonical phone is `+1 (916) 261-261-9` — middle `261` dropped). Root cause: `resume-tailor-mirror` subagent (RFC 044) was rewriting `contact` from its own interpretation. Even with a stricter subagent prompt (tracked in BL-E), the engine must not trust the subagent for identity. This PR makes that contract enforceable in code.

## Test plan
- [x] `npm test` → 1834/1834
- [x] New BL-G case: subagent emits mangled phone + wrong name casing + junk linkedin → DOCX and PDF receive canonical `profile.identity` values
- [ ] Next `prepare --phase commit` for a Strong row writes correct phone in PDF (will verify in next prepare run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)