### PR TITLE
feat(check): BL-156 / RFC 056 — --reprocess-since recovery for historical rejection backlog

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -40,7 +40,7 @@ The dispatcher also runs deterministic pre-command hooks (BL-151 / RFC 054). Tod
 
 The `--profile <id>` regex is applied by `engine/core/profile_loader.js` `validateId`. Path traversal is blocked: `profiles/<id>/` must resolve strictly inside the configured profiles dir.
 
-Per-command flags: `--phase <pre|commit|search|push>`, `--results-file <path>`, `--batch <n>`, `--prepare`, `--since <iso>`, `--no-sync`, `--no-callout`, `--auto`, `--company <name>`, `--role <title>`, `--question <text>`. Each is documented under the command that consumes it.
+Per-command flags: `--phase <pre|commit|search|push>`, `--results-file <path>`, `--batch <n>`, `--prepare`, `--since <iso>`, `--reprocess-since <iso>`, `--no-sync`, `--no-callout`, `--auto`, `--company <name>`, `--role <title>`, `--question <text>`. Each is documented under the command that consumes it.
 
 ## Commands
 
@@ -210,7 +210,7 @@ Common errors:
 
 ### check
 
-Synopsis: `node engine/cli.js check --profile <id> [--prepare | --apply | --auto] [--since <iso>] [--dry-run] [--verbose]`
+Synopsis: `node engine/cli.js check --profile <id> [--prepare | --apply | --auto] [--since <iso>] [--reprocess-since <iso>] [--dry-run] [--verbose]`
 
 Two-phase Gmail response polling. Phase 1 (`--prepare`) builds Gmail batch queries and writes `check_context.json` for a Claude MCP session to fetch emails into `raw_emails.json`. Phase 3 (default invocation, with `--apply` to commit) reads `raw_emails.json`, classifies each message (rejection / interview invite / info request / recruiter outreach / LinkedIn alert), matches it to active TSV rows, and plans status transitions and Notion page comments. `--auto` runs the full loop in one process via the OAuth Gmail client.
 
@@ -225,6 +225,7 @@ Flags:
 | `--apply` | boolean | false | Phase 3 commit. Without `--apply`, phase 3 runs in dry-run mode (plan only). |
 | `--auto` | boolean | false | Single-process autonomous flow using IMAP + app-password (RFC 021). Requires `<ID>_GMAIL_USER` and `<ID>_GMAIL_APP_PASSWORD`. Generate the app-password at <https://myaccount.google.com/apppasswords> (requires 2FA). |
 | `--since <iso>` | string | saved cursor | Override cursor. Clamped to a 30-day max window. |
+| `--reprocess-since <iso>` | string | — | One-time recovery (RFC 056). Sets the cursor to `<iso>` **and** bypasses the `processed_messages.json` dedup for that window, re-matching fetched mail against the current active set. Status transitions are idempotent (terminal jobs are absent from the active set); `comment_only` actions are dropped to avoid duplicate comments. Use with `--auto`; dry-run unless `--apply`. |
 | `--dry-run` | boolean | true for phase 3 default | Phase 1 honors it (skip context-file write). Phase 3 default is dry-run unless `--apply` is set. |
 | `--verbose` | boolean | false | In `--auto`, prints per-batch Gmail-id counts to stderr. |
 

