### PR TITLE
feat(check): BL-154 / RFC 055 — additive Notion→TSV reconcile + check pre-hook

### DIFF
--- a/docs/runbooks/gmail-cron.md
+++ b/docs/runbooks/gmail-cron.md
@@ -223,10 +223,17 @@ invariant — keep it that way.
 
 ### State sync between Mac and fly.io
 
-Two parallel state stores exist (Mac local + fly.io volume). They're
-deliberately not auto-synced. Notion is the source of truth for status;
-each side's `processed_messages.json` prevents re-processing on its own
-side.
+Two parallel state stores exist (Mac local + fly.io volume). Notion is
+the source of truth for status; each side's `processed_messages.json`
+prevents re-processing on its own side.
+
+Since RFC 055, `check` runs the auto-sync pre-hook (like `scan` /
+`prepare`): it pulls Notion -> TSV **additively** before reading the
+local TSV, creating rows for any Notion application the local TSV did
+not list. So the fly volume's `applications.tsv` is no longer a frozen
+copy -- every tick it reconstructs the full active set from Notion and
+the cron tracks every applied job, not just the ones present at deploy
+time. Pass `--no-sync` to skip the pull (e.g. offline debugging).
 
 If one side processes the same email the other side already saw, you
 get one extra Notion comment. Status itself is idempotent.

--- a/engine/cli.js
+++ b/engine/cli.js
@@ -302,6 +302,19 @@ async function runCli({ argv, env = process.env, stdout, stderr, commands } = {}
         c.stderr(`warn: auto-sync failed: ${e.message}`);
       }
     },
