### PR TITLE
fix(discovery): BL-52 — Adzuna age filter param max_days → max_days_old

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,8 @@ ME_USAJOBS_EMAIL=
 # https://myaccount.google.com/apppasswords (requires 2FA).
 ME_GMAIL_USER=
 ME_GMAIL_APP_PASSWORD=
+# Adzuna keyword-search adapter (discovery:adzuna). Free tier, no credit card:
+# register at https://developer.adzuna.com/ and copy the "Application ID" +
+# "Application Key". The adapter reads APP_ID + API_KEY (prefix stripped).
+ME_ADZUNA_APP_ID=
+ME_ADZUNA_API_KEY=

--- a/engine/modules/discovery/adzuna.js
+++ b/engine/modules/discovery/adzuna.js
@@ -180,7 +180,10 @@ async function fetchKeyword(
     app_key: appKey,
     what: keyword,
     where: location,
-    max_days: String(maxDays),
+    // Adzuna's age-filter param is `max_days_old`. Sending `max_days` makes
+    // the API gateway reject the whole request with an HTML 400 page (not a
+    // JSON error), which previously zeroed out every keyword on live scans.
+    max_days_old: String(maxDays),
     results_per_page: String(resultsPerPage),
     "content-type": "application/json",
   }).toString();

--- a/engine/modules/discovery/adzuna.test.js
+++ b/engine/modules/discovery/adzuna.test.js
@@ -117,7 +117,10 @@ test("adzuna: uses default keywords and params when no discovery config", async 
   assert.ok(calls[0].includes("what=Product+Manager"));
   assert.ok(calls[1].includes("what=Senior+Product+Manager"));
   assert.ok(calls[0].includes("where=United+States"));
-  assert.ok(calls[0].includes("max_days=30"));
+  // Adzuna's age-filter param is `max_days_old` (not `max_days`) — sending the
+  // wrong name makes the gateway 400 the request. Guard against regressing it.
+  assert.ok(calls[0].includes("max_days_old=30"));
+  assert.ok(!calls[0].includes("max_days=30"));
   assert.ok(calls[0].includes("results_per_page=50"));
 });
 


### PR DESCRIPTION
## What

BL-52: get the Adzuna keyword-search adapter actually returning jobs on live scans.

## Root cause

The adapter sent the age filter as `max_days=30`, but Adzuna's documented param is **`max_days_old`**. Adzuna's API gateway rejects an unknown param with an **HTML 400 page** (not a JSON error), so every keyword 400'd and scans logged `adzuna: 0 returned` even with valid keys.

Confirmed reproducibly (3 runs):
- `max_days_old=30` → HTTP 200
- `max_days=30` → HTTP 400 (HTML WAF page)
- no age param → HTTP 200

## Fix

- `max_days` → `max_days_old` in `engine/modules/discovery/adzuna.js`.
- Document `{PROFILE}_ADZUNA_APP_ID` / `_ADZUNA_API_KEY` in `.env.example`.
- `adzuna.test.js` asserts `max_days_old` and that `max_days=` is absent.

**No rate-limit / delay handling added** — a 5-keyword burst returns all-200 with or without spacing (`200,200,200,200,200`), so the earlier 400 storm was purely the bad param, not throttling.

## Verification

- Live `discover()` for jared → **250 listings** (5 keywords × 50), was 0.
- `adzuna.test.js` 16/16; full suite **1978/1978**; `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)