--- a/engine/cli.js
+++ b/engine/cli.js
@@ -39,6 +39,7 @@ const PARSE_OPTIONS = {
     need: { type: "string" },
     prepare: { type: "boolean", default: false },
     since: { type: "string" },
+    "reprocess-since": { type: "string" },
     "no-sync": { type: "boolean", default: false },
     "no-callout": { type: "boolean", default: false },
     auto: { type: "boolean", default: false },
@@ -128,6 +129,14 @@ check flags:
                          Generate an app-password at
                          myaccount.google.com/apppasswords (requires 2FA).
   --since <ISO>          Override cursor (clamped to 30 days max).
+  --reprocess-since <ISO>
+                         One-time recovery (RFC 056): set cursor to <ISO> AND
+                         bypass the processed_messages.json dedup for that
+                         window, re-matching fetched mail against the current
+                         active set. Idempotent for status changes (already-
+                         terminal jobs are absent from the active set);
+                         comment_only actions are dropped to avoid duplicate
+                         comments. Use with --auto; dry-run unless --apply.
 
 reclassify flags:
   --apply                Mutate processed_messages.json. Default: dry-run.
@@ -252,6 +261,7 @@ async function runCli({ argv, env = process.env, stdout, stderr, commands } = {}
       need: parsed.values.need ? parseInt(parsed.values.need, 10) : null,
       prepare: Boolean(parsed.values.prepare),
       since: parsed.values.since || "",
+      reprocessSince: parsed.values["reprocess-since"] || "",
       noSync: Boolean(parsed.values["no-sync"]),
       noCallout: Boolean(parsed.values["no-callout"]),
       auto: Boolean(parsed.values.auto),

--- a/engine/cli.test.js
+++ b/engine/cli.test.js
@@ -119,6 +119,23 @@ test("runCli dispatches to registered handler with normalized ctx", async () => 
   assert.equal(ctx.env.PAT_NOTION_TOKEN, "y");
 });
 
+test("runCli parses --reprocess-since into ctx.flags.reprocessSince (RFC 056)", async () => {
+  const s = makeStreams();
+  const check = spyCommand(() => 0);
+  const code = await runCli({
+    argv: ["check", "--profile", "jared", "--auto", "--reprocess-since", "2026-04-01T00:00:00Z"],
+    env: { JARED_NOTION_TOKEN: "x" },
+    stdout: s.stdout,
+    stderr: s.stderr,
+    commands: { check },
+  });
+  assert.equal(code, 0);
+  assert.equal(check.calls.length, 1);
+  assert.equal(check.calls[0].flags.reprocessSince, "2026-04-01T00:00:00Z");
+  // Default empty when absent.
+  assert.equal(check.calls[0].flags.since, "");
+});
+
 test("runCli passes through handler exit code and traps thrown errors", async () => {
   const s = makeStreams();
   const exitCode = await runCli({

--- a/engine/commands/check.js
+++ b/engine/commands/check.js
@@ -952,7 +952,10 @@ async function runAutoBody(ctx, deps, profile, paths) {
   // runApply: no stale context snapshot).
   const saved = deps.loadProcessed(paths.processedPath);
   const now = deps.now();
-  const sinceIso = flags.since || null;
+  // --reprocess-since (RFC 056) doubles as a cursor override: set the window
+  // start, then bypass the processed-id dedup below for that window.
+  const reprocessSince = flags.reprocessSince || null;
+  const sinceIso = reprocessSince || flags.since || null;
   const epoch = deps.computeCursorEpoch({
     lastCheck: saved.last_check,
     sinceIso,
@@ -977,7 +980,12 @@ async function runAutoBody(ctx, deps, profile, paths) {
   });
 
   const processedSet = new Set((saved.processed || []).map((e) => e.id));
-  const newEmails = rawEmails.filter((e) => e && e.messageId && !processedSet.has(e.messageId));
+  // RFC 056: --reprocess-since re-includes already-processed mail in the
+  // window so the expanded active set gets a chance to match historical
+  // rejections that were fetched-but-unmatched while the set was stale.
+  const newEmails = reprocessSince
+    ? rawEmails.filter((e) => e && e.messageId)
+    : rawEmails.filter((e) => e && e.messageId && !processedSet.has(e.messageId));
 
   const tsvCache = [...apps];
   const nowIso = now.toISOString();
@@ -1024,7 +1032,17 @@ async function runAutoBody(ctx, deps, profile, paths) {
     return 0;
   }
 
-  const { logRows, actions, rejections } = processEmailsLoop(newEmails, state, procCtx);
+  const loopResult = processEmailsLoop(newEmails, state, procCtx);
+  const { logRows, rejections } = loopResult;
+  let actions = loopResult.actions;
+  // RFC 056: under --reprocess-since, drop comment_only actions. Status
+  // changes are idempotent (terminal jobs are absent from the active set),
+  // but comment_only (e.g. INFO_REQUEST) has no such guard and would
+  // duplicate comments for mail already processed. Recovery targets the
+  // durable status transitions, not stale info-request pings.
+  if (reprocessSince) {
+    actions = actions.filter((a) => a.kind !== "comment_only");
+  }
 
   emitDryRunJson(stdout, deps, { newEmails, logRows, actions, state, rejections });
 

--- a/engine/commands/check.test.js
+++ b/engine/commands/check.test.js
@@ -868,6 +868,124 @@ test("check --auto: makeGmailClient receives loaded credentials", async () => {
   assert.equal(calls.makeGmailClient[0].appPassword, "abcd efgh ijkl mnop");
 });
 
+// ---------- RFC 056: --reprocess-since ----------
+
+test("check --auto --reprocess-since: re-includes already-processed mail (bypasses dedup) → recovers rejection", async () => {
+  const { deps, calls } = makeAutoDeps({
+    // m1 is already in processed — a normal run skips it (see the dedup test).
+    loadProcessed: () => ({
+      processed: [{ id: "m1", date: "2026-04-15T09:00:00Z", company: "unknown", type: "OTHER" }],
+      last_check: "2026-04-29T09:00:00Z",
+    }),
+    fetchGmailEmails: async () => [
+      {
+        messageId: "m1",
+        from: "no-reply@affirm.com",
+        subject: "An update on your application with Affirm",
+        body: "Unfortunately, we will not be proceeding.",
+        date: "2026-04-20T10:00:00Z",
+      },
+    ],
+  });
+  const { ctx } = makeCtx({
+    auto: true,
+    apply: true,
+    reprocessSince: "2026-04-01T00:00:00Z",
+  });
+  const code = await makeCheckCommand(deps)(ctx);
+  assert.equal(code, 0);
+  // dedup bypassed → the historical rejection now matches the active job.
+  assert.equal(calls.updatePageStatus.length, 1);
+  assert.equal(calls.updatePageStatus[0].status, "Rejected");
+});
+
+test("check --auto --reprocess-since: drops comment_only (no duplicate info-request comment)", async () => {
+  const infoEmail = {
+    messageId: "m1",
+    from: "no-reply@affirm.com",
+    subject: "Affirm assessment",
+    body: "please complete the following coding challenge.",
+    date: "2026-04-20T10:00:00Z",
+  };
+  // Normal run: comment_only IS posted.
+  {
+    const { deps, calls } = makeAutoDeps({ fetchGmailEmails: async () => [infoEmail] });
+    const { ctx } = makeCtx({ auto: true, apply: true });
+    await makeCheckCommand(deps)(ctx);
+    assert.equal(calls.addPageComment.length, 1, "normal run comments");
+    assert.equal(calls.updatePageStatus.length, 0);
+  }
+  // Reprocess run: comment_only dropped → no duplicate comment.
+  {
+    const { deps, calls } = makeAutoDeps({
+      loadProcessed: () => ({
+        processed: [{ id: "m1", date: "2026-04-15T09:00:00Z", company: "Affirm", type: "OTHER" }],
+        last_check: "2026-04-29T09:00:00Z",
+      }),
+      fetchGmailEmails: async () => [infoEmail],
+    });
+    const { ctx } = makeCtx({
+      auto: true,
+      apply: true,
+      reprocessSince: "2026-04-01T00:00:00Z",
+    });
+    await makeCheckCommand(deps)(ctx);
+    assert.equal(calls.addPageComment.length, 0, "reprocess drops comment_only");
+    assert.equal(calls.updatePageStatus.length, 0);
+  }
+});
+
+test("check --auto --reprocess-since: already-terminal job is absent from active set → not re-acted", async () => {
+  const { deps, calls } = makeAutoDeps({
+    loadApplications: () => ({
+      apps: [
+        fakeApp({
+          key: "k1",
+          companyName: "Affirm",
+          title: "PM",
+          notion_page_id: "p1",
+          status: "Rejected", // terminal → excluded from activeJobsMap
+        }),
+      ],
+    }),
+    loadProcessed: () => ({
+      processed: [{ id: "m1", date: "2026-04-15T09:00:00Z", company: "Affirm", type: "REJECTION" }],
+      last_check: "2026-04-29T09:00:00Z",
+    }),
+    fetchGmailEmails: async () => [
+      {
+        messageId: "m1",
+        from: "no-reply@affirm.com",
+        subject: "An update on your application with Affirm",
+        body: "Unfortunately, we will not be proceeding.",
+        date: "2026-04-20T10:00:00Z",
+      },
+    ],
+  });
+  const { ctx } = makeCtx({
+    auto: true,
+    apply: true,
+    reprocessSince: "2026-04-01T00:00:00Z",
+  });
+  const code = await makeCheckCommand(deps)(ctx);
+  assert.equal(code, 0);
+  assert.equal(calls.updatePageStatus.length, 0, "no duplicate Rejected on a terminal job");
+  assert.equal(calls.addPageComment.length, 0);
+});
+
+test("check --auto --reprocess-since: sets cursor to the reprocess ISO", async () => {
+  let lastEpochArgs = null;
+  const { deps } = makeAutoDeps({
+    computeCursorEpoch: (args) => {
+      lastEpochArgs = args;
+      return 1700000000;
+    },
+  });
+  const { ctx } = makeCtx({ auto: true, reprocessSince: "2026-04-01T00:00:00Z" });
+  await makeCheckCommand(deps)(ctx);
+  assert.equal(lastEpochArgs.sinceIso, "2026-04-01T00:00:00Z");
+});
+
 test("check --apply: Notion error on one action — others still processed", async () => {
   let callIdx = 0;
   const { deps, calls } = makeDeps({

--- a/rfc/056-reprocess-historical-rejection-backlog.md
+++ b/rfc/056-reprocess-historical-rejection-backlog.md
@@ -1,0 +1,146 @@
+# RFC 056 — Reprocess historical rejection backlog
+
+- Status: **proposed**
+- Date: 2026-05-30
+- Refs: BL-156, RFC 055 (cron TSV sync + heartbeat), RFC 021 (gmail IMAP), RFC 014 (status split)
+- Tier: M
+
+## Problem
+
+RFC 055 fixed the cron going forward: `check --auto` now reconciles the
+full active set from Notion before searching Gmail. Deployed and live on
+2026-05-30 (success heartbeats confirm it).
+
+But a 30-day verification backfill produced **0 status transitions** for
+jared (heartbeat: emails 10 / matched 10 / Rejected 0) and 0 emails for
+lilia. Root cause, code-grounded:
+
+1. The Gmail search includes an **ATS-sender batch**
+   ([check.js:296](../engine/commands/check.js), `buildBatches`) that
+   fetches mail from Greenhouse / Lever / etc. **regardless** of whether
+   the company is in `activeJobsMap`.
+2. `applyMutations` writes **every** fetched email into
+   `processed_messages.json` ([check.js:757](../engine/commands/check.js)),
+   including those that matched no active job (`match=NONE`).
+3. `runAutoBody` filters already-processed message ids out **before**
+   matching ([check.js:980](../engine/commands/check.js)).
+
+So while the fly active set was stale (weeks), ATS rejections for
+untracked jobs were fetched, matched NONE, and recorded as processed. A
+normal re-run skips them, and the now-expanded active set never gets to
+match them. The historical rejection backlog is locked in
+`processed_messages.json`.
+
+## Goal
+
+A one-time, idempotent recovery that re-matches the locked historical
+emails against the reconciled (full) active set, flipping the jobs that
+actually got a rejection to **Rejected** in Notion — without duplicate
+comments and without touching jobs already at a terminal status.
+
+## Approach
+
+### New flag: `check --reprocess-since <ISO>`
+
+Behaves like `--since <ISO>` (sets the cursor epoch) **plus** bypasses
+the `processed_messages.json` dedup filter for the window:
+
+```js
+const newEmails = flags.reprocessSince
+  ? rawEmails.filter((e) => e && e.messageId)            // bypass dedup
+  : rawEmails.filter((e) => e && e.messageId && !processedSet.has(e.messageId));
+```
+
+Everything downstream is unchanged. Re-saving `processed_messages.json`
+at the end stays idempotent (same ids re-recorded).
+
+### Idempotency — already structurally guaranteed for status changes
+
+No new guard needed for the rejection path:
+
+- `buildActiveJobsMap` only includes statuses ∈ {To Apply, Applied,
+  Interview, Offer}. A job already **Rejected**/**Closed** in Notion is
+  reconciled into the fly TSV as such (RFC 055 additive pull) and is
+  therefore **absent from `activeJobsMap`** → never matched → never
+  re-acted.
+- Even if a stale row slips through, `processPipeline` skips when
+  `SKIP_STATUSES.has(job.status)` ([check.js:517](../engine/commands/check.js)).
+
+So re-fetching an already-handled rejection is a no-op: its job isn't
+active, so it produces no action.
+
+### The one real duplicate risk: `comment_only`
+
+`INFO_REQUEST` emails produce `kind: "comment_only"`
+([check.js:579](../engine/commands/check.js)) with **no** status guard.
+Bypassing dedup would re-post the "📋 info request" comment for any
+info-request email already processed.
+
+Mitigation (chosen): **during reprocess, drop `comment_only` actions** —
+apply only `status+comment`. Recovery targets rejections (and
+position-closed / interview transitions), which are the time-durable
+signals. Historical info-requests are stale and not worth a duplicate.
+One added line in `applyMutations`/action assembly, gated on
+`flags.reprocessSince`.
+
+### Forward precision (small additive schema bump, optional)
+
+Record `match` on each processed entry going forward
+([check.js:757](../engine/commands/check.js) add `match: r.match || "NONE"`).
+This lets a *future* `--reprocess-since` re-include only never-matched
+emails (precise), without the blanket `comment_only` drop. Pure-additive;
+old entries simply lack the field. Include if cheap; not required for the
+one-time recovery.
+
+## Verification-first rollout (addresses the unconfirmed diagnosis)
+
+The 0-transitions diagnosis is code-grounded but **not box-verified**
+(SSH blocked by operator network). The dry-run IS the confirmation:
+
+1. Land code, redeploy fly.
+2. **Dry-run** `check --profile jared --reprocess-since 2026-04-29T00:00:00Z`
+   (no `--apply`): re-fetches the window, bypasses dedup, reports how
+   many status transitions *would* happen. No Notion writes.
+   - If it reports `→ Rejected: N` with N ≫ 0 → hypothesis confirmed AND
+     recovery scope is known before any mutation.
+   - If N == 0 → hypothesis wrong (active set didn't expand on the box);
+     stop and investigate the reconcile path instead.
+3. If sane, run with `--apply` for jared + lilia.
+4. Confirm heartbeats show non-zero `→ Rejected: N`; spot-check a few
+   flipped jobs in Notion.
+
+Execution mechanism (SSH blocked): one-off cron tick (add line, deploy,
+fire, revert, clean redeploy) — same pattern used for the RFC 055
+backfill — or an operator SSH from an un-proxied network.
+
+## Test plan
+
+- `runAutoBody`: with `flags.reprocessSince`, processed ids in the
+  window are NOT filtered (re-included); without it, dedup unchanged.
+- Idempotency: a processed REJECTION whose job is already Rejected
+  (absent from active map) yields no action on reprocess.
+- `comment_only` drop: an `INFO_REQUEST` re-fetched under reprocess
+  produces no comment action; under a normal run it still does.
+- A genuinely-recoverable case: stale processed entry + job present and
+  Active in the (expanded) map + rejection email in window → reprocess
+  emits exactly one `status+comment` → Rejected.
+- Arg parse: `--reprocess-since <ISO>` sets cursor + flag; bad/missing
+  value errors clearly; mutually-sane with `--apply`.
+- All network mocked. `npm test` green incl. `prettier --check .`.
+
+## NOT in scope
+
+- Daily cron behaviour (fixed under RFC 055).
+- Rejections older than the Gmail search window (`after:` epoch).
+- Retroactive Interview/Offer beyond existing classifier logic.
+- A standalone push path or any Notion write outside `applyMutations`.
+
+## Why not alternatives
+
+- **Manually prune `processed_messages.json` on the volume**: needs
+  container file surgery (SSH blocked), is destructive, and loses the
+  dedup safety for `comment_only`. The flag is reusable and testable.
+- **Clear all of `processed_messages.json`**: re-posts every historical
+  `comment_only` and re-walks everything; blunt and duplicate-prone.
+- **Query Notion per email to dedup comments**: heavy, and unnecessary
+  given the active-set filter already covers the status path.


### PR DESCRIPTION
## What

Follow-up to RFC 055 (BL-154/155). The cron is fixed going forward, but historical rejections accumulated during the stale period are locked in `processed_messages.json`: every fetched email (incl. unmatched) was recorded as processed, so re-runs skip them even after the active set expands.

Adds `check --reprocess-since <ISO>` (RFC 056): sets the cursor **and** bypasses the `processed_messages.json` dedup for that window, re-matching fetched mail against the current (reconciled) active set.

## Idempotency / no duplicates

- Terminal jobs (Rejected/Closed) are absent from `activeJobsMap` → never matched → never re-acted. Status path is idempotent with no new guard.
- `comment_only` (e.g. INFO_REQUEST) has no such guard → **dropped under reprocess** to avoid duplicate Notion comments. Recovery targets durable status transitions.

## Tests (1970 green)

- bypass dedup → recovers a historical rejection
- `comment_only` dropped under reprocess (vs posted on a normal run)
- already-terminal job → no re-action
- cursor set to the reprocess ISO
- CLI flag parse → `flags.reprocessSince`

## Docs

`docs/reference/cli.md` updated (cli-args-sync gate passes). RFC 056 added.

## Rollout (verification-first)

1. Deploy. 2. Dry-run `--reprocess-since 2026-04-29` (no `--apply`) → reports would-be `→ Rejected: N`; confirms diagnosis + scope with zero Notion writes. 3. If sane, `--apply` for jared + lilia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)