### PR TITLE
docs(skill): escalation auto-ships at coverage >=85

### DIFF
--- a/skills/job-pipeline/SKILL.md
+++ b/skills/job-pipeline/SKILL.md
@@ -351,10 +351,9 @@ If a Strong row genuinely cannot proceed (e.g. `master_profile.md` is missing an
 
 **Escalation decision** (after loop exit):
 
-- `final_coverage < 85 && last_delta < 1` → `tailorEscalated = true`, `tailorEscalationReason = "no_growth_below_threshold"`.
-- `final_coverage < 85 && last_delta >= 1` (still climbing, hit the cap — requires `iterations == 6`) → `tailorEscalated = true`, `tailorEscalationReason = "iteration_cap_below_threshold"`.
-- `final_coverage >= 85 && uncertain_facts.length > 0` → `tailorEscalated = true`, `tailorEscalationReason = "uncertain_about_fact"`.
-- Otherwise → `tailorEscalated = false`, `tailorEscalationReason = null` (auto-ship).
+- `final_coverage >= 85` → **always auto-ship**: `tailorEscalated = false`, `tailorEscalationReason = null`. Carry forward `uncertain_facts[]` in `tailorEscalationDetail.uncertain_facts` as a heads-up for the operator, but the row pushes to Notion. Threshold met means the resume mirror is good enough; remaining uncertain_facts are honest disclosures the operator can review in Notion's Cover Letter / Notes fields, not blockers (2026-05-26 — was previously gating ship, which over-escalated cosmetic gaps like "AWS is a plus, not in master profile").
+- `final_coverage < 85 && last_delta < 1` (after iter≥2) → `tailorEscalated = true`, `tailorEscalationReason = "no_growth_below_threshold"`.
+- `final_coverage < 85 && last_delta >= 1 && iterations == 6` → `tailorEscalated = true`, `tailorEscalationReason = "iteration_cap_below_threshold"`.
 
 **Per-row fields to attach** (carried into the results.json entry written in Step 10):
 - `tailoredResume` — the final `resume_data` object from the last subagent run. Schema matches `engine/modules/resume/resume_docx.js` input.


### PR DESCRIPTION
## What

Aligns job-pipeline SKILL **Step 6.5 escalation decision** with the 2026-05-26 behavior that was already documented inline but lived only as an uncommitted local edit:

- `final_coverage >= 85` → **always auto-ship** (`tailorEscalated=false`); carry `uncertain_facts[]` forward in `tailorEscalationDetail.uncertain_facts` as an operator heads-up instead of gating the ship.
- Below-threshold rules unchanged: `no_growth_below_threshold` (iter≥2), `iteration_cap_below_threshold` (iter==6).

## Why

The previous rule escalated any ≥85 row that still carried an `uncertain_fact`, over-flagging cosmetic gaps (e.g. "AWS is a plus, not in master profile") that aren't real blockers. Threshold-met means the mirror is good enough; remaining uncertain_facts are honest disclosures the operator reviews in Notion.

Committing so origin/main and cloud sessions pick it up (it was diverging as a local-only edit).

## Test

- `prettier --check skills/job-pipeline/SKILL.md` → clean.
- Docs-only change to SKILL prose; no engine code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)