+    // RFC 055 (Change A): the fly.io cron runs `check --auto --apply` daily
+    // and builds its Gmail search from the local TSV. Without a pull, that
+    // TSV is stale (new apps are created on the operator's Mac + Notion,
+    // never on the fly volume). Auto-sync before check so the now-additive
+    // reconcilePull lands the full active set before check reads the TSV.
+    check: async (c, h) => {
+      if (c.flags.noSync) return;
+      try {
+        await runAutoSync(c.profileId, c, h);
+      } catch (e) {
+        c.stderr(`warn: auto-sync failed: ${e.message}`);
+      }
+    },
   };
 
   try {

--- a/engine/cli.test.js
+++ b/engine/cli.test.js
@@ -341,6 +341,71 @@ test("prepare --no-sync skips the auto-sync hook", async () => {
   assert.equal(syncCalls.length, 0);
 });
 
+test("check pre-hook auto-triggers sync (RFC 055)", async () => {
+  // RFC 055: the fly.io cron runs `check --auto --apply` daily. Auto-sync
+  // first so the (now additive) pull lands the full active set before
+  // check reads the TSV.
+  const s = makeStreams();
+  const syncCalls = [];
+  const callOrder = [];
+  const code = await runCli({
+    argv: ["check", "--profile", "jared", "--auto", "--apply"],
+    stdout: s.stdout,
+    stderr: s.stderr,
+    commands: {
+      check: spyCommand(() => {
+        callOrder.push("check");
+        return 0;
+      }),
+      sync: async (ctx) => {
+        callOrder.push("sync");
+        syncCalls.push(ctx);
+        return 0;
+      },
+    },
+  });
+  assert.equal(code, 0);
+  assert.equal(syncCalls.length, 1);
+  assert.equal(syncCalls[0].flags.apply, true);
+  assert.deepEqual(callOrder, ["sync", "check"]);
+});
+
+test("check --no-sync skips the auto-sync hook (RFC 055)", async () => {
+  const s = makeStreams();
+  const syncCalls = [];
+  const code = await runCli({
+    argv: ["check", "--profile", "jared", "--no-sync"],
+    stdout: s.stdout,
+    stderr: s.stderr,
+    commands: {
+      check: spyCommand(() => 0),
+      sync: async (ctx) => {
+        syncCalls.push(ctx);
+        return 0;
+      },
+    },
+  });
+  assert.equal(code, 0);
+  assert.equal(syncCalls.length, 0);
+});
+
+test("check hook: sync failure is non-fatal — check still exits 0 (RFC 055)", async () => {
+  const s = makeStreams();
+  const code = await runCli({
+    argv: ["check", "--profile", "jared"],
+    stdout: s.stdout,
+    stderr: s.stderr,
+    commands: {
+      check: spyCommand(() => 0),
+      sync: async () => {
+        throw new Error("no token");
+      },
+    },
+  });
+  assert.equal(code, 0);
+  assert.match(s.err(), /auto-sync failed/);
+});
+
 test("runCli passes prepare-specific flags to handler", async () => {
   const s = makeStreams();
   const prepare = spyCommand(() => 0);

--- a/engine/commands/sync.js
+++ b/engine/commands/sync.js
@@ -48,7 +48,19 @@ const DEFAULT_DEPS = {
   },
 };
 
-function reconcilePull(apps, notionPages, propertyMap) {
+// Reconcile Notion → local TSV. Pure: no I/O, no Date.now(). `now` (ISO
+// string) is passed in so added rows get deterministic createdAt/updatedAt.
+//
+// Returns { updates, adds }:
+//   updates — { before, after } pairs for existing local rows whose
+//             notion_page_id / status drifted from Notion (Notion wins).
+//   adds    — full TSV row objects for Notion pages with NO matching local
+//             row. This makes the pull additive: the fly.io cron's stale
+//             TSV picks up apps created on the operator's Mac (RFC 055).
+//
+// Idempotent: on a rerun the previously-added rows now exist locally, so
+// they match in the update pass and never re-appear in `adds`.
+function reconcilePull(apps, notionPages, propertyMap, now) {
   // Notion is source of truth for status (and notion_page_id, naturally).
   // We match by `key` field if present in the Notion property map; otherwise
   // by composite (source, jobId).
@@ -56,21 +68,27 @@ function reconcilePull(apps, notionPages, propertyMap) {
   const sourceField = propertyMap.source && propertyMap.source.field;
   const jobIdField = propertyMap.jobId && propertyMap.jobId.field;
 
-  const byKey = new Map();
-  for (const page of notionPages) {
+  const matchKeyFor = (page) => {
     const k = keyField ? page.key : null;
     const composite =
       sourceField && jobIdField && page.source && page.jobId
         ? `${String(page.source).toLowerCase()}:${page.jobId}`
         : null;
-    const matchKey = k || composite;
+    return k || composite;
+  };
+
+  const byKey = new Map();
+  for (const page of notionPages) {
+    const matchKey = matchKeyFor(page);
     if (matchKey) byKey.set(matchKey, page);
   }
 
   const updates = [];
+  const consumed = new Set();
   for (const app of apps) {
     const page = byKey.get(app.key);
     if (!page) continue;
+    consumed.add(app.key);
     const next = { ...app };
     let changed = false;
     if (page.notionPageId && app.notion_page_id !== page.notionPageId) {
@@ -83,7 +101,38 @@ function reconcilePull(apps, notionPages, propertyMap) {
     }
     if (changed) updates.push({ before: app, after: next });
   }
-  return updates;
+
+  // Any Notion page whose matchKey was not consumed by an existing local row
+  // becomes an add. Build a full v5 TSV row so save() round-trips cleanly.
+  const adds = [];
+  for (const [matchKey, page] of byKey) {
+    if (consumed.has(matchKey)) continue;
+    const source = page.source ? String(page.source) : "notion";
+    adds.push({
+      key: matchKey,
+      source,
+      jobId: page.jobId || "",
+      companyName: page.companyName || "",
+      title: page.title || "",
+      url: page.url || "",
+      locations: Array.isArray(page.locations) ? page.locations.map(String) : [],
+      status: page.status || "",
+      notion_page_id: page.notionPageId || "",
+      resume_ver: "",
+      cl_key: "",
+      salary_min: "",
+      salary_max: "",
+      cl_path: "",
+      createdAt: now,
+      updatedAt: now,
+      fit_score: "",
+      fit_rationale: "",
+      fit_evaluated_at: "",
+      skip_reason: "",
+    });
+  }
+
+  return { updates, adds };
 }
 
 function makeSyncCommand(overrides = {}) {
@@ -124,18 +173,26 @@ function makeSyncCommand(overrides = {}) {
 
     // PULL phase always runs (read-only against Notion) so users see what
     // Notion state will land locally, whether they passed --apply or not.
-    let pulled = [];
+    let updates = [];
+    let adds = [];
     let pullErrors = 0;
     try {
       const pages = await deps.fetchJobsFromDatabase(getClient(), databaseId, propertyMap);
-      pulled = reconcilePull(apps, pages, propertyMap);
-      stdout(`pull plan: ${pulled.length} local row(s) would change from Notion state`);
-      for (const u of pulled.slice(0, 10)) {
+      ({ updates, adds } = reconcilePull(apps, pages, propertyMap, deps.now()));
+      stdout(
+        `pull plan: ${updates.length} local row(s) would change from Notion state, ` +
+          `${adds.length} new row(s) would be added`
+      );
+      for (const u of updates.slice(0, 10)) {
         stdout(
           `  pull: ${u.before.key} | status ${u.before.status || "(none)"} → ${u.after.status || "(none)"}`
         );
       }
-      if (pulled.length > 10) stdout(`  … and ${pulled.length - 10} more`);
+      if (updates.length > 10) stdout(`  … and ${updates.length - 10} more`);
+      for (const a of adds.slice(0, 10)) {
+        stdout(`  add: ${a.key} | status ${a.status || "(none)"}`);
+      }
+      if (adds.length > 10) stdout(`  … and ${adds.length - 10} more`);
     } catch (err) {
       pullErrors += 1;
       ctx.stderr(`  pull error: ${err.message}`);
@@ -146,16 +203,20 @@ function makeSyncCommand(overrides = {}) {
       return pullErrors > 0 ? 1 : 0;
     }
 
-    // Apply pull updates into the keyed map, then save once.
-    for (const u of pulled) {
+    // Apply pull updates + adds into the keyed map, then save once.
+    for (const u of updates) {
       byKey.set(u.before.key, { ...u.after, updatedAt: deps.now() });
     }
-    if (pulled.length) {
+    for (const row of adds) {
+      byKey.set(row.key, row);
+    }
+    const changedCount = updates.length + adds.length;
+    if (changedCount) {
       const merged = Array.from(byKey.values());
       deps.saveApplications(applicationsPath, merged);
       stdout(
         `saved ${merged.length} applications to ${applicationsPath} ` +
-          `(${pulled.length} updated from Notion)`
+          `(${updates.length} updated from Notion, ${adds.length} added)`
       );
     }
 

--- a/engine/commands/sync.test.js
+++ b/engine/commands/sync.test.js
@@ -130,6 +130,50 @@ test("sync --apply applies pull updates from Notion (status wins)", async () => 
   assert.match(out.all(), /status To Apply → Applied/);
 });
 
+test("sync --apply adds a new row for a Notion page with no local match (RFC 055)", async () => {
+  const saved = [];
+  const { deps } = makeDeps({
+    loadApplications: () => ({ apps: [fakeApp({ jobId: "1" })] }),
+    saveApplications: (file, apps) => saved.push({ file, apps }),
+    fetchJobsFromDatabase: async () => [
+      {
+        notionPageId: "p2",
+        key: "lever:abc",
+        source: "lever",
+        jobId: "abc",
+        companyName: "Stripe",
+        title: "Senior PM",
+        status: "Interview",
+      },
+    ],
+  });
+  const { ctx, out } = makeCtx({ flags: { dryRun: false, apply: true, verbose: false } });
+  const code = await makeSyncCommand(deps)(ctx);
+  assert.equal(code, 0);
+  assert.equal(saved.length, 1);
+  const addedRow = saved[0].apps.find((a) => a.key === "lever:abc");
+  assert.ok(addedRow, "added row is persisted");
+  assert.equal(addedRow.notion_page_id, "p2");
+  assert.equal(addedRow.status, "Interview");
+  assert.match(out.all(), /1 added/);
+});
+
+test("sync dry-run reports add count but does not save (RFC 055)", async () => {
+  const { deps, calls } = makeDeps({
+    loadApplications: () => ({ apps: [] }),
+    fetchJobsFromDatabase: async () => [
+      { notionPageId: "p2", key: "lever:abc", source: "lever", jobId: "abc", status: "Applied" },
+    ],
+  });
+  const { ctx, out } = makeCtx(); // dry-run by default
+  const code = await makeSyncCommand(deps)(ctx);
+  assert.equal(code, 0);
+  assert.equal(calls.saveApplications.length, 0, "dry-run must not write");
+  assert.match(out.all(), /1 new row\(s\) would be added/);
+  assert.match(out.all(), /add: lever:abc/);
+  assert.match(out.all(), /\(dry-run/);
+});
+
 test("sync --apply with no pull changes does not save TSV", async () => {
   const { deps, calls } = makeDeps();
   const { ctx } = makeCtx({ flags: { dryRun: false, apply: true, verbose: false } });
@@ -192,6 +236,8 @@ test("sync exits 1 on pull failure", async () => {
   assert.match(out.all(), /pull error.*notion 502/);
 });
 
+const NOW = "2026-04-20T00:00:00Z";
+
 test("reconcilePull matches by key and reports status changes", () => {
   const apps = [
     fakeApp({ key: "greenhouse:1", jobId: "1", status: "To Apply", notion_page_id: "" }),
@@ -201,10 +247,81 @@ test("reconcilePull matches by key and reports status changes", () => {
     { notionPageId: "p1", key: "greenhouse:1", status: "Applied" },
     { notionPageId: "p2", key: "greenhouse:2", status: "Applied" }, // no change
   ];
-  const updates = reconcilePull(apps, pages, DEFAULT_PROPERTY_MAP);
+  const { updates, adds } = reconcilePull(apps, pages, DEFAULT_PROPERTY_MAP, NOW);
   assert.equal(updates.length, 1);
   assert.equal(updates[0].after.notion_page_id, "p1");
   assert.equal(updates[0].after.status, "Applied");
+  assert.equal(adds.length, 0, "all pages matched existing rows → no adds");
+});
+
+test("reconcilePull adds a Notion page with no matching local row (RFC 055)", () => {
+  const apps = [fakeApp({ key: "greenhouse:1", jobId: "1" })];
+  const pages = [
+    { notionPageId: "p1", key: "greenhouse:1", status: "Applied" }, // existing → update
+    {
+      notionPageId: "p2",
+      key: "lever:abc",
+      source: "lever",
+      jobId: "abc",
+      companyName: "Stripe",
+      title: "Senior PM",
+      url: "https://x/abc",
+      status: "Interview",
+    },
+  ];
+  const { updates, adds } = reconcilePull(apps, pages, DEFAULT_PROPERTY_MAP, NOW);
+  assert.equal(updates.length, 1);
+  assert.equal(adds.length, 1);
+  const row = adds[0];
+  assert.equal(row.key, "lever:abc");
+  assert.equal(row.notion_page_id, "p2");
+  assert.equal(row.status, "Interview");
+  assert.equal(row.companyName, "Stripe");
+  assert.equal(row.title, "Senior PM");
+  assert.equal(row.source, "lever");
+  assert.equal(row.jobId, "abc");
+  assert.equal(row.url, "https://x/abc");
+  assert.deepEqual(row.locations, []);
+  assert.equal(row.createdAt, NOW);
+  assert.equal(row.updatedAt, NOW);
+  // Empties for fields Notion doesn't supply.
+  assert.equal(row.resume_ver, "");
+  assert.equal(row.cl_key, "");
+  assert.equal(row.salary_min, "");
+  assert.equal(row.fit_score, "");
+  assert.equal(row.skip_reason, "");
+});
+
+test("reconcilePull defaults source to 'notion' when the page has none", () => {
+  const apps = [];
+  const pages = [{ notionPageId: "p9", key: "manual-entry", status: "Applied" }];
+  const { adds } = reconcilePull(apps, pages, DEFAULT_PROPERTY_MAP, NOW);
+  assert.equal(adds.length, 1);
+  assert.equal(adds[0].source, "notion");
+  assert.equal(adds[0].key, "manual-entry");
+});
+
+test("reconcilePull is idempotent: a previously-added row is not re-added", () => {
+  const page = {
+    notionPageId: "p2",
+    key: "lever:abc",
+    source: "lever",
+    jobId: "abc",
+    companyName: "Stripe",
+    title: "Senior PM",
+    status: "Interview",
+  };
+  // First pass: row does not exist locally → add.
+  const firstApps = [fakeApp({ key: "greenhouse:1", jobId: "1" })];
+  const first = reconcilePull(firstApps, [page], DEFAULT_PROPERTY_MAP, NOW);
+  assert.equal(first.adds.length, 1);
+
+  // Simulate the saved state: the added row is now part of the local TSV.
+  const secondApps = firstApps.concat([first.adds[0]]);
+  const second = reconcilePull(secondApps, [page], DEFAULT_PROPERTY_MAP, NOW);
+  assert.equal(second.adds.length, 0, "no duplicate add on rerun");
+  // Status already matches → no spurious update either.
+  assert.equal(second.updates.length, 0);
 });
 
 // ---------- hub callout update ----------

--- a/rfc/055-cron-tsv-sync-and-success-heartbeat.md
+++ b/rfc/055-cron-tsv-sync-and-success-heartbeat.md
@@ -1,0 +1,168 @@
+# RFC 055 — Cron TSV freshness + success heartbeat
+
+- Status: **proposed**
+- Date: 2026-05-29
+- Refs: BL-154, BL-155, RFC 054 (auto-sync + archive), RFC 021 (gmail cron IMAP), RFC 005 (cron autonomous check + failure notify), RFC 014 (status split)
+- Tier: M
+
+## Problem
+
+Operator-reported (2026-05-29): "rejections show up in Gmail but Notion
+gets only one comment per day, and Notion only ever logs the cron when a
+run *fails*."
+
+Two distinct root causes, both in the fly.io `check --auto` cron path.
+
+### P1 — the cron tracks a stale, divergent copy of the application set
+
+`check --auto` builds its Gmail search from `buildActiveJobsMap(apps)`
+([check.js:181](../engine/commands/check.js)), where `apps` is read from
+the fly volume's `profiles/<id>/applications.tsv`. Only companies with an
+active row (`status ∈ {To Apply, Applied, Interview, Offer}` **and** a
+`notion_page_id`) get searched. A rejection email from a company that
+isn't in that map is never even fetched → no Notion comment.
+
+That TSV on the fly volume is effectively frozen:
+
+- New applications are created by `prepare` **on the Mac** (the commit
+  phase needs the LLM skill; it never runs on fly). They land in the Mac
+  TSV + Notion, never on the fly volume.
+- The fly box only ever runs `check`, which writes back status updates
+  for emails it *already matched* plus recruiter/linkedin Inbox rows.
+- RFC 054's auto-sync pre-hook is wired to `scan` and `prepare` only
+  ([cli.js:288](../engine/cli.js)). `check` has no pre-hook, so the fly
+  TSV never reconciles against Notion.
+- Even if `check` *did* run auto-sync, `reconcilePull`
+  ([sync.js:71](../engine/commands/sync.js)) iterates over **existing**
+  TSV rows and only updates `status` / `notion_page_id`. It never adds a
+  Notion page that has no local row. So a freshly-seeded or stale fly TSV
+  cannot learn about applications it doesn't already list.
+
+Net effect: the fly TSV's active set ≈ whatever was active when the
+volume was last seeded (~2026-05-12 deploy), decaying as `check` marks a
+few Rejected. Local active-with-notion counts on 2026-05-29: **jared 383,
+lilia 85** — the fly box tracks a small fraction of these. This is the
+same silent-staleness failure class as the Indeed ingest-file incident
+(incidents.md, 2026-05-23).
+
+### P2 — Notion only hears about the cron on failure
+
+`runAuto` → `notifyFailure` posts an @-mention comment to
+`notion.cron_ops_page_id` **only when the run throws**
+([check.js:144](../engine/commands/check.js)). A successful run writes its
+summary to stdout (→ fly logs, short-lived) and `email_check_log.md` on
+the volume — nothing in Notion. The operator has no Notion-visible signal
+that the cron ran at all on a normal day, so a silently-broken cron looks
+identical to a quiet inbox.
+
+## Approach
+
+Two independent changes, landing as two PRs under this RFC.
+
+### Change A (P1) — additive reconcile + `check` pre-hook
+
+1. **Make `reconcilePull` additive.** After the existing update pass over
+   local rows, append a new TSV row for every Notion page that matched no
+   local row, carrying `notion_page_id`, `status`, company, title, and
+   the composite/`key` identity used for matching. Source defaults to a
+   sentinel (`"notion"`) when the page has no `source` field. New rows
+   get `createdAt`/`updatedAt = now`. This makes a `sync --apply` (and
+   therefore auto-sync) reconstruct the full active set from Notion, not
+   just refresh known rows.
+
+2. **Add `check` to `PIPELINE_PRE_HOOKS`** ([cli.js:288](../engine/cli.js))
+   with the same `--no-sync` opt-out and non-fatal error semantics as
+   `scan`/`prepare`. Now every cron tick: pull Notion → TSV (additive) →
+   build `activeJobsMap` over the *full* active set → search Gmail.
+
+Order matters: the pre-hook runs before `runAuto` reads the TSV, so the
+same process sees the freshly-reconciled rows.
+
+Consequence (intended): `scan`/`prepare` also gain additive reconcile.
+This is desirable — a fresh checkout or a new machine rebuilds its TSV
+from Notion instead of starting blind. The archive sweep already tolerates
+rows it doesn't recognise.
+
+### Change B (P2) — success heartbeat to the ops page
+
+Add `notifySuccess({ profile, profileId, summary, now, ... })`, a sibling
+of `notifyFailure`. On a successful `--auto --apply` run (both the
+zero-new-emails early return and the post-`applyMutations` path), post a
+**plain comment (no @-mention)** to `cron_ops_page_id`:
+
+```
+🟢 [2026-05-29T08:00:12Z] check jared — emails: 12, matched: 4,
+   → Rejected: 2, → Interview: 1, → Closed: 0, info: 1,
+   inbox: 0, notion errors: 0
+```
+
+- No @-mention → no push notification (failures keep the @-mention +
+  push). Avoids daily notification fatigue while leaving a durable trail.
+- Posted even on a zero-email day (`emails: 0`) so a missing heartbeat
+  means "cron didn't run", not "quiet inbox".
+- Best-effort and swallowed, exactly like `notifyFailure`: a heartbeat
+  post failure never changes the run's exit code.
+- Scoped to `--auto` (the cron path). `--apply`/`--prepare` manual phases
+  are unchanged.
+
+## Why not alternatives
+
+- **`check` builds `activeJobsMap` directly from Notion** (skip the TSV):
+  decouples cron from TSV freshness entirely, but duplicates the
+  Notion-read + property-map logic that already lives in `sync`, and
+  changes `check`'s data source in a way that complicates the manual
+  `--prepare`/`--apply` two-phase flow. Reusing the existing additive
+  reconcile is smaller and keeps one Notion-read path.
+- **Operationally copy the Mac TSV to the volume**: fragile, manual, and
+  exactly the "operator must remember" pattern that caused the Indeed
+  staleness incident.
+- **Success @-mention**: rejected for notification fatigue.
+
+## Test plan
+
+Change A:
+
+- `reconcilePull`: unit test — Notion page with no matching local row →
+  produces an add (new row with `notion_page_id`, status, company,
+  title); existing-row update path unchanged; idempotent on a second run
+  (no duplicate add).
+- `cli.js`: `check` pre-hook fires unless `--no-sync`; auto-sync throw is
+  non-fatal (warn + proceed); `check --auto` after reconcile sees the new
+  rows in `activeJobsMap` (integration test with faked sync handler +
+  faked Gmail fetch).
+
+Change B:
+
+- `notifySuccess`: posts a no-mention comment when `cron_ops_page_id` is
+  set; skips quietly when it's absent or `NOTION_TOKEN` missing; a thrown
+  post is swallowed and the run still returns 0.
+- `runAuto` success path (zero-email and post-apply) both call
+  `notifySuccess` exactly once; failure path still calls `notifyFailure`
+  and not `notifySuccess`.
+
+All network mocked (no real Gmail/Notion). Smoke: `npm test` green.
+
+## NOT in scope
+
+- Changing the classifier, the Gmail batch construction, or the
+  failure-comment format.
+- A push-channel for success (Notion comment only).
+- Syncing the two state stores (Mac ↔ fly) wholesale — Notion stays the
+  source of truth; additive reconcile is the bridge.
+- Re-adding a Notion *push* path from `sync` (RFC 054 removed it; pages
+  are still created only by `prepare` commit).
+
+## Rollout
+
+1. Land Change A, redeploy fly (`scripts/deploy_fly.sh`), confirm next
+   tick's `email_check_log.md` shows matched rejections for recent
+   applications.
+2. Land Change B, redeploy, confirm a 🟢 heartbeat comment lands on each
+   profile's `cron_ops_page_id`.
+
+Operator verification one-liner (from a shell whose 6pn tunnel works):
+
+```
+fly ssh console -a ai-job-searcher-cron --command \
+  'tail -40 /data/profiles/jared/email_check_log.md'
+```


### PR DESCRIPTION
## Summary
- Fixes the cron under-reporting bug: `check --auto` searched Gmail only for companies in the fly-volume TSV, which was a stale/divergent copy. Recent applications (created by `prepare` on the Mac + Notion) were never on the fly TSV → their rejection emails were never fetched → ~one Notion comment per day.
- `reconcilePull` is now **additive**: returns `{ updates, adds }` and builds full v5 TSV rows for Notion pages with no matching local row. Pure (`now` injected), idempotent (a re-run matches the now-existing row, no duplicate).
- `check` added to `PIPELINE_PRE_HOOKS` (mirrors `scan`/`prepare`): pulls Notion→TSV additively before reading the TSV, so `activeJobsMap` covers the full active set. `--no-sync` opts out; sync failure is non-fatal.
- Side effect (intended): `scan`/`prepare` also gain additive reconcile — a fresh checkout / new machine rebuilds its TSV from Notion.

See [RFC 055](rfc/055-cron-tsv-sync-and-success-heartbeat.md). Change B (success heartbeat, BL-155) follows in a separate PR.

## Test plan
- [x] `npm test` — 1957 pass, 0 fail
- [x] reconcilePull: add for unmatched page (correct v5 fields), `source` defaults to `notion`, idempotent on rerun, `--apply` persists, dry-run reports without saving
- [x] cli: `check` fires pre-hook unless `--no-sync`; sync throw non-fatal (check still exits 0)
- [ ] Operator: redeploy fly, confirm next tick's `email_check_log.md` matches rejections for recent apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)