### PR TITLE
style: fix check.test.js prettier drift on main (post-#46)

### DIFF
--- a/engine/commands/check.test.js
+++ b/engine/commands/check.test.js
@@ -1138,7 +1138,12 @@ test("check --auto --dry-run: no heartbeat posted", async () => {
   const { deps, calls } = makeAutoDeps({
     loadProfile: opsProfile,
     fetchGmailEmails: async () => [
-      { messageId: "m1", from: "no-reply@affirm.com", subject: "bad news", body: "not moving forward" },
+      {
+        messageId: "m1",
+        from: "no-reply@affirm.com",
+        subject: "bad news",
+        body: "not moving forward",
+      },
     ],
   });
   const { ctx } = makeCtx({ auto: true }); // dry-run (apply defaults false)


### PR DESCRIPTION
PR #46 merged with a red `prettier --check` step (not a required status), so main is format-dirty. This reformats the single affected file so the format check passes on main and future PRs. No logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)