### PR TITLE
fix(classifier): RFC 057 / BL-157 — ACK autoresponders no longer classify as interview invites

### DIFF
--- a/engine/core/classifier.js
+++ b/engine/core/classifier.js
@@ -8,6 +8,21 @@
 // First match wins — this avoids ambiguous double-classification (e.g. a
 // rejection letter that mentions "we received your application").
 
+// The single INTERVIEW_INVITE pattern that can also match an acknowledgment's
+// description of its *future* hiring process ("...schedule an interview...").
+// Named so the ACK-precedence guard in classify() can scope itself to ONLY
+// this pattern — the direct-invite patterns ("your interview is on…", "invite
+// you to…", Calendly, round-N, phone screen) are guard-immune and must never
+// be demoted. Tightened 2026-05-30 (RFC 057 / BL-157): trailing \b rejects
+// plural "interviews"; negative lookbehind rejects forward-looking prefixes
+// ("expect/plan/intend to schedule"). Root case: a Sharecare/Workday ACK on
+// lilia — "we have received your application … expect to schedule interviews
+// in the next couple of weeks" — matched the old pattern and flipped the card
+// to Interview (sent 3×, hence a phantom "Interview: 3"). Singular directed
+// forms ("schedule your interview", bare "schedule interview") still match.
+const SCHEDULE_INTERVIEW =
+  /(?<!(?:expect|plan|planning|hope|hoping|going|aiming|aim|wish|intend|intending) to )schedule (?:(?:your|the|our|my|a|an)\s+)?(interview|phone screen)\b/i;
+
 const PATTERNS = {
   REJECTION: [
     // Bare /unfortunately/i removed 2026-05-12 (BL-26 revision). Duolingo ACK
@@ -104,7 +119,9 @@ const PATTERNS = {
     //   - /(your|let me know your) availability (for|to) (call|chat|conversation)/
     // Real trigger: Deel ACK 14-apr (Jared dry-run, 2026-05-12), which
     // also cross-bound to Next Insurance via matcher.
-    /schedule (?:(?:your|the|our|my|a|an)\s+)?(interview|phone screen)/i,
+    // RFC 057 / BL-157 — see SCHEDULE_INTERVIEW definition above. Extracted to
+    // a named const so the ACK-precedence guard can scope to this pattern only.
+    SCHEDULE_INTERVIEW,
     /(would|we'd) like to (schedule|set up|interview)/i,
     /invite you (to|for) (an? )?(interview|phone screen|conversation|chat)/i,
     /your interview (is|with|on)/i,
@@ -179,10 +196,41 @@ const PATTERNS = {
     /thanks for applying/i,
     /thank you for your (application|interest)/i,
     /application confirmed/i,
+    // 2026-05-30 (RFC 057 / BL-157) — autoresponder subject lines. Sharecare
+    // (Workday) sends "Application Received for <role>" with a body that only
+    // describes the future hiring process. The subject alone is an
+    // unambiguous acknowledgment signal.
+    /application (received|confirmation)/i,
     /we have received/i,
     /we.ve received/i,
   ],
 };
+
+// ACK-precedence guard inputs (RFC 057 / BL-157). first-match-wins returns
+// INTERVIEW_INVITE before ACKNOWLEDGMENT, so an acknowledgment that says it
+// will schedule an interview *conditionally on selection* ("we have received
+// your application … if you are selected we will schedule an interview")
+// would still mutate the card. The guard (in classify) demotes to
+// ACKNOWLEDGMENT only when ALL of: (a) the winning match came from
+// SCHEDULE_INTERVIEW specifically — direct-invite patterns are immune; (b) a
+// strong application-receipt signal is present; (c) the scheduling is gated
+// by a selection condition. A committal invite ("we will schedule an
+// interview next week", "your interview is on Thursday") has no selection
+// condition and is left as INTERVIEW_INVITE.
+const STRONG_ACK = [
+  /received your application/i,
+  /your application (?:has been|was) received/i,
+  /application (?:received|confirmation)/i,
+];
+const ACK_CONDITIONAL = [
+  /\bif (?:you(?:'re| are)? )?(?:selected|chosen|shortlisted|a (?:good |strong )?(?:fit|match)|advance|move forward|proceed)/i,
+  /\bif selected\b/i,
+  // Selection-scoped only. A bare /should (you|your application)/ matched the
+  // routine courtesy closers real invites carry ("should you have any
+  // questions", "should you need to reschedule") and demoted them — review
+  // Finding 4. Require an advance/selection verb after "should you".
+  /\bshould you (?:be )?(?:selected|chosen|shortlisted|advance|proceed|move forward)\b/i,
+];
 
 // POSITION_CLOSED goes BEFORE REJECTION (2026-05-12). When both signals are
 // present ("unfortunately…the position is now closed"), the closure is the
@@ -201,6 +249,19 @@ function classify({ subject, body } = {}) {
     for (const pattern of PATTERNS[type]) {
       const match = text.match(pattern);
       if (match) {
+        // ACK-precedence guard (RFC 057 / BL-157): a conditional-on-selection
+        // "schedule an interview" inside an application-acknowledgment is the
+        // ACK's description of its own future process, not an action signal.
+        // Scoped to SCHEDULE_INTERVIEW only — direct-invite patterns (your
+        // interview is on…, invite you to…, Calendly, round-N) are immune.
+        if (
+          type === "INTERVIEW_INVITE" &&
+          pattern === SCHEDULE_INTERVIEW &&
+          STRONG_ACK.some((p) => p.test(text)) &&
+          ACK_CONDITIONAL.some((p) => p.test(text))
+        ) {
+          return { type: "ACKNOWLEDGMENT", evidence: match[0] };
+        }
         return { type, evidence: match[0] };
       }
     }

--- a/engine/core/classifier.test.js
+++ b/engine/core/classifier.test.js
@@ -790,6 +790,115 @@ test("classify: article-bound 'your/the take-home assignment' → INFO_REQUEST (
   }
 });
 
+// Regression 2026-05-30 (RFC 057 / BL-157) — Sharecare (Workday) application
+// acknowledgment on lilia (sharecare@myworkday.com, fetched read-only over
+// IMAP). Subject "Application Received for <role>"; body only describes the
+// future hiring process: "we have received your application … expect to
+// schedule interviews in the next couple of weeks". The old
+// /schedule …(interview|phone screen)/ pattern matched "schedule interviews"
+// and flipped the card to Interview. Workday sent the same mail 3× → a
+// phantom "Interview: 3" in the heartbeat for a single job. After fix:
+// trailing \b rejects the plural, forward-looking lookbehind + ACK guard
+// catch the rest. Must be ACKNOWLEDGMENT.
+test("classify: Sharecare 'Application Received … expect to schedule interviews' → ACKNOWLEDGMENT (RFC 057)", () => {
+  const subject = "Application Received for Data Entry Specialist - Medical Records (Remote)";
+  const body =
+    "Dear Lilia, This letter is to let you know that we have received your " +
+    "application. We appreciate your interest in our company and the position " +
+    "for which you applied. We are reviewing applications and expect to " +
+    "schedule interviews in the next couple of weeks. If you are selected for " +
+    "an interview, you can expect an email or phone call from us in the near " +
+    "future. Thank you again for your interest in Sharecare. Regards, " +
+    "Sharecare Talent Acquisition Team";
+  const r = classify({ subject, body });
+  assert.equal(
+    r.type,
+    "ACKNOWLEDGMENT",
+    `expected ACKNOWLEDGMENT, got ${r.type} (evidence: "${r.evidence}")`
+  );
+});
+
+// Guard control — the singular future form ("we will schedule an interview
+// if you're selected") passes the trailing \b (singular) but is still an ACK
+// describing its process. STRONG_ACK + FORWARD_LOOKING_INVITE both present →
+// demote to ACKNOWLEDGMENT.
+test("classify: ACK 'we will schedule an interview if selected' → ACKNOWLEDGMENT (RFC 057 guard)", () => {
+  const r = classify({
+    subject: "Application Received",
+    body:
+      "Thank you — we have received your application. If you are selected, we " +
+      "will schedule an interview with you in the coming weeks.",
+  });
+  assert.equal(
+    r.type,
+    "ACKNOWLEDGMENT",
+    `expected ACKNOWLEDGMENT, got ${r.type} (evidence: "${r.evidence}")`
+  );
+});
+
+// Negative control — forward-looking "expect to schedule interviews" /
+// "plan to schedule interviews" in plain process text (no ACK signal) must
+// NOT classify as INTERVIEW_INVITE.
+test("classify: forward-looking 'expect/plan to schedule interviews' → not INTERVIEW_INVITE (RFC 057)", () => {
+  const fixtures = [
+    "We expect to schedule interviews in the next couple of weeks.",
+    "The team plans to schedule interviews once the role is approved.",
+    "Hiring managers will schedule interviews with shortlisted candidates.",
+  ];
+  for (const body of fixtures) {
+    const r = classify({ subject: "Process overview", body });
+    assert.notEqual(
+      r.type,
+      "INTERVIEW_INVITE",
+      `should NOT be INTERVIEW_INVITE: "${body}" (got ${r.type}, evidence: "${r.evidence}")`
+    );
+  }
+});
+
+// No-regression — genuine invites still match even when an application-receipt
+// pleasantry is present, because the FORWARD_LOOKING cue is absent (direct
+// invite, not a future-process description). Guards must not over-demote.
+test("classify: receipt + direct invite ('your interview is on…') → INTERVIEW_INVITE (RFC 057 no over-demote)", () => {
+  const fixtures = [
+    "We have received your application. Your interview is on Thursday at 2pm PT.",
+    "Thanks for applying! Please schedule your interview using the link below.",
+  ];
+  for (const body of fixtures) {
+    const r = classify({ subject: "Next steps", body });
+    assert.equal(
+      r.type,
+      "INTERVIEW_INVITE",
+      `expected INTERVIEW_INVITE for: "${body}", got ${r.type} (evidence: "${r.evidence}")`
+    );
+  }
+});
+
+// Guard-scope no-regression (RFC 057, review Finding 2) — the ACK guard must
+// NOT demote a genuine invite just because a receipt phrase and a scheduling
+// phrase co-occur. It demotes ONLY when the SCHEDULE_INTERVIEW pattern won AND
+// the scheduling is gated by a selection condition. These two stay invites:
+//   1. committal "we will schedule an interview" with no "if selected" gate;
+//   2. a direct-invite pattern ("your interview is on…") wins — the stray
+//      "we will schedule a follow-up" sentence must not trigger the guard.
+test("classify: committal invite + receipt, no selection-condition → INTERVIEW_INVITE (RFC 057 guard scope)", () => {
+  const fixtures = [
+    "Thanks, we received your application earlier. Following your strong screen, we will schedule an interview next week.",
+    "We have received your application. Your interview is on Thursday at 2pm. We will schedule a follow-up after.",
+    // review Finding 4 — courtesy closers ("should you have questions",
+    // "should you need to reschedule") must not trip the selection-condition.
+    "We received your application and would like to schedule your interview. Should you have any questions, reply here.",
+    "We have received your application. Please schedule your interview using the link. Should you need to reschedule, use the same link.",
+  ];
+  for (const body of fixtures) {
+    const r = classify({ subject: "Next steps", body });
+    assert.equal(
+      r.type,
+      "INTERVIEW_INVITE",
+      `expected INTERVIEW_INVITE for: "${body}", got ${r.type} (evidence: "${r.evidence}")`
+    );
+  }
+});
+
 // Negative control — generic "closed" without position context must NOT
 // match (e.g. "our office is closed for the holiday").
 test("classify: bare 'closed' without position/role context → not POSITION_CLOSED", () => {

--- a/incidents.md
+++ b/incidents.md
@@ -1,7 +1,21 @@
 ---
 title: "Incident log"
 status: live
-last_updated: 2026-05-18
+last_updated: 2026-05-30
+---
+
+## 2026-05-30 — acknowledgment autoresponder classified as interview invite, flipped a card to Interview (RFC 057 / BL-157)
+
+**Severity**: LOW (no data loss; one lilia card wrongly shown in Interview; reverted manually). Surfaced while verifying the RFC 056 recovery run.
+
+**Cause**: A Sharecare/Workday application-acknowledgment (`sharecare@myworkday.com`, subject "Application Received for Data Entry Specialist…") whose body only describes the future hiring process — "we have received your application … we are reviewing applications and **expect to schedule interviews** in the next couple of weeks" — matched the INTERVIEW_INVITE pattern `/schedule (?:…)?(interview|phone screen)/i` on the substring "schedule interviews". Two reinforcing factors in `engine/core/classifier.js`: (1) the pattern had no trailing `\b` (matched plural "interviews") and no guard for forward-looking prefixes; (2) `ACKNOWLEDGMENT` is last in `ORDER`, so the strong receipt signal ("we have received your application") could not override the weak forward-looking interview match. Workday sent the mail 3× → the recovery heartbeat read `→ Interview: 3` for what was a single job. Same class as the 2026-05-02 Indeed-digest and 2026-05-12 Tyson&Mendes incidents (forward-looking process text inside ACK bodies).
+
+**What changed**: `engine/core/classifier.js` — the schedule pattern extracted to `SCHEDULE_INTERVIEW` with a trailing `\b` (rejects plural "interviews") and a negative lookbehind for forward-looking prefixes ("expect/plan/intend to schedule"). Added autoresponder subject forms to ACKNOWLEDGMENT (`/application (received|confirmation)/i`). Added a narrowly-scoped ACK-precedence guard in `classify()`: demote to ACKNOWLEDGMENT only when the winning match is `SCHEDULE_INTERVIEW` specifically (direct-invite patterns are immune) AND a strong receipt signal is present AND the scheduling is gated by a selection condition ("if selected", "should you be chosen"). Singular directed invites ("schedule your interview", "your interview is on…") are untouched. 5 new regression fixtures (3 real Sharecare bodies + guard + no-regression). 1975/1975 tests pass.
+
+**Prevention**: Two-round adversarial code review caught two over-demotion regressions before merge (guard firing on whole-text presence regardless of winning pattern; courtesy-closer "should you have questions" tripping the selection cue) — both fixed with fixtures pinned. The lilia card (Clinic Administrative Assistant @ Fresenius) was reverted Interview → To Apply with an audit comment.
+
+**Follow-up**: BL-158 — the same email matched the *wrong* job (Data Entry @ Sharecare → Clinic Admin @ Fresenius); matcher cross-binding, separate from classification.
+
 ---
 
 ## 2026-05-18 — `location_blocklist` checked only `locations[0]`, missed multi-loc and state-coded US elements (BL-24)

--- a/rfc/057-classifier-ack-vs-interview-precedence.md
+++ b/rfc/057-classifier-ack-vs-interview-precedence.md
@@ -1,0 +1,136 @@
+# RFC 057 — Classifier: acknowledgment autoresponders must not classify as interview invites
+
+- **Status:** proposed
+- **Tier:** M
+- **Author:** Claude (with Jared)
+- **Created:** 2026-05-30
+- **Refs:** BL-157, RFC 056 (recovery run that surfaced it), `engine/core/classifier.js`
+
+## Образ результата (user-level)
+
+Сегодня бот иногда поднимает вакансию в **Interview** по письму, которое
+на самом деле — авто-ответ «мы получили вашу заявку». После фикса:
+
+- Письмо вида «Application Received… we are reviewing applications and
+  **expect to schedule interviews** in the next couple of weeks» больше
+  **не** даёт статус Interview. Оно остаётся подтверждением (ACK,
+  статус карточки не меняется).
+- Настоящие приглашения («we'd like to schedule **your** interview»,
+  «invite you to interview», «book a time on my calendar», round-N,
+  phone screen, Calendly) по-прежнему дают Interview.
+- В Notion на ложные ACK больше не сыплются 🔔-комментарии про интервью.
+- Поведение одинаково для всех профилей (jared, lilia) — фикс в общем
+  движке.
+
+Что НЕ входит: исправление матчинга «письмо ↔ не та вакансия»
+(вторичный баг, найден в том же инциденте) — отдельная задача BL-158.
+Также вне scope: ретро-переразметка уже обработанных писем (для этого
+есть `reclassify` / `--reprocess-since`).
+
+## Контекст / инцидент
+
+2026-05-30, при верификации recovery-прогона (RFC 056) у профиля lilia
+heartbeat показал `→ Interview: 3`. Разбор: все три «перехода» — это
+**одно и то же** авто-письмо Workday/Sharecare, пришедшее трижды:
+
+```
+From:    sharecare@myworkday.com
+Subject: Application Received for Data Entry Specialist - Medical Records (Remote)
+Body:    "...we have received your application. ...We are reviewing
+          applications and expect to schedule interviews in the next
+          couple of weeks. If you are selected for an interview, you can
+          expect an email or phone call from us..."
+```
+
+`classify()` вернул `INTERVIEW_INVITE` с evidence `"schedule interview"`.
+
+## Root cause
+
+Два усиливающих друг друга фактора в `engine/core/classifier.js`:
+
+1. **Слишком широкий паттерн INTERVIEW_INVITE.**
+   `/schedule (?:(?:your|the|our|my|a|an)\s+)?(interview|phone screen)/i`
+   срабатывает на `"expect to schedule interviews"`:
+   - артикль необязателен → ловит безартиклевую форму «schedule
+     interviews»;
+   - нет `\b` после `interview` → ловит множественное «interviews»;
+   - нет требования, чтобы планировали интервью **получателю** — фраза
+     описывает будущий процесс компании, а не приглашение.
+
+2. **ACKNOWLEDGMENT стоит последним в `ORDER`.**
+   `ORDER = [POSITION_CLOSED, REJECTION, INTERVIEW_INVITE, INFO_REQUEST,
+   ACKNOWLEDGMENT]`, first-match-wins. У письма есть явный ACK-сигнал
+   (`/received your application/i`, `/we have received/i`), но
+   INTERVIEW_INVITE проверяется раньше и побеждает. Сильный сигнал
+   «заявку получили» не может перебить слабую forward-looking фразу.
+
+Тот же класс ошибки уже латали точечно (2026-05-02 Indeed-digest:
+убрали bare `\binterview\b`/`\bavailability\b`; 2026-05-12 Tyson&Mendes:
+убрали `next steps in the process`). Это следующий случай той же
+болезни — forward-looking process-текст в теле ACK.
+
+## Дизайн (на выбор, рекомендация — Вариант C)
+
+### Вариант A — точечно ужать regex (минимум кода)
+Заменить `schedule…interview` паттерн на directed-форму:
+- требовать притяжательное/определённое наполнение и singular + `\b`:
+  `/schedule (?:your|the|our|my)\s+(?:phone\s+)?interview\b/i`
+  и отдельно `/schedule (?:a|an)\s+interview\b(?!s)/i` для «schedule an
+  interview»;
+- добавить негативный guard на forward-looking префиксы
+  (`expect to|plan to|hope to|will|going to|aim to` + `schedule`).
+
+Плюс: хирургично, мало риска для других типов. Минус: не лечит другие
+forward-looking фразы в ACK (`share your availability`, и т. п.).
+
+### Вариант B — ACK-precedence guard
+Если текст матчит ACKNOWLEDGMENT **и** единственное доказательство
+INTERVIEW_INVITE / INFO_REQUEST — это известная «process-описательная»
+фраза, классифицировать как ACKNOWLEDGMENT. Реализация: пометить часть
+INTERVIEW/INFO паттернов как «weak/forward-looking» и при наличии
+сильного ACK демотировать.
+
+Плюс: лечит весь класс. Минус: усложняет first-match-wins логику,
+больше тест-поверхности.
+
+### Вариант C — A + субъектный ACK short-circuit (рекомендуется)
+- Применить ужатие из A.
+- Добавить в ACKNOWLEDGMENT субъектные формы автоответов:
+  `/application received/i`, `/application (confirmation|confirmed)/i`.
+- Ввести лёгкий guard: если matched-evidence INTERVIEW_INVITE
+  принадлежит «forward-looking» подсписку **и** одновременно матчит
+  сильный ACK — отдать ACKNOWLEDGMENT. Подсписок forward-looking держим
+  явным и маленьким (сейчас в нём только `schedule…interview`-семейство),
+  чтобы не размывать настоящие инвайты.
+
+## Идемпотентность / безопасность
+
+- Уже обработанные письма не переразмечаются на обычных прогонах
+  (dedup по `processed_messages.json`); ложные ACK из инцидента уже
+  записаны → повторно карточки не тронут. Re-flip возможен только при
+  явном `--reprocess-since`, который мы не запускаем.
+- Карточку lilia (Clinic Administrative Assistant @ Fresenius) уже
+  откатили вручную в To Apply + аудит-комментарий (2026-05-30).
+
+## Definition of Done
+
+- `classify()` на 3 Sharecare-фикстурах возвращает `ACKNOWLEDGMENT`
+  (regression-фикстуры добавлены в `classifier.test.js`).
+- Все существующие INTERVIEW_INVITE / INFO_REQUEST / REJECTION кейсы в
+  `classifier.test.js` остаются зелёными (настоящие инвайты не сломаны).
+- Добавлены позитивные anti-regression кейсы: «schedule your interview»,
+  «we'd like to schedule», «invite you to interview», round-N, phone
+  screen, Calendly → по-прежнему INTERVIEW_INVITE.
+- `npm test` зелёный (вкл. prettier `--check`).
+- Мульти-агентное ревью (тир M): code-reviewer по диффу.
+- Прототип-комментарий в начале `classifier.js` обновлён (sync-нота),
+  запись в incidents.md про этот случай.
+- BL-158 заведён на вторичный матчер-баг (письмо ушло не на ту вакансию).
+
+## Открытые вопросы
+
+- Вариант A / B / C — какой берём? (рекомендую C)
+- Нужно ли в этом же PR добавить `share your availability` в
+  forward-looking подсписок, или это отдельный кейс под отдельную
+  фикстуру? (предлагаю не трогать в этом PR — нет подтверждённого
+  инцидента, держим PR узким).


### PR DESCRIPTION
## What & why

A Sharecare/Workday application acknowledgment — subject "Application Received for …", body "we have received your application … expect to **schedule interviews** in the next couple of weeks" — was classified `INTERVIEW_INVITE` and flipped a lilia card to Interview. Workday sent it 3× → the RFC 056 recovery heartbeat read `→ Interview: 3` for a single job. Found while verifying that recovery run.

Root cause (`engine/core/classifier.js`): the schedule pattern had no trailing `\b` (matched plural "interviews") and no forward-looking guard, and `ACKNOWLEDGMENT` is last in `ORDER` so the strong receipt signal couldn't override the weak interview match.

## Fix (Variant C, RFC 057)

- `SCHEDULE_INTERVIEW` const: trailing `\b` (rejects plural "interviews") + negative lookbehind for forward-looking prefixes (`expect/plan/intend to schedule`).
- ACK subject forms added (`/application (received|confirmation)/i`).
- Narrowly-scoped ACK-precedence guard: demote to ACKNOWLEDGMENT only when the winning match is `SCHEDULE_INTERVIEW` specifically (direct invites immune) **and** a strong receipt signal **and** a selection condition are present. Committal/direct invites untouched.

Shared engine — protects both jared and lilia.

## Tests / review

- 1975/1975 tests pass (5 new fixtures incl. 3 real Sharecare bodies), prettier clean.
- Two-round adversarial review caught + fixed two over-demotion regressions (whole-text guard; courtesy-closer "should you have questions") before merge.

## Follow-ups / notes

- lilia card (Clinic Administrative Assistant @ Fresenius) reverted Interview → To Apply with an audit comment (out of band).
- BL-158 filed: the same email matched the *wrong* job (matcher cross-binding) — separate from classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)