### PR TITLE
feat(check): BL-155 / RFC 055 — cron success heartbeat to Notion

### DIFF
--- a/engine/commands/check.js
+++ b/engine/commands/check.js
@@ -141,6 +141,70 @@ function buildFailureComment(profileId, err, now) {
   );
 }
 
+// ---------- Success heartbeat (Phase 3 / RFC 055 Change B) ----------
+//
+// Best-effort: post a plain (NO @-mention) Notion comment to the per-profile
+// cron_ops_page_id on every successful --auto --apply run, including zero-email
+// days. This gives Notion a visible heartbeat so a SILENTLY broken cron (no
+// heartbeat) is distinguishable from a quiet inbox (heartbeat with all zeros).
+// No @-mention because a daily success ping should not push-notify anyone.
+// Post failure is swallowed — a heartbeat must never change the run's exit code.
+
+function buildSuccessComment(profileId, c, now) {
+  const ts = now.toISOString();
+  return (
+    `🟢 [${ts}] check ${profileId} — ` +
+    `emails: ${c.emails}, matched: ${c.matched}, ` +
+    `→ Rejected: ${c.rejected}, → Interview: ${c.interview}, → Closed: ${c.closed}, ` +
+    `info: ${c.info}, inbox: ${c.inbox}, notion errors: ${c.notionErrors}`
+  );
+}
+
+async function notifySuccess({ profile, profileId, summaryCounts, now, env, deps, stderr }) {
+  const opsPageId = profile && profile.notion && profile.notion.cron_ops_page_id;
+  if (!opsPageId) {
+    stderr("  no cron_ops_page_id in profile.json — Notion heartbeat skipped");
+    return;
+  }
+
+  const secrets = deps.loadSecrets(profileId, env);
+  const token = secrets && secrets.NOTION_TOKEN;
+  if (!token) {
+    stderr(`  no ${secretEnvName(profileId, "NOTION_TOKEN")} in env — Notion heartbeat skipped`);
+    return;
+  }
+
+  try {
+    const client = deps.makeClient(token);
+    const text = buildSuccessComment(profileId, summaryCounts, now);
+    // null userId → plain comment, no @-mention / push (notion_sync.addPageComment).
+    await deps.addPageComment(client, opsPageId, text, null);
+  } catch (notifyErr) {
+    // Swallow — a heartbeat-post failure must never affect the run.
+    stderr(`  success heartbeat post failed: ${notifyErr.message}`);
+  }
+}
+
+// Derive per-status heartbeat counts from the run's actions + tallies.
+function buildSuccessCounts({ emails, matched, actions, inbox, notionErrors }) {
+  let rejected = 0;
+  let interview = 0;
+  let closed = 0;
+  let info = 0;
+  for (const a of actions || []) {
+    if (a.kind === "comment_only") {
+      info += 1;
+    } else if (a.newStatus === "Rejected") {
+      rejected += 1;
+    } else if (a.newStatus === "Interview") {
+      interview += 1;
+    } else if (a.newStatus === "Closed") {
+      closed += 1;
+    }
+  }
+  return { emails, matched, rejected, interview, closed, info, inbox, notionErrors };
+}
+
 async function notifyFailure({ profile, profileId, paths, err, now, env, deps, stderr }) {
   // Always write to disk first — that's the durable signal.
   try {
@@ -939,6 +1003,23 @@ async function runAutoBody(ctx, deps, profile, paths) {
     if (flags.apply) {
       // Bump last_check even with zero new emails — cursor advances.
       deps.saveProcessed(paths.processedPath, saved, [], now);
+      // Heartbeat MUST post on zero-email days too — a missing heartbeat is
+      // the signal that the cron didn't run at all.
+      await notifySuccess({
+        profile,
+        profileId,
+        summaryCounts: buildSuccessCounts({
+          emails: 0,
+          matched: 0,
+          actions: [],
+          inbox: 0,
+          notionErrors: 0,
+        }),
+        now,
+        env,
+        deps,
+        stderr,
+      });
     }
     return 0;
   }
@@ -969,6 +1050,22 @@ async function runAutoBody(ctx, deps, profile, paths) {
     stderr,
   });
   if (!result.ok) return 1;
+
+  await notifySuccess({
+    profile,
+    profileId,
+    summaryCounts: buildSuccessCounts({
+      emails: newEmails.length,
+      matched: logRows.filter((r) => r.match !== "NONE").length,
+      actions,
+      inbox: state.newInboxRows.length,
+      notionErrors: result.notionErrors,
+    }),
+    now,
+    env,
+    deps,
+    stderr,
+  });
 
   stdout(
     `applied: ${actions.length - result.notionErrors} Notion ops, ${state.newInboxRows.length} Inbox rows, ${rejections.length} rejections${
@@ -1005,3 +1102,5 @@ module.exports.buildPipelineState = buildPipelineState;
 module.exports.ACTIVE_STATUSES = ACTIVE_STATUSES;
 module.exports.SKIP_STATUSES = SKIP_STATUSES;
 module.exports.DEFAULT_PROPERTY_MAP = DEFAULT_PROPERTY_MAP;
+module.exports.buildSuccessComment = buildSuccessComment;
+module.exports.buildSuccessCounts = buildSuccessCounts;

--- a/engine/commands/check.test.js
+++ b/engine/commands/check.test.js
@@ -10,6 +10,8 @@ const {
   processPipeline,
   processEmailsLoop,
   buildPipelineState,
+  buildSuccessComment,
+  buildSuccessCounts,
 } = require("./check.js");
 
 function captureOut() {
@@ -1016,6 +1018,150 @@ test("check --auto: addPageComment throws → swallowed, log still written, retu
   // Original error visible in stderr; notion-post failure doesn't mask it.
   assert.match(out.errs.join("\n"), /primary failure/);
   assert.match(out.errs.join("\n"), /failure notification post failed/);
+});
+
+// ---------- Change B: success heartbeat (RFC 055) ----------
+
+const opsProfile = () => ({
+  id: "jared",
+  paths: {
+    root: "/tmp/profiles/jared",
+    applicationsTsv: "/tmp/profiles/jared/applications.tsv",
+  },
+  filterRules: {},
+  notion: { user_id: "user-123", cron_ops_page_id: "ops-page-uuid" },
+});
+
+test("buildSuccessComment: one-line format with per-status counts", () => {
+  const text = buildSuccessComment(
+    "jared",
+    buildSuccessCounts({
+      emails: 12,
+      matched: 4,
+      actions: [
+        { newStatus: "Rejected" },
+        { newStatus: "Rejected" },
+        { newStatus: "Interview" },
+        { kind: "comment_only" },
+      ],
+      inbox: 0,
+      notionErrors: 0,
+    }),
+    new Date("2026-05-29T08:00:12Z")
+  );
+  assert.equal(
+    text,
+    "🟢 [2026-05-29T08:00:12.000Z] check jared — emails: 12, matched: 4, " +
+      "→ Rejected: 2, → Interview: 1, → Closed: 0, info: 1, inbox: 0, notion errors: 0"
+  );
+});
+
+test("check --auto: zero-email --apply → heartbeat posted, NO @mention", async () => {
+  const { deps, calls } = makeAutoDeps({ loadProfile: opsProfile });
+  const { ctx } = makeCtx({ auto: true, apply: true });
+  const code = await makeCheckCommand(deps)(ctx);
+  assert.equal(code, 0);
+  // Zero emails → no per-action comments; the only comment is the heartbeat.
+  assert.equal(calls.addPageComment.length, 1);
+  const c = calls.addPageComment[0];
+  assert.equal(c.pageId, "ops-page-uuid");
+  assert.match(c.text, /🟢/);
+  assert.match(c.text, /emails: 0/);
+  assert.match(c.text, /notion errors: 0/);
+  // No @-mention on a heartbeat.
+  assert.ok(c.mention === null || c.mention === undefined);
+});
+
+test("check --auto: post-apply success → heartbeat posted exactly once with real counts, NO @mention", async () => {
+  const { deps, calls } = makeAutoDeps({
+    loadProfile: opsProfile,
+    fetchGmailEmails: async () => [
+      {
+        messageId: "m1",
+        from: "no-reply@affirm.com",
+        subject: "An update on your application with Affirm",
+        body: "Unfortunately, we will not be proceeding.",
+        date: "2026-04-30T10:00:00Z",
+      },
+    ],
+  });
+  const { ctx } = makeCtx({ auto: true, apply: true });
+  const code = await makeCheckCommand(deps)(ctx);
+  assert.equal(code, 0);
+  // Two comments: per-action rejection comment (mention=user-123) + heartbeat (no mention).
+  const heartbeats = calls.addPageComment.filter((c) => c.pageId === "ops-page-uuid");
+  assert.equal(heartbeats.length, 1);
+  assert.match(heartbeats[0].text, /🟢/);
+  assert.match(heartbeats[0].text, /emails: 1/);
+  assert.match(heartbeats[0].text, /→ Rejected: 1/);
+  assert.ok(heartbeats[0].mention === null || heartbeats[0].mention === undefined);
+});
+
+test("check --auto: heartbeat skipped quietly when cron_ops_page_id absent", async () => {
+  // makeAutoDeps default profile has user_id but NO cron_ops_page_id.
+  const { deps, calls } = makeAutoDeps();
+  const { ctx, out } = makeCtx({ auto: true, apply: true });
+  const code = await makeCheckCommand(deps)(ctx);
+  assert.equal(code, 0);
+  assert.equal(calls.addPageComment.length, 0);
+  assert.match(out.errs.join("\n"), /Notion heartbeat skipped/);
+});
+
+test("check --auto: heartbeat skipped quietly when NOTION_TOKEN absent", async () => {
+  const { deps, calls } = makeAutoDeps({
+    loadProfile: opsProfile,
+    loadSecrets: () => ({}),
+  });
+  const { ctx, out } = makeCtx({ auto: true, apply: true });
+  const code = await makeCheckCommand(deps)(ctx);
+  assert.equal(code, 0);
+  assert.equal(calls.addPageComment.length, 0);
+  assert.match(out.errs.join("\n"), /Notion heartbeat skipped/);
+});
+
+test("check --auto: heartbeat post throws → swallowed, run still returns 0", async () => {
+  const { deps, calls } = makeAutoDeps({
+    loadProfile: opsProfile,
+    addPageComment: async () => {
+      throw new Error("notion outage");
+    },
+  });
+  const { ctx, out } = makeCtx({ auto: true, apply: true });
+  const code = await makeCheckCommand(deps)(ctx);
+  assert.equal(code, 0);
+  assert.match(out.errs.join("\n"), /success heartbeat post failed/);
+  // No failure-log written — this is a success path, not a failure path.
+  assert.equal(calls.appendFailureLog.length, 0);
+});
+
+test("check --auto --dry-run: no heartbeat posted", async () => {
+  const { deps, calls } = makeAutoDeps({
+    loadProfile: opsProfile,
+    fetchGmailEmails: async () => [
+      { messageId: "m1", from: "no-reply@affirm.com", subject: "bad news", body: "not moving forward" },
+    ],
+  });
+  const { ctx } = makeCtx({ auto: true }); // dry-run (apply defaults false)
+  const code = await makeCheckCommand(deps)(ctx);
+  assert.equal(code, 0);
+  assert.equal(calls.addPageComment.length, 0);
+});
+
+test("check --auto: failure path does NOT post a success heartbeat", async () => {
+  const { deps, calls } = makeAutoDeps({
+    loadProfile: opsProfile,
+    fetchGmailEmails: async () => {
+      throw new Error("invalid_grant");
+    },
+  });
+  const { ctx } = makeCtx({ auto: true, apply: true });
+  const code = await makeCheckCommand(deps)(ctx);
+  assert.equal(code, 1);
+  // Exactly one comment — the failure @mention — and it is NOT a heartbeat.
+  assert.equal(calls.addPageComment.length, 1);
+  assert.match(calls.addPageComment[0].text, /🔴/);
+  assert.doesNotMatch(calls.addPageComment[0].text, /🟢/);
+  assert.equal(calls.appendFailureLog.length, 1);
 });
 
 test("check --auto: appendFailureLog receives error with stack info", async () => {


### PR DESCRIPTION
## Summary
- Notion previously only logged the cron when a run **failed** (`notifyFailure` → @-mention on `cron_ops_page_id`). Successful runs went to stdout + on-disk log only, so a silently broken cron looked identical to a quiet inbox.
- Adds `notifySuccess` (sibling of `notifyFailure`): on every successful `--auto --apply` run — including zero-email days — posts a **plain comment, no @-mention** (no push) with the run summary.
- Best-effort: skips quietly without `cron_ops_page_id`/token; a post failure is swallowed and never changes the exit code. Scoped to the `--auto` flow.

Heartbeat format:
`🟢 [ts] check <id> — emails: N, matched: N, → Rejected: N, → Interview: N, → Closed: N, info: N, inbox: N, notion errors: N`

See [RFC 055](rfc/055-cron-tsv-sync-and-success-heartbeat.md). Builds on PR #45 (Change A); disjoint files (only `check.js`).

## Test plan
- [x] `npm test` — 1957 pass, 0 fail (+8 new in check.test.js)
- [x] posts no-mention comment when ops page set; skips without page-id/token; swallows post error (run still returns 0)
- [x] both success paths (zero-email + post-apply) call it once; failure path does not
- [ ] Operator: redeploy fly, confirm 🟢 heartbeat lands per profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)