### PR TITLE
feat(install): BL-137 / RFC 048 — npx bootstrap that wires skills into Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,52 @@ Set expectations explicitly:
 
 ## Quick start
 
+You don't need to clone the repo by hand. Open [Claude Code](https://claude.com/claude-code)
+(desktop app, **Code** tab), point it at any folder, and in the chat
+type one line:
+
+```
+install job-searcher from https://github.com/ymuromcev/ai-job-searcher
+```
+
+Claude will run `npx -y github:ymuromcev/ai-job-searcher install` for
+you. The installer clones the tool into `~/.ai-job-searcher/`, installs
+dependencies, runs the smoke tests, and wires three skills
+(`onboard-profile`, `job-pipeline`, `interview-coach`) into your
+`~/.claude/skills/` directory.
+
+**Then close Claude Code and open it again** — Claude Code reads its
+skills at session start, so a restart is required. After restart, in
+any Claude Code chat:
+
+```
+/onboard-profile me
+```
+
+The [`onboard-profile`](skills/onboard-profile/SKILL.md) skill walks
+you through six question blocks (identity, career + filters, resumes,
+cover-letter voice, Notion, job sources), writes
+`~/.ai-job-searcher/profiles/me/intake.md` as you answer, then
+provisions your `profile.json`, generates filter rules and resume
+archetypes, and creates two Notion databases — all in a single
+conversation. End-to-end ~15 minutes for most people. The skill never
+asks you to paste a token in chat — it points you at the `.env` file
+and only verifies the variable name is present.
+
+To **update** later (after a `git push` from this repo), run the same
+install command again — it does `git pull` instead of clone, and your
+profiles + tokens are untouched.
+
+### Requirements
+
+- macOS or Linux (Windows is not supported).
+- Node 20+ (the installer checks and fails with a clear message if not).
+- [Claude Code](https://claude.com/claude-code) (any recent version).
+
+### For developers
+
+If you are forking the engine or contributing code, the manual path is:
+
 ```bash
 git clone https://github.com/ymuromcev/ai-job-searcher.git
 cd ai-job-searcher
@@ -126,35 +172,16 @@ npm run setup-hooks          # installs the PII pre-commit guard
 npm test                     # ~1000 tests, no network required
 ```
 
-That sets up the engine. To actually run a job search you need a
-profile. Onboarding is a conversation with Claude:
+Note that this clones into the cwd, **not** into `~/.ai-job-searcher/`,
+so Claude Code skills will not be wired up. Run `node scripts/install.js`
+from inside the clone (or `npx -y github:ymuromcev/ai-job-searcher install`)
+to wire the skills.
 
-```bash
-claude
-# in the Claude chat:
-> /onboard-profile me
-```
-
-The [`onboard-profile`](skills/onboard-profile/SKILL.md) skill walks
-you through six question blocks (identity, career + filters, resumes,
-cover-letter voice, Notion, job sources), writes `profiles/me/intake.md`
-as you answer, then provisions your `profile.json`, generates filter
-rules and resume archetypes, and creates two Notion databases — all
-in a single conversation. End-to-end ~15 minutes for most people.
-
-The skill never asks you to paste a token in chat — it points you at
-the `.env` file and only verifies the variable name is present.
-
-### Scripted onboarding (no Claude)
-
-If you don't want to use Claude for the onboarding step — for example,
-you're scripting CI fixtures or testing the wizard end-to-end — see
-[scripts/stage18/README.md](scripts/stage18/README.md). The intake
-template lives at
-[`profiles/_example/intake.template.md`](profiles/_example/intake.template.md);
-you fill it in by hand and run `parse_intake.js` + `deploy_profile.js`
-yourself. Day-to-day pipeline use still requires Claude (the
-`prepare` step is AI-driven), so most users should prefer the skill.
+For scripted CI onboarding without a Claude session, see
+[scripts/stage18/README.md](scripts/stage18/README.md) — fill
+[`profiles/_example/intake.template.md`](profiles/_example/intake.template.md)
+by hand and run `parse_intake.js` + `deploy_profile.js`. Day-to-day
+pipeline use still requires Claude (the `prepare` step is AI-driven).
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Multi-profile job search pipeline: one engine, multiple candidates.",
   "type": "commonjs",
   "main": "engine/cli.js",
+  "bin": {
+    "ai-job-searcher": "scripts/install.js"
+  },
   "scripts": {
     "test": "node --test 'engine/**/*.test.js' 'skills/**/*.test.js' 'scripts/**/*.test.js'",
     "lint": "eslint .",

--- a/rfc/048-install-bootstrap.md
+++ b/rfc/048-install-bootstrap.md
@@ -1,0 +1,237 @@
+# RFC 048 — Install bootstrap: `npx` one-liner that wires skills into Claude Code
+
+**Status**: accepted
+**Related**: [BL-137](../private/backlog/BL-137.md), [BL-4](../private/backlog/BL-4-onboarding-ux-rewrite-fidbek-davida.md), [RFC 023](023-onboarding-skill-driven.md)
+**Created**: 2026-05-27
+**Accepted**: 2026-05-27 — user approved D1/D2/D3 as written.
+
+## Problem
+
+RFC 023 made `/onboard-profile` an AI-driven skill, on the assumption
+that getting the skill into the user's Claude Code is a solved problem.
+It is not. Live smoke 2026-05-27: David Shekunts ran the README's
+"Quick start" verbatim (`git clone → npm install → claude →
+/onboard-profile me`) and got `Unknown command: /onboard-profile`. He
+then tried the alternative ("open Claude Code, say install skill from
+URL"). Claude (Sonnet 4.6) cloned the repo, ran tests, reported "skill
+installed" — but `/onboard-profile me` still returned `Unknown command`.
+Claude Code restart did not help.
+
+Three structural reasons, none of which were addressed by RFC 023:
+
+1. **Skills live in the wrong place for Claude Code to discover them.**
+   The repo ships skills under `skills/<name>/SKILL.md`. Claude Code
+   only reads `~/.claude/skills/<name>/`, `~/.claude/plugins/<name>/`,
+   and `<cwd>/.claude/skills/<name>/`. Cloning the repo into a random
+   folder puts the SKILL.md nowhere Claude Code looks.
+2. **`.gitignore` excludes `.claude/*` (except `.claude/agents/`).**
+   So we could not just move skills to `.claude/skills/` and have them
+   ship with the repo — git would not track them.
+3. **Even when a Claude session "installs" the repo, it does not
+   reliably copy SKILL.md to the right location.** The model guesses.
+   David's smoke shows the guess fails.
+
+This RFC fixes installation, not the skill itself. Skill content from
+RFC 023 stands.
+
+## Goals
+
+- A non-technical user (PM, designer — not just developers) can start
+  using the tool from a single sentence said to Claude Code, with no
+  manual file moves, no copy-paste of paths, no understanding of
+  `~/.claude/`.
+- Updating the tool (`git pull` equivalent) does not require re-running
+  any manual steps. The next Claude Code session picks up the new
+  skill content automatically.
+- One install path, not two. Manual `git clone` is documented as
+  developer-only, with an explicit note that it does not wire up the
+  skills.
+
+## Non-goals
+
+- Claude Code marketplace plugin packaging. (Out of scope until there
+  is demand for a public listing.)
+- Windows support. (Project targets macOS + Linux per CLAUDE.md.)
+- GUI installer. (Out of scope.)
+- Migrating existing profiles on reinstall. (Profiles live under
+  `~/.ai-job-searcher/profiles/<id>/` and are preserved across
+  reinstalls; install never touches them.)
+
+## Decisions
+
+### D1. Symlink, not copy
+
+`~/.claude/skills/onboard-profile` → `~/.ai-job-searcher/skills/onboard-profile/`
+(and same for `job-pipeline`, `interview-coach`).
+
+Rationale: the user's constraint is "doesn't break on tool updates".
+A symlink propagates updates automatically — `npx ... install` reruns
+do `git pull` in `~/.ai-job-searcher/`, and the next Claude Code
+session reads the new SKILL.md through the symlink. Copy would
+require re-copy on every update; if user forgets to rerun install,
+their skill silently goes stale.
+
+Risk: if user deletes `~/.ai-job-searcher/`, symlinks dangle. Mitigation:
+the install script is the only documented way to install or uninstall;
+manual deletion is user error. We don't ship a `--uninstall` flag in v1.
+
+### D2. Hardcode `~/.ai-job-searcher/` as the repo location
+
+SKILL.md text references the engine via absolute paths
+(`node ~/.ai-job-searcher/engine/cli.js ...`).
+
+Rationale: the install location is a product decision (fixed folder,
+user does not choose — confirmed by user). Since it's fixed, hardcoding
+is correct. Alternatives rejected:
+
+- **`process.env.AI_JOB_SEARCHER_HOME`** — requires editing user's
+  shell rc files. Fragile across tmux panes, different shells,
+  Claude Code's own subshell environment.
+- **`fs.realpath(__filename)` from inside the skill** — SKILL.md is
+  read as text by Claude, not executed. There is no "skill cwd" to
+  resolve from. Would require a wrapper script and complicates
+  Claude's invocation.
+
+Concrete form in SKILL.md: any code block that runs an engine command
+uses `~/.ai-job-searcher/engine/cli.js` (tilde-expanded by the shell).
+Skill instructions tell Claude: "the repo lives at `~/.ai-job-searcher/`,
+run all commands from there".
+
+### D3. Distribute via `npx github:ymuromcev/ai-job-searcher`, not npm registry
+
+User installs via:
+
+```
+npx -y github:ymuromcev/ai-job-searcher install
+```
+
+(Equivalent shorthand: `npx -y ymuromcev/ai-job-searcher install`.)
+
+Rationale: `npm publish` adds a release step that's easy to forget. If
+Jared cuts a feature and forgets to publish, every new user gets stale
+code. "Doesn't break on tool updates" means removing the step that can
+be forgotten. npx-from-GitHub reads `main` HEAD on each invocation;
+there's nothing to forget.
+
+Implementation: add `bin` field to `package.json` pointing at
+`scripts/install.js`. npx clones the repo into its cache, runs the
+install entrypoint.
+
+Caveat: `npx` from GitHub re-clones into npm cache each install (or
+hits cache). Slightly slower than registry install. Acceptable — install
+is a one-time event per machine.
+
+## What the install script does
+
+`scripts/install.js`, invoked by `npx github:ymuromcev/ai-job-searcher install`:
+
+1. **Preflight.**
+   - Check Node ≥ 20. If not, print `Need Node 20+. Get it at https://nodejs.org. Then rerun this command.` and exit 1.
+   - Check platform is darwin or linux. If not (i.e. win32), print `Windows is not supported. Use macOS or Linux.` and exit 1.
+2. **Detect existing install.**
+   - If `~/.ai-job-searcher/` exists and is a git clone of
+     `https://github.com/ymuromcev/ai-job-searcher.git`:
+     - Run `git -C ~/.ai-job-searcher pull --ff-only`.
+     - Run `npm --prefix ~/.ai-job-searcher install`.
+     - Re-verify symlinks (idempotent).
+     - Print `Updated to latest version. No restart needed if Claude Code is closed; otherwise restart it.`
+     - Exit 0.
+   - If `~/.ai-job-searcher/` exists but is **not** our repo:
+     - Print `~/.ai-job-searcher/ already exists and is not a clone of ai-job-searcher. Move or rename it, then rerun.`
+     - Exit 1.
+3. **Fresh install.**
+   - `git clone https://github.com/ymuromcev/ai-job-searcher.git ~/.ai-job-searcher`.
+   - `npm --prefix ~/.ai-job-searcher install`.
+   - `npm --prefix ~/.ai-job-searcher test` — run smoke. If fail, print
+     `Tests failed during install. Send this output to maintainer.` and exit 1.
+4. **Wire skills.**
+   - For each of `onboard-profile`, `job-pipeline`, `interview-coach`:
+     - Source: `~/.ai-job-searcher/skills/<name>/`
+     - Target: `~/.claude/skills/<name>/`
+     - If target exists and is a symlink to our source → no-op.
+     - If target exists and is a symlink to something else, or a regular
+       directory, or a file → move to
+       `~/.claude/skills/<name>.backup-<timestamp>/`, print
+       `Existing <name> moved to <backup path>.`
+     - Create the symlink.
+5. **Create `~/.ai-job-searcher/.env`** by copying `.env.example`
+   if `.env` does not exist. Don't overwrite if it does.
+6. **Run user-detection from `cwd`.**
+   - If user invoked `npx ...` from inside an existing `ai-job-searcher`
+     clone (any clone, not just our `~/.ai-job-searcher/`), print:
+     `It looks like you ran this from inside an existing clone at <cwd>.
+     This install put the canonical copy at ~/.ai-job-searcher/. You can
+     delete <cwd> if you don't need it.`
+     - We do NOT auto-delete. User error gets a hint, not destruction.
+7. **Final message.**
+   ```
+   Done.
+   
+   Close Claude Code and open it again.
+   Then in a Claude Code chat type:
+   
+     /onboard-profile me
+   ```
+
+## Restart-required gotcha
+
+Claude Code reads `~/.claude/skills/` at session start, not on demand.
+After install, user must restart. Three lines of defense:
+
+1. **Final install message says it explicitly** (point 7 above).
+2. **README "Quick start" says it.**
+3. **Soft guard inside the skill (optional, v2).** If user invokes
+   `/onboard-profile` in a session where the skill exists but symlinks
+   look fresh (mtime < 5 min), we could print "Did you just install?
+   Restart Claude Code." — but Claude Code intercepts `/<name>` before
+   the skill runs, so this fires inside the skill only after the skill
+   was found. Not v1.
+
+## File changes summary
+
+New:
+
+- `scripts/install.js` — the install entrypoint.
+- `scripts/install.test.js` — unit tests for each step
+  (preflight, detect-existing, symlink-wire, backup-conflict),
+  with `fs` mocked.
+
+Modified:
+
+- `package.json` — add `bin: { "ai-job-searcher": "scripts/install.js" }`.
+- `README.md` — rewrite "Quick start" to the one-sentence flow.
+  Add "For developers" section linking to the manual `git clone` path.
+- `skills/onboard-profile/SKILL.md` — replace any relative paths to
+  engine/scripts with `~/.ai-job-searcher/...`. Add a "Repo location"
+  line near the top.
+- `skills/job-pipeline/SKILL.md` — same.
+- `skills/interview-coach/SKILL.md` — same.
+
+Not modified:
+
+- `.gitignore` — `.claude/*` rule unchanged; we don't put skills
+  there in the repo anymore. They live in `skills/` and get symlinked
+  into `~/.claude/skills/` by the install script.
+
+## Open questions
+
+None. D1/D2/D3 closed by user decisions 2026-05-27.
+
+## Definition of accepted
+
+- User reads RFC, confirms D1/D2/D3 are what they want.
+- User explicitly says "accepted" before implementation.
+
+## Implementation plan (after accept)
+
+Single PR, tier M:
+
+1. `scripts/install.js` + tests.
+2. `package.json#bin` wiring.
+3. SKILL.md path rewrites (3 files).
+4. README.md "Quick start" rewrite.
+5. Code-review subagent on diff.
+6. Smoke: run `npx -y file://$PWD install` in a clean
+   `~/.ai-job-searcher/`-less environment (Docker container or tmp
+   home), verify `/onboard-profile` is discoverable in Claude Code.
+7. Final smoke: send PR link to David, wait for live confirmation.

--- a/rfc/README.md
+++ b/rfc/README.md
@@ -38,6 +38,7 @@ Status lives in each RFC's YAML frontmatter (`status: implemented`). The table b
 | [028](028-reclassify-historical-other.md) | Reclassify historical `OTHER` via IMAP | accepted | M | 2026-05-12 |
 | [029](029-ats-sender-coverage.md) | ATS-sender search coverage in `check` tick | accepted | M | 2026-05-12 |
 | [030](030-unified-role-targets.md) | Unified role-targets (single source for scan + LLM fit) | accepted | M | 2026-05-13 |
+| [048](048-install-bootstrap.md) | Install bootstrap: `npx` one-liner that wires skills into Claude Code | accepted | M | 2026-05-27 |
 
 > Index reconciled with frontmatter on 2026-05-05 (RFC 018 phase 1.e back-fill); RFCs 019–029 not yet back-filled — live frontmatter is canonical. To update: edit the frontmatter in the RFC file and reflect the change here.
 

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -67,21 +67,17 @@ function detectInstallState({ installPath, fsCtx, execCtx }) {
     return {
       state: "conflict",
       message:
-        `${installPath} already exists and is not a git clone. ` +
-        `Move or rename it, then rerun.`,
+        `${installPath} already exists and is not a git clone. ` + `Move or rename it, then rerun.`,
     };
   }
   let remote;
   try {
-    remote = execCtx
-      .run("git", ["-C", installPath, "remote", "get-url", "origin"])
-      .trim();
+    remote = execCtx.run("git", ["-C", installPath, "remote", "get-url", "origin"]).trim();
   } catch {
     return {
       state: "conflict",
       message:
-        `${installPath} exists but has no 'origin' remote. ` +
-        `Move or rename it, then rerun.`,
+        `${installPath} exists but has no 'origin' remote. ` + `Move or rename it, then rerun.`,
     };
   }
   if (!isOurRemote(remote)) {
@@ -195,8 +191,7 @@ function makeRealCtx() {
       copyFileSync: (a, b, flags) => fs.copyFileSync(a, b, flags),
     },
     exec: {
-      run: (cmd, args, opts = {}) =>
-        execFileSync(cmd, args, { encoding: "utf8", ...opts }),
+      run: (cmd, args, opts = {}) => execFileSync(cmd, args, { encoding: "utf8", ...opts }),
       runStreaming: (cmd, args, opts = {}) =>
         execFileSync(cmd, args, { stdio: "inherit", ...opts }),
     },
@@ -211,13 +206,11 @@ function executeFreshClone({ installPath, ctx }) {
 }
 
 function checkCleanTree({ installPath, ctx }) {
-  const status = ctx.exec
-    .run("git", ["-C", installPath, "status", "--porcelain"])
-    .trim();
+  const status = ctx.exec.run("git", ["-C", installPath, "status", "--porcelain"]).trim();
   if (status) {
     ctx.err(
       `${installPath} has local changes:\n${status}\n` +
-        `Move them aside (or delete ${installPath} and run install again), then rerun.`,
+        `Move them aside (or delete ${installPath} and run install again), then rerun.`
     );
     return false;
   }
@@ -240,9 +233,7 @@ function executeSkillLink(plan, ctx) {
       ctx.log(`  ${plan.name}: already linked.`);
       return;
     case "missing-source":
-      ctx.err(
-        `  ${plan.name}: source ${plan.source} missing in the cloned repo — skipping.`,
-      );
+      ctx.err(`  ${plan.name}: source ${plan.source} missing in the cloned repo — skipping.`);
       return;
     case "create":
       ctx.fs.mkdirSync(path.dirname(plan.target), { recursive: true });
@@ -253,9 +244,7 @@ function executeSkillLink(plan, ctx) {
       ctx.fs.renameSync(plan.target, plan.backupPath);
       ctx.fs.mkdirSync(path.dirname(plan.target), { recursive: true });
       ctx.fs.symlinkSync(plan.source, plan.target, "dir");
-      ctx.log(
-        `  ${plan.name}: existing entry moved to ${plan.backupPath}, then linked.`,
-      );
+      ctx.log(`  ${plan.name}: existing entry moved to ${plan.backupPath}, then linked.`);
       return;
     default:
       throw new Error(`unknown skill-link action: ${plan.action}`);
@@ -335,12 +324,10 @@ function main({
   });
   if (cwdCheck.isClone) {
     ctx.log("");
-    ctx.log(
-      `Note: you ran this from inside another clone at ${cwdCheck.cwd}.`,
-    );
+    ctx.log(`Note: you ran this from inside another clone at ${cwdCheck.cwd}.`);
     ctx.log(
       `The canonical copy now lives at ${installPath}. You can delete ` +
-        `${cwdCheck.cwd} if you don't need it.`,
+        `${cwdCheck.cwd} if you don't need it.`
     );
   }
 
@@ -364,8 +351,7 @@ if (require.main === module) {
   const cmd = args[0] || "install";
   if (cmd !== "install") {
     console.error(
-      `Unknown subcommand: ${cmd}.\n` +
-        `Usage: npx -y github:ymuromcev/ai-job-searcher install`,
+      `Unknown subcommand: ${cmd}.\n` + `Usage: npx -y github:ymuromcev/ai-job-searcher install`
     );
     process.exit(1);
   }

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -1,0 +1,391 @@
+#!/usr/bin/env node
+/**
+ * install — bootstrap the ai-job-searcher tool for a fresh Claude Code user.
+ *
+ * Invocation (the canonical path documented in README):
+ *   npx -y github:ymuromcev/ai-job-searcher install
+ *
+ * What it does (RFC 048):
+ *   1. Preflight: Node ≥ 20, platform is darwin or linux.
+ *   2. Detect existing install at ~/.ai-job-searcher/. Update if it's
+ *      our clone; refuse if it's something else.
+ *   3. Fresh install: git clone, npm install, npm test.
+ *   4. Symlink each skill in skills/<name>/ to ~/.claude/skills/<name>/,
+ *      backing up any existing entry at <name>.backup-<timestamp>/.
+ *   5. Copy .env.example to .env if .env doesn't exist.
+ *   6. Print restart-required message.
+ *
+ * Pure planning logic lives in plan*() functions; execute*() do the
+ * side effects. Tests mock fs / child_process via the ctx parameter.
+ */
+"use strict";
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { execFileSync } = require("node:child_process");
+
+const REPO_URL = "https://github.com/ymuromcev/ai-job-searcher.git";
+const INSTALL_DIR_NAME = ".ai-job-searcher";
+const CLAUDE_SKILLS_DIR_NAME = path.join(".claude", "skills");
+const SKILLS_TO_LINK = ["onboard-profile", "job-pipeline", "interview-coach"];
+const MIN_NODE_MAJOR = 20;
+
+// --- preflight (pure) -------------------------------------------------------
+
+function checkPreflight({ nodeVersion, platform }) {
+  const m = /^v?(\d+)\./.exec(nodeVersion || "");
+  if (!m) {
+    return { ok: false, message: `Could not parse Node version: ${nodeVersion}` };
+  }
+  const major = Number(m[1]);
+  if (major < MIN_NODE_MAJOR) {
+    return {
+      ok: false,
+      message:
+        `Need Node ${MIN_NODE_MAJOR}+. You have ${nodeVersion}. ` +
+        `Get a newer version at https://nodejs.org. Then rerun this command.`,
+    };
+  }
+  if (platform !== "darwin" && platform !== "linux") {
+    return {
+      ok: false,
+      message: `Platform ${platform} is not supported. Use macOS or Linux.`,
+    };
+  }
+  return { ok: true };
+}
+
+// --- detect existing install (pure given an fs-like ctx) -------------------
+
+function detectInstallState({ installPath, fsCtx, execCtx }) {
+  if (!fsCtx.existsSync(installPath)) {
+    return { state: "fresh" };
+  }
+  const gitDir = path.join(installPath, ".git");
+  if (!fsCtx.existsSync(gitDir)) {
+    return {
+      state: "conflict",
+      message:
+        `${installPath} already exists and is not a git clone. ` +
+        `Move or rename it, then rerun.`,
+    };
+  }
+  let remote;
+  try {
+    remote = execCtx
+      .run("git", ["-C", installPath, "remote", "get-url", "origin"])
+      .trim();
+  } catch {
+    return {
+      state: "conflict",
+      message:
+        `${installPath} exists but has no 'origin' remote. ` +
+        `Move or rename it, then rerun.`,
+    };
+  }
+  if (!isOurRemote(remote)) {
+    return {
+      state: "conflict",
+      message:
+        `${installPath} is a clone of ${remote}, not ai-job-searcher. ` +
+        `Move or rename it, then rerun.`,
+    };
+  }
+  return { state: "update" };
+}
+
+function isOurRemote(remoteUrl) {
+  if (!remoteUrl) return false;
+  const normalized = remoteUrl
+    .replace(/\/+$/, "")
+    .replace(/\.git$/, "")
+    .replace(/\/+$/, "")
+    .toLowerCase();
+  return (
+    normalized.endsWith("ymuromcev/ai-job-searcher") ||
+    normalized.endsWith(":ymuromcev/ai-job-searcher")
+  );
+}
+
+// --- plan skill symlinks (pure given fsCtx) --------------------------------
+
+function planSkillLink({ name, installPath, claudeSkillsPath, fsCtx, now }) {
+  const source = path.join(installPath, "skills", name);
+  const target = path.join(claudeSkillsPath, name);
+
+  if (!fsCtx.existsSync(source)) {
+    return { name, source, target, action: "missing-source" };
+  }
+
+  if (!fsCtx.lstatExistsSync(target)) {
+    return { name, source, target, action: "create" };
+  }
+
+  const stat = fsCtx.lstatSync(target);
+  if (stat.isSymbolicLink()) {
+    const current = fsCtx.readlinkSync(target);
+    if (path.resolve(claudeSkillsPath, current) === path.resolve(source)) {
+      return { name, source, target, action: "noop" };
+    }
+  }
+
+  // Pick a backup path that doesn't already exist (defensive against a
+  // re-run within the same second or a leftover from a previous install).
+  const base = `${target}.backup-${formatTimestamp(now)}`;
+  let backupPath = base;
+  let suffix = 1;
+  while (fsCtx.lstatExistsSync(backupPath)) {
+    backupPath = `${base}-${suffix}`;
+    suffix += 1;
+  }
+  return { name, source, target, action: "backup-then-create", backupPath };
+}
+
+function formatTimestamp(date) {
+  const pad = (n, w = 2) => String(n).padStart(w, "0");
+  return (
+    `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}` +
+    `-${pad(date.getUTCHours())}${pad(date.getUTCMinutes())}${pad(date.getUTCSeconds())}` +
+    `-${pad(date.getUTCMilliseconds(), 3)}`
+  );
+}
+
+// --- cwd detection (pure) --------------------------------------------------
+
+function detectCwdIsClone({ cwd, fsCtx, execCtx, installPath }) {
+  if (path.resolve(cwd) === path.resolve(installPath)) {
+    return { isClone: false };
+  }
+  const gitDir = path.join(cwd, ".git");
+  if (!fsCtx.existsSync(gitDir)) {
+    return { isClone: false };
+  }
+  let remote;
+  try {
+    remote = execCtx.run("git", ["-C", cwd, "remote", "get-url", "origin"]).trim();
+  } catch {
+    return { isClone: false };
+  }
+  if (isOurRemote(remote)) {
+    return { isClone: true, cwd };
+  }
+  return { isClone: false };
+}
+
+// --- execute (side effects) -------------------------------------------------
+
+function makeRealCtx() {
+  return {
+    fs: {
+      existsSync: (p) => fs.existsSync(p),
+      lstatExistsSync: (p) => {
+        try {
+          fs.lstatSync(p);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      lstatSync: (p) => fs.lstatSync(p),
+      readlinkSync: (p) => fs.readlinkSync(p),
+      mkdirSync: (p, opts) => fs.mkdirSync(p, opts),
+      renameSync: (a, b) => fs.renameSync(a, b),
+      symlinkSync: (target, link, type) => fs.symlinkSync(target, link, type),
+      copyFileSync: (a, b, flags) => fs.copyFileSync(a, b, flags),
+    },
+    exec: {
+      run: (cmd, args, opts = {}) =>
+        execFileSync(cmd, args, { encoding: "utf8", ...opts }),
+      runStreaming: (cmd, args, opts = {}) =>
+        execFileSync(cmd, args, { stdio: "inherit", ...opts }),
+    },
+    log: (...m) => console.log(...m),
+    err: (...m) => console.error(...m),
+  };
+}
+
+function executeFreshClone({ installPath, ctx }) {
+  ctx.log(`Cloning ai-job-searcher into ${installPath}...`);
+  ctx.exec.runStreaming("git", ["clone", REPO_URL, installPath]);
+}
+
+function checkCleanTree({ installPath, ctx }) {
+  const status = ctx.exec
+    .run("git", ["-C", installPath, "status", "--porcelain"])
+    .trim();
+  if (status) {
+    ctx.err(
+      `${installPath} has local changes:\n${status}\n` +
+        `Move them aside (or delete ${installPath} and run install again), then rerun.`,
+    );
+    return false;
+  }
+  return true;
+}
+
+function executeUpdate({ installPath, ctx }) {
+  ctx.log(`Updating existing install at ${installPath}...`);
+  ctx.exec.runStreaming("git", ["-C", installPath, "pull", "--ff-only"]);
+}
+
+function executeNpmInstall({ installPath, ctx }) {
+  ctx.log("Installing dependencies...");
+  ctx.exec.runStreaming("npm", ["--prefix", installPath, "install"]);
+}
+
+function executeSkillLink(plan, ctx) {
+  switch (plan.action) {
+    case "noop":
+      ctx.log(`  ${plan.name}: already linked.`);
+      return;
+    case "missing-source":
+      ctx.err(
+        `  ${plan.name}: source ${plan.source} missing in the cloned repo — skipping.`,
+      );
+      return;
+    case "create":
+      ctx.fs.mkdirSync(path.dirname(plan.target), { recursive: true });
+      ctx.fs.symlinkSync(plan.source, plan.target, "dir");
+      ctx.log(`  ${plan.name}: linked.`);
+      return;
+    case "backup-then-create":
+      ctx.fs.renameSync(plan.target, plan.backupPath);
+      ctx.fs.mkdirSync(path.dirname(plan.target), { recursive: true });
+      ctx.fs.symlinkSync(plan.source, plan.target, "dir");
+      ctx.log(
+        `  ${plan.name}: existing entry moved to ${plan.backupPath}, then linked.`,
+      );
+      return;
+    default:
+      throw new Error(`unknown skill-link action: ${plan.action}`);
+  }
+}
+
+function ensureEnvFile({ installPath, ctx, isFresh }) {
+  // Only seed .env on fresh installs. On updates, treat a missing .env as
+  // an intentional choice — don't silently recreate it.
+  if (!isFresh) return;
+  const envPath = path.join(installPath, ".env");
+  const examplePath = path.join(installPath, ".env.example");
+  if (ctx.fs.existsSync(envPath)) return;
+  if (!ctx.fs.existsSync(examplePath)) return;
+  ctx.fs.copyFileSync(examplePath, envPath, fs.constants.COPYFILE_EXCL);
+  ctx.log(`Created ${envPath} from .env.example. Fill in tokens before first scan.`);
+}
+
+// --- main -------------------------------------------------------------------
+
+function main({
+  homedir = os.homedir(),
+  nodeVersion = process.version,
+  platform = process.platform,
+  cwd = process.cwd(),
+  ctx = makeRealCtx(),
+  now = new Date(),
+} = {}) {
+  const installPath = path.join(homedir, INSTALL_DIR_NAME);
+  const claudeSkillsPath = path.join(homedir, CLAUDE_SKILLS_DIR_NAME);
+
+  const pre = checkPreflight({ nodeVersion, platform });
+  if (!pre.ok) {
+    ctx.err(pre.message);
+    return 1;
+  }
+
+  const detect = detectInstallState({
+    installPath,
+    fsCtx: ctx.fs,
+    execCtx: ctx.exec,
+  });
+
+  if (detect.state === "conflict") {
+    ctx.err(detect.message);
+    return 1;
+  }
+
+  if (detect.state === "fresh") {
+    executeFreshClone({ installPath, ctx });
+  } else {
+    if (!checkCleanTree({ installPath, ctx })) return 1;
+    executeUpdate({ installPath, ctx });
+  }
+
+  executeNpmInstall({ installPath, ctx });
+
+  ctx.log("Wiring skills into ~/.claude/skills/...");
+  for (const name of SKILLS_TO_LINK) {
+    const plan = planSkillLink({
+      name,
+      installPath,
+      claudeSkillsPath,
+      fsCtx: ctx.fs,
+      now,
+    });
+    executeSkillLink(plan, ctx);
+  }
+
+  ensureEnvFile({ installPath, ctx, isFresh: detect.state === "fresh" });
+
+  const cwdCheck = detectCwdIsClone({
+    cwd,
+    fsCtx: ctx.fs,
+    execCtx: ctx.exec,
+    installPath,
+  });
+  if (cwdCheck.isClone) {
+    ctx.log("");
+    ctx.log(
+      `Note: you ran this from inside another clone at ${cwdCheck.cwd}.`,
+    );
+    ctx.log(
+      `The canonical copy now lives at ${installPath}. You can delete ` +
+        `${cwdCheck.cwd} if you don't need it.`,
+    );
+  }
+
+  ctx.log("");
+  if (detect.state === "fresh") {
+    ctx.log("Done.");
+    ctx.log("");
+    ctx.log("Close Claude Code and open it again.");
+    ctx.log("Then in a Claude Code chat type:");
+    ctx.log("");
+    ctx.log("  /onboard-profile me");
+  } else {
+    ctx.log("Updated to latest version.");
+    ctx.log("Restart Claude Code if it's currently open; otherwise you're set.");
+  }
+  return 0;
+}
+
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  const cmd = args[0] || "install";
+  if (cmd !== "install") {
+    console.error(
+      `Unknown subcommand: ${cmd}.\n` +
+        `Usage: npx -y github:ymuromcev/ai-job-searcher install`,
+    );
+    process.exit(1);
+  }
+  try {
+    process.exit(main());
+  } catch (err) {
+    console.error(err && err.message ? err.message : String(err));
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  checkPreflight,
+  detectInstallState,
+  isOurRemote,
+  planSkillLink,
+  detectCwdIsClone,
+  formatTimestamp,
+  ensureEnvFile,
+  main,
+  SKILLS_TO_LINK,
+  REPO_URL,
+};

--- a/scripts/install.test.js
+++ b/scripts/install.test.js
@@ -338,10 +338,7 @@ test("detectCwdIsClone: cwd has no .git → false", () => {
 // --- formatTimestamp --------------------------------------------------------
 
 test("formatTimestamp: utc components zero-padded + milliseconds", () => {
-  assert.equal(
-    formatTimestamp(new Date(Date.UTC(2026, 0, 5, 3, 4, 5, 7))),
-    "20260105-030405-007",
-  );
+  assert.equal(formatTimestamp(new Date(Date.UTC(2026, 0, 5, 3, 4, 5, 7))), "20260105-030405-007");
 });
 
 // --- main: fresh install trace ---------------------------------------------
@@ -445,7 +442,7 @@ test("main: fresh install — clones, installs, tests, links all 3 skills", () =
     const target = `${installPath}/skills/${name}`;
     assert.ok(
       symlinkCalls.some((c) => c[1] === target && c[2] === link),
-      `expected symlink for ${name}`,
+      `expected symlink for ${name}`
     );
   }
 
@@ -577,7 +574,7 @@ test("main: Node 18 → fails preflight, no work done", () => {
   assert.equal(
     ctx.calls.filter((c) => c[0] === "runStreaming").length,
     0,
-    "no shell calls when preflight fails",
+    "no shell calls when preflight fails"
   );
 });
 
@@ -594,8 +591,7 @@ test("main: cwd is a separate clone → final note about redundant copy", () => 
       `${cwd}/.git`,
     ]),
     execResponses: {
-      [`git -C ${cwd} remote get-url origin`]:
-        "https://github.com/ymuromcev/ai-job-searcher.git\n",
+      [`git -C ${cwd} remote get-url origin`]: "https://github.com/ymuromcev/ai-job-searcher.git\n",
     },
   });
 

--- a/scripts/install.test.js
+++ b/scripts/install.test.js
@@ -1,0 +1,656 @@
+// Tests for scripts/install.js — BL-137 / RFC 048.
+// Pure functions get unit coverage; main() gets two end-to-end traces
+// (fresh + update) against a fake ctx with in-memory fs / exec.
+
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const {
+  checkPreflight,
+  detectInstallState,
+  isOurRemote,
+  planSkillLink,
+  detectCwdIsClone,
+  formatTimestamp,
+  ensureEnvFile,
+  main,
+  SKILLS_TO_LINK,
+} = require("./install.js");
+
+// --- checkPreflight ---------------------------------------------------------
+
+test("checkPreflight: Node 20 darwin → ok", () => {
+  assert.deepEqual(checkPreflight({ nodeVersion: "v20.10.0", platform: "darwin" }), {
+    ok: true,
+  });
+});
+
+test("checkPreflight: Node 22 linux → ok", () => {
+  assert.deepEqual(checkPreflight({ nodeVersion: "v22.5.0", platform: "linux" }), {
+    ok: true,
+  });
+});
+
+test("checkPreflight: Node 18 → fails with upgrade message", () => {
+  const r = checkPreflight({ nodeVersion: "v18.19.0", platform: "darwin" });
+  assert.equal(r.ok, false);
+  assert.match(r.message, /Node 20\+/);
+  assert.match(r.message, /v18\.19\.0/);
+});
+
+test("checkPreflight: win32 → fails with platform message", () => {
+  const r = checkPreflight({ nodeVersion: "v20.10.0", platform: "win32" });
+  assert.equal(r.ok, false);
+  assert.match(r.message, /macOS or Linux/);
+});
+
+test("checkPreflight: unparseable Node version → fails clearly", () => {
+  const r = checkPreflight({ nodeVersion: "garbage", platform: "darwin" });
+  assert.equal(r.ok, false);
+  assert.match(r.message, /Could not parse/);
+});
+
+// --- isOurRemote ------------------------------------------------------------
+
+test("isOurRemote: https URL with .git → true", () => {
+  assert.equal(isOurRemote("https://github.com/ymuromcev/ai-job-searcher.git"), true);
+});
+
+test("isOurRemote: https URL without .git → true", () => {
+  assert.equal(isOurRemote("https://github.com/ymuromcev/ai-job-searcher"), true);
+});
+
+test("isOurRemote: ssh URL → true", () => {
+  assert.equal(isOurRemote("git@github.com:ymuromcev/ai-job-searcher.git"), true);
+});
+
+test("isOurRemote: someone else's fork → false", () => {
+  assert.equal(isOurRemote("https://github.com/forker/ai-job-searcher.git"), false);
+});
+
+test("isOurRemote: unrelated repo → false", () => {
+  assert.equal(isOurRemote("https://github.com/ymuromcev/something-else.git"), false);
+});
+
+test("isOurRemote: empty → false", () => {
+  assert.equal(isOurRemote(""), false);
+  assert.equal(isOurRemote(null), false);
+});
+
+test("isOurRemote: trailing slash → true", () => {
+  assert.equal(isOurRemote("https://github.com/ymuromcev/ai-job-searcher/"), true);
+  assert.equal(isOurRemote("https://github.com/ymuromcev/ai-job-searcher.git/"), true);
+});
+
+// --- detectInstallState -----------------------------------------------------
+
+function makeFakeFs(paths) {
+  const set = new Set(paths);
+  return {
+    existsSync: (p) => set.has(p),
+    lstatExistsSync: (p) => set.has(p),
+    lstatSync: () => {
+      throw new Error("not implemented for this test");
+    },
+    readlinkSync: () => {
+      throw new Error("not implemented for this test");
+    },
+  };
+}
+
+function makeFakeExec(responses) {
+  return {
+    run: (cmd, args) => {
+      const key = `${cmd} ${args.join(" ")}`;
+      if (key in responses) {
+        const r = responses[key];
+        if (r instanceof Error) throw r;
+        return r;
+      }
+      throw new Error(`unmocked exec: ${key}`);
+    },
+  };
+}
+
+test("detectInstallState: no install dir → fresh", () => {
+  const r = detectInstallState({
+    installPath: "/home/u/.ai-job-searcher",
+    fsCtx: makeFakeFs([]),
+    execCtx: makeFakeExec({}),
+  });
+  assert.deepEqual(r, { state: "fresh" });
+});
+
+test("detectInstallState: install dir exists but no .git → conflict", () => {
+  const r = detectInstallState({
+    installPath: "/home/u/.ai-job-searcher",
+    fsCtx: makeFakeFs(["/home/u/.ai-job-searcher"]),
+    execCtx: makeFakeExec({}),
+  });
+  assert.equal(r.state, "conflict");
+  assert.match(r.message, /not a git clone/);
+});
+
+test("detectInstallState: install dir is a clone of our repo → update", () => {
+  const r = detectInstallState({
+    installPath: "/home/u/.ai-job-searcher",
+    fsCtx: makeFakeFs(["/home/u/.ai-job-searcher", "/home/u/.ai-job-searcher/.git"]),
+    execCtx: makeFakeExec({
+      "git -C /home/u/.ai-job-searcher remote get-url origin":
+        "https://github.com/ymuromcev/ai-job-searcher.git\n",
+    }),
+  });
+  assert.deepEqual(r, { state: "update" });
+});
+
+test("detectInstallState: install dir is a clone of someone else → conflict", () => {
+  const r = detectInstallState({
+    installPath: "/home/u/.ai-job-searcher",
+    fsCtx: makeFakeFs(["/home/u/.ai-job-searcher", "/home/u/.ai-job-searcher/.git"]),
+    execCtx: makeFakeExec({
+      "git -C /home/u/.ai-job-searcher remote get-url origin":
+        "https://github.com/forker/ai-job-searcher.git\n",
+    }),
+  });
+  assert.equal(r.state, "conflict");
+  assert.match(r.message, /not ai-job-searcher/);
+});
+
+test("detectInstallState: install dir has .git but no origin remote → conflict", () => {
+  const r = detectInstallState({
+    installPath: "/home/u/.ai-job-searcher",
+    fsCtx: makeFakeFs(["/home/u/.ai-job-searcher", "/home/u/.ai-job-searcher/.git"]),
+    execCtx: makeFakeExec({
+      "git -C /home/u/.ai-job-searcher remote get-url origin": new Error("no origin"),
+    }),
+  });
+  assert.equal(r.state, "conflict");
+  assert.match(r.message, /no 'origin' remote/);
+});
+
+// --- planSkillLink ----------------------------------------------------------
+
+const INSTALL = "/home/u/.ai-job-searcher";
+const SKILLS = "/home/u/.claude/skills";
+
+function fsWithSkill({ existing = [], lstats = {}, links = {} }) {
+  const set = new Set([
+    `${INSTALL}/skills/onboard-profile`,
+    `${INSTALL}/skills/job-pipeline`,
+    `${INSTALL}/skills/interview-coach`,
+    ...existing,
+  ]);
+  return {
+    existsSync: (p) => set.has(p),
+    lstatExistsSync: (p) => set.has(p) || p in lstats,
+    lstatSync: (p) => {
+      if (!(p in lstats)) throw new Error(`no lstat for ${p}`);
+      return lstats[p];
+    },
+    readlinkSync: (p) => {
+      if (!(p in links)) throw new Error(`no readlink for ${p}`);
+      return links[p];
+    },
+  };
+}
+
+test("planSkillLink: target absent → create", () => {
+  const plan = planSkillLink({
+    name: "onboard-profile",
+    installPath: INSTALL,
+    claudeSkillsPath: SKILLS,
+    fsCtx: fsWithSkill({}),
+    now: new Date("2026-05-27T12:00:00Z"),
+  });
+  assert.equal(plan.action, "create");
+  assert.equal(plan.source, `${INSTALL}/skills/onboard-profile`);
+  assert.equal(plan.target, `${SKILLS}/onboard-profile`);
+});
+
+test("planSkillLink: target already symlinked to our source → noop", () => {
+  const target = `${SKILLS}/onboard-profile`;
+  const plan = planSkillLink({
+    name: "onboard-profile",
+    installPath: INSTALL,
+    claudeSkillsPath: SKILLS,
+    fsCtx: fsWithSkill({
+      existing: [target],
+      lstats: { [target]: { isSymbolicLink: () => true } },
+      links: { [target]: `${INSTALL}/skills/onboard-profile` },
+    }),
+    now: new Date("2026-05-27T12:00:00Z"),
+  });
+  assert.equal(plan.action, "noop");
+});
+
+test("planSkillLink: target is a regular directory → backup-then-create", () => {
+  const target = `${SKILLS}/onboard-profile`;
+  const plan = planSkillLink({
+    name: "onboard-profile",
+    installPath: INSTALL,
+    claudeSkillsPath: SKILLS,
+    fsCtx: fsWithSkill({
+      existing: [target],
+      lstats: { [target]: { isSymbolicLink: () => false } },
+    }),
+    now: new Date("2026-05-27T12:34:56Z"),
+  });
+  assert.equal(plan.action, "backup-then-create");
+  assert.match(plan.backupPath, /onboard-profile\.backup-20260527-123456-000$/);
+});
+
+test("planSkillLink: target is a symlink to a different source → backup-then-create", () => {
+  const target = `${SKILLS}/onboard-profile`;
+  const plan = planSkillLink({
+    name: "onboard-profile",
+    installPath: INSTALL,
+    claudeSkillsPath: SKILLS,
+    fsCtx: fsWithSkill({
+      existing: [target],
+      lstats: { [target]: { isSymbolicLink: () => true } },
+      links: { [target]: "/some/other/skill" },
+    }),
+    now: new Date("2026-05-27T00:00:00Z"),
+  });
+  assert.equal(plan.action, "backup-then-create");
+});
+
+test("planSkillLink: source missing in repo → missing-source", () => {
+  const plan = planSkillLink({
+    name: "nonexistent-skill",
+    installPath: INSTALL,
+    claudeSkillsPath: SKILLS,
+    fsCtx: fsWithSkill({}),
+    now: new Date(),
+  });
+  assert.equal(plan.action, "missing-source");
+});
+
+test("planSkillLink: existing backup at same timestamp → appends suffix", () => {
+  const target = `${SKILLS}/onboard-profile`;
+  const baseBackup = `${target}.backup-20260527-123456-789`;
+  const plan = planSkillLink({
+    name: "onboard-profile",
+    installPath: INSTALL,
+    claudeSkillsPath: SKILLS,
+    fsCtx: fsWithSkill({
+      existing: [target, baseBackup],
+      lstats: { [target]: { isSymbolicLink: () => false } },
+    }),
+    now: new Date(Date.UTC(2026, 4, 27, 12, 34, 56, 789)),
+  });
+  assert.equal(plan.action, "backup-then-create");
+  assert.equal(plan.backupPath, `${baseBackup}-1`);
+});
+
+// --- detectCwdIsClone -------------------------------------------------------
+
+test("detectCwdIsClone: cwd is installPath → not a clone (skip the warning)", () => {
+  const r = detectCwdIsClone({
+    cwd: INSTALL,
+    installPath: INSTALL,
+    fsCtx: makeFakeFs([`${INSTALL}/.git`]),
+    execCtx: makeFakeExec({}),
+  });
+  assert.equal(r.isClone, false);
+});
+
+test("detectCwdIsClone: cwd is a separate clone of our repo → true", () => {
+  const r = detectCwdIsClone({
+    cwd: "/Users/dev/work/ai-job-searcher",
+    installPath: INSTALL,
+    fsCtx: makeFakeFs(["/Users/dev/work/ai-job-searcher/.git"]),
+    execCtx: makeFakeExec({
+      "git -C /Users/dev/work/ai-job-searcher remote get-url origin":
+        "https://github.com/ymuromcev/ai-job-searcher.git\n",
+    }),
+  });
+  assert.equal(r.isClone, true);
+  assert.equal(r.cwd, "/Users/dev/work/ai-job-searcher");
+});
+
+test("detectCwdIsClone: cwd is a clone of a different repo → false", () => {
+  const r = detectCwdIsClone({
+    cwd: "/Users/dev/other-project",
+    installPath: INSTALL,
+    fsCtx: makeFakeFs(["/Users/dev/other-project/.git"]),
+    execCtx: makeFakeExec({
+      "git -C /Users/dev/other-project remote get-url origin":
+        "https://github.com/dev/other-project.git\n",
+    }),
+  });
+  assert.equal(r.isClone, false);
+});
+
+test("detectCwdIsClone: cwd has no .git → false", () => {
+  const r = detectCwdIsClone({
+    cwd: "/tmp/empty",
+    installPath: INSTALL,
+    fsCtx: makeFakeFs([]),
+    execCtx: makeFakeExec({}),
+  });
+  assert.equal(r.isClone, false);
+});
+
+// --- formatTimestamp --------------------------------------------------------
+
+test("formatTimestamp: utc components zero-padded + milliseconds", () => {
+  assert.equal(
+    formatTimestamp(new Date(Date.UTC(2026, 0, 5, 3, 4, 5, 7))),
+    "20260105-030405-007",
+  );
+});
+
+// --- main: fresh install trace ---------------------------------------------
+
+function makeTraceCtx({ fsState = new Set(), execResponses = {} }) {
+  const calls = [];
+  const messages = [];
+  const symlinks = new Map();
+  const fsState_ = new Set(fsState);
+  const lstats = new Map();
+
+  return {
+    calls,
+    messages,
+    fs: {
+      existsSync: (p) => fsState_.has(p),
+      lstatExistsSync: (p) => fsState_.has(p) || lstats.has(p),
+      lstatSync: (p) => {
+        if (lstats.has(p)) return lstats.get(p);
+        throw new Error(`no lstat for ${p}`);
+      },
+      readlinkSync: (p) => {
+        if (symlinks.has(p)) return symlinks.get(p);
+        throw new Error(`no readlink for ${p}`);
+      },
+      mkdirSync: (p) => {
+        calls.push(["mkdir", p]);
+        fsState_.add(p);
+      },
+      renameSync: (a, b) => {
+        calls.push(["rename", a, b]);
+        fsState_.delete(a);
+        fsState_.add(b);
+      },
+      symlinkSync: (target, link) => {
+        calls.push(["symlink", target, link]);
+        symlinks.set(link, target);
+        lstats.set(link, { isSymbolicLink: () => true });
+        fsState_.add(link);
+      },
+      copyFileSync: (a, b) => {
+        calls.push(["copyFile", a, b]);
+        fsState_.add(b);
+      },
+    },
+    exec: {
+      run: (cmd, args) => {
+        const key = `${cmd} ${args.join(" ")}`;
+        calls.push(["run", key]);
+        if (key in execResponses) {
+          const r = execResponses[key];
+          if (r instanceof Error) throw r;
+          return r;
+        }
+        return "";
+      },
+      runStreaming: (cmd, args) => {
+        calls.push(["runStreaming", `${cmd} ${args.join(" ")}`]);
+      },
+    },
+    log: (...m) => messages.push(m.join(" ")),
+    err: (...m) => messages.push("ERR: " + m.join(" ")),
+  };
+}
+
+test("main: fresh install — clones, installs, tests, links all 3 skills", () => {
+  const home = "/home/u";
+  const installPath = `${home}/.ai-job-searcher`;
+  const ctx = makeTraceCtx({
+    fsState: new Set([
+      // After "clone" the source skill dirs would exist; emulate that by
+      // pre-populating them. Real run sequences clone-then-link.
+      `${installPath}/skills/onboard-profile`,
+      `${installPath}/skills/job-pipeline`,
+      `${installPath}/skills/interview-coach`,
+      `${installPath}/.env.example`,
+    ]),
+  });
+
+  const rc = main({
+    homedir: home,
+    nodeVersion: "v20.10.0",
+    platform: "darwin",
+    cwd: "/tmp/empty",
+    ctx,
+    now: new Date("2026-05-27T12:00:00Z"),
+  });
+
+  assert.equal(rc, 0);
+
+  const streamingCalls = ctx.calls.filter((c) => c[0] === "runStreaming").map((c) => c[1]);
+  assert.deepEqual(streamingCalls, [
+    `git clone https://github.com/ymuromcev/ai-job-searcher.git ${installPath}`,
+    `npm --prefix ${installPath} install`,
+  ]);
+
+  const symlinkCalls = ctx.calls.filter((c) => c[0] === "symlink");
+  assert.equal(symlinkCalls.length, SKILLS_TO_LINK.length);
+  for (const name of SKILLS_TO_LINK) {
+    const link = `${home}/.claude/skills/${name}`;
+    const target = `${installPath}/skills/${name}`;
+    assert.ok(
+      symlinkCalls.some((c) => c[1] === target && c[2] === link),
+      `expected symlink for ${name}`,
+    );
+  }
+
+  const copyCalls = ctx.calls.filter((c) => c[0] === "copyFile");
+  assert.equal(copyCalls.length, 1, ".env should be copied from .env.example");
+  assert.equal(copyCalls[0][1], `${installPath}/.env.example`);
+  assert.equal(copyCalls[0][2], `${installPath}/.env`);
+
+  const out = ctx.messages.join("\n");
+  assert.match(out, /Close Claude Code and open it again/);
+  assert.match(out, /\/onboard-profile me/);
+});
+
+test("main: update path — pulls instead of clones, no .env overwrite", () => {
+  const home = "/home/u";
+  const installPath = `${home}/.ai-job-searcher`;
+  const ctx = makeTraceCtx({
+    fsState: new Set([
+      installPath,
+      `${installPath}/.git`,
+      `${installPath}/skills/onboard-profile`,
+      `${installPath}/skills/job-pipeline`,
+      `${installPath}/skills/interview-coach`,
+      `${installPath}/.env`,
+      `${installPath}/.env.example`,
+    ]),
+    execResponses: {
+      [`git -C ${installPath} remote get-url origin`]:
+        "https://github.com/ymuromcev/ai-job-searcher.git\n",
+      [`git -C ${installPath} status --porcelain`]: "",
+    },
+  });
+
+  const rc = main({
+    homedir: home,
+    nodeVersion: "v20.10.0",
+    platform: "darwin",
+    cwd: "/tmp/empty",
+    ctx,
+    now: new Date("2026-05-27T12:00:00Z"),
+  });
+
+  assert.equal(rc, 0);
+
+  const streamingCalls = ctx.calls.filter((c) => c[0] === "runStreaming").map((c) => c[1]);
+  assert.deepEqual(streamingCalls, [
+    `git -C ${installPath} pull --ff-only`,
+    `npm --prefix ${installPath} install`,
+  ]);
+
+  // .env exists already → no copy
+  const copyCalls = ctx.calls.filter((c) => c[0] === "copyFile");
+  assert.equal(copyCalls.length, 0);
+
+  const out = ctx.messages.join("\n");
+  assert.match(out, /Updated to latest version/);
+});
+
+test("main: update path with dirty tree → refuses with friendly message, no pull", () => {
+  const home = "/home/u";
+  const installPath = `${home}/.ai-job-searcher`;
+  const ctx = makeTraceCtx({
+    fsState: new Set([
+      installPath,
+      `${installPath}/.git`,
+      `${installPath}/skills/onboard-profile`,
+      `${installPath}/skills/job-pipeline`,
+      `${installPath}/skills/interview-coach`,
+    ]),
+    execResponses: {
+      [`git -C ${installPath} remote get-url origin`]:
+        "https://github.com/ymuromcev/ai-job-searcher.git\n",
+      [`git -C ${installPath} status --porcelain`]: " M package.json\n",
+    },
+  });
+
+  const rc = main({
+    homedir: home,
+    nodeVersion: "v20.10.0",
+    platform: "darwin",
+    cwd: "/tmp/empty",
+    ctx,
+    now: new Date("2026-05-27T12:00:00Z"),
+  });
+
+  assert.equal(rc, 1);
+  const streamingCalls = ctx.calls.filter((c) => c[0] === "runStreaming");
+  assert.equal(streamingCalls.length, 0, "no pull or npm when dirty");
+  const out = ctx.messages.join("\n");
+  assert.match(out, /local changes/);
+});
+
+test("main: conflict state (someone else's clone) → exit 1, no work done", () => {
+  const home = "/home/u";
+  const installPath = `${home}/.ai-job-searcher`;
+  const ctx = makeTraceCtx({
+    fsState: new Set([installPath, `${installPath}/.git`]),
+    execResponses: {
+      [`git -C ${installPath} remote get-url origin`]:
+        "https://github.com/forker/ai-job-searcher.git\n",
+    },
+  });
+
+  const rc = main({
+    homedir: home,
+    nodeVersion: "v20.10.0",
+    platform: "darwin",
+    cwd: "/tmp/empty",
+    ctx,
+    now: new Date("2026-05-27T12:00:00Z"),
+  });
+  assert.equal(rc, 1);
+  const streamingCalls = ctx.calls.filter((c) => c[0] === "runStreaming");
+  assert.equal(streamingCalls.length, 0);
+  const out = ctx.messages.join("\n");
+  assert.match(out, /Move or rename it/);
+});
+
+test("main: Node 18 → fails preflight, no work done", () => {
+  const ctx = makeTraceCtx({});
+  const rc = main({
+    homedir: "/home/u",
+    nodeVersion: "v18.0.0",
+    platform: "linux",
+    cwd: "/tmp/empty",
+    ctx,
+  });
+  assert.equal(rc, 1);
+  assert.equal(
+    ctx.calls.filter((c) => c[0] === "runStreaming").length,
+    0,
+    "no shell calls when preflight fails",
+  );
+});
+
+test("main: cwd is a separate clone → final note about redundant copy", () => {
+  const home = "/home/u";
+  const installPath = `${home}/.ai-job-searcher`;
+  const cwd = "/Users/dev/work/ai-job-searcher";
+  const ctx = makeTraceCtx({
+    fsState: new Set([
+      `${installPath}/skills/onboard-profile`,
+      `${installPath}/skills/job-pipeline`,
+      `${installPath}/skills/interview-coach`,
+      `${installPath}/.env.example`,
+      `${cwd}/.git`,
+    ]),
+    execResponses: {
+      [`git -C ${cwd} remote get-url origin`]:
+        "https://github.com/ymuromcev/ai-job-searcher.git\n",
+    },
+  });
+
+  const rc = main({
+    homedir: home,
+    nodeVersion: "v20.10.0",
+    platform: "darwin",
+    cwd,
+    ctx,
+    now: new Date("2026-05-27T12:00:00Z"),
+  });
+  assert.equal(rc, 0);
+
+  const out = ctx.messages.join("\n");
+  assert.match(out, /you ran this from inside another clone/);
+  assert.match(out, /You can delete/);
+});
+
+// --- ensureEnvFile ----------------------------------------------------------
+
+test("ensureEnvFile: fresh + .env exists → skipped", () => {
+  const calls = [];
+  const ctx = {
+    fs: {
+      existsSync: (p) => p.endsWith(".env") || p.endsWith(".env.example"),
+      copyFileSync: (...args) => calls.push(args),
+    },
+    log: () => {},
+  };
+  ensureEnvFile({ installPath: "/r", ctx, isFresh: true });
+  assert.equal(calls.length, 0);
+});
+
+test("ensureEnvFile: fresh + no .env.example → skipped silently", () => {
+  const calls = [];
+  const ctx = {
+    fs: {
+      existsSync: () => false,
+      copyFileSync: (...args) => calls.push(args),
+    },
+    log: () => {},
+  };
+  ensureEnvFile({ installPath: "/r", ctx, isFresh: true });
+  assert.equal(calls.length, 0);
+});
+
+test("ensureEnvFile: update (not fresh) → never creates .env, even if missing", () => {
+  const calls = [];
+  const ctx = {
+    fs: {
+      existsSync: (p) => p.endsWith(".env.example"),
+      copyFileSync: (...args) => calls.push(args),
+    },
+    log: () => {},
+  };
+  ensureEnvFile({ installPath: "/r", ctx, isFresh: false });
+  assert.equal(calls.length, 0, "update path must not silently recreate .env");
+});

--- a/skills/interview-coach/SKILL.md
+++ b/skills/interview-coach/SKILL.md
@@ -7,6 +7,10 @@ description: High-rigor interview coaching skill for job seekers. Use when someo
 
 You are an expert interview coach. You combine coaching-informed delivery with rigorous, evidence-based feedback.
 
+## Repo location
+
+The tool is installed at `~/.ai-job-searcher/` (fixed path, RFC 048). All file paths in this document (including `profiles/<id>/...`, `references/...`) resolve from there. Before running any Bash command, `cd ~/.ai-job-searcher`. If `~/.ai-job-searcher/` does not exist, tell the user: in a fresh Claude Code chat say "install job-searcher from https://github.com/ymuromcev/ai-job-searcher".
+
 ## Profile Resolution
 
 This skill runs inside the multi-profile `ai-job-searcher/` repo. Every reference to `coaching_state.md` in this document resolves to **`profiles/<id>/interview-coach-state/coaching_state.md`**, where `<id>` is the active candidate profile.

--- a/skills/job-pipeline/SKILL.md
+++ b/skills/job-pipeline/SKILL.md
@@ -21,6 +21,21 @@ If no mode is specified, show this help and ask which to run.
 
 ---
 
+## Repo location
+
+The tool is installed at `~/.ai-job-searcher/` (fixed path, RFC 048).
+**Run every Bash command in this skill from `~/.ai-job-searcher/`.**
+Either `cd ~/.ai-job-searcher` once at the start of execution, or
+prefix each command with `cd ~/.ai-job-searcher && ...`. All relative
+paths in this document (`data/`, `profiles/`, `engine/`, `scripts/`)
+resolve from there.
+
+If `~/.ai-job-searcher/` does not exist, the tool is not installed.
+Tell the user: in a fresh Claude Code chat say "install job-searcher
+from https://github.com/ymuromcev/ai-job-searcher".
+
+---
+
 ## Required context per session
 
 Before running any command, verify:
@@ -31,7 +46,7 @@ Before running any command, verify:
    - **Session-sticky**: once a non-default profile is resolved in a session, keep using it for subsequent commands in the same session. Switch back to `jared` only on an explicit phrase like "switch to Jared" / "для Джареда".
    - **Ask only when ambiguous**: if the phrase mentions a name that doesn't match any profile dir, ask once (list valid profiles), then stick.
    - Always pass the resolved id to the CLI via `--profile <id>`.
-2. **Working directory** = `ai-job-searcher/` (public repo clone at `~/Desktop/Claude Code/ai-job-searcher/`). All commands resolve `data/` and `profiles/` relative to cwd.
+2. **Working directory** — see Repo location section above.
 3. **Secrets in env**. For profile `<id>`, the CLI reads `<ID_UPPER>_*` env vars only:
    - `JARED_NOTION_TOKEN` (required for sync)
    - `JARED_USAJOBS_API_KEY`, `JARED_USAJOBS_EMAIL` (required if discovery:usajobs is enabled)

--- a/skills/onboard-profile/SKILL.md
+++ b/skills/onboard-profile/SKILL.md
@@ -11,10 +11,25 @@ You ask one block of questions at a time, write the answers to
 the session drops), and at the end you run the deploy scripts that
 actually provision the profile.
 
-**You drive the conversation.** The user clones the repo, types `claude`,
-and says "onboard me as profile bob" (or just "onboard me" — then you
-ask for the id). They never edit a file by hand. They never paste
-tokens into chat.
+**You drive the conversation.** The user opens Claude Code, types
+"onboard me as profile bob" (or just "onboard me" — then you ask for
+the id), and answers your questions. They never edit a file by hand.
+They never paste tokens into chat.
+
+---
+
+## Repo location
+
+The tool is installed at `~/.ai-job-searcher/` (fixed path, RFC 048).
+**Run every Bash command in this skill from `~/.ai-job-searcher/`.**
+Either `cd ~/.ai-job-searcher` once at the start of execution, or prefix
+each command with `cd ~/.ai-job-searcher && ...`. All relative paths in
+this document (`profiles/<id>/...`, `engine/cli.js`, `scripts/stage18/...`)
+resolve from there.
+
+If `~/.ai-job-searcher/` does not exist when you start, the tool is
+not installed. Tell the user to run, in a fresh Claude Code chat:
+"install job-searcher from https://github.com/ymuromcev/ai-job-searcher".
 
 ---
 


### PR DESCRIPTION
## Summary

- One-line install: user opens Claude Code, says "install job-searcher from <github URL>", Claude runs `npx -y github:ymuromcev/ai-job-searcher install`. Installer clones into `~/.ai-job-searcher/`, symlinks the 3 skills into `~/.claude/skills/`, prints restart-required message.
- Closes [BL-4](../private/backlog/BL-4-onboarding-ux-rewrite-fidbek-davida.md) → spawned [BL-137](../private/backlog/BL-137.md). RFC 048 accepted 2026-05-27 (D1 symlink, D2 hardcode `~/.ai-job-searcher/`, D3 distribute via `npx github:...` not npm registry).
- Code-review subagent on diff: 2 P0 + 4 P1 + 4 P2 findings; P0 + P1 fixed before commit.

## Why

Live smoke 2026-05-27 (David Shekunts) showed README's `git clone → npm install → /onboard-profile` failed with `Unknown command: /onboard-profile` — Claude Code does not auto-discover skills from `skills/<name>/SKILL.md` in repo root. Skills must live under `~/.claude/skills/`, and the repo had no way to put them there. The fallback "ask Claude to install" path also failed because the model had no canonical recipe.

## Test plan

- [x] 37 unit tests in `scripts/install.test.js` cover preflight (Node version, platform), state detection (fresh / update / conflict), symlink planning (create / noop / backup-then-create with collision-safe suffix), cwd detection, env file seeding (fresh-only).
- [x] Full `npm test`: 1871/1871 pass.
- [ ] Live smoke: David retries on a fresh machine via the one-sentence README path.