### PR TITLE
fix(sync): BL-168 / RFC 058 — reconcile resolves Company relation to name

### DIFF
--- a/engine/commands/sync.js
+++ b/engine/commands/sync.js
@@ -24,6 +24,7 @@ const applications = require("../core/applications_tsv.js");
 const notion = require("../core/notion_sync.js");
 const { resolveProfilesDir } = require("../core/paths.js");
 const archiveSweep = require("../core/archive_used_artifacts.js");
+const { makeCompanyNameResolver } = require("../core/company_resolver.js");
 
 // Canonical map lives in notion_sync.js — all Notion-touching commands
 // share it. Re-export here as a const so the rest of this file stays
@@ -38,6 +39,9 @@ const DEFAULT_DEPS = {
   makeClient: notion.makeClient,
   fetchJobsFromDatabase: notion.fetchJobsFromDatabase,
   updateCalloutBlock: notion.updateCalloutBlock,
+  // RFC 058: reverse company resolver (relation page-id → name). Injected so
+  // tests can fake Notion. Defaults to the real Companies-DB reader.
+  makeCompanyNameResolver,
   now: () => new Date().toISOString(),
   // BL-151 / RFC 054: archive-sweep facade. Defaults to the real `fs`
   // module; tests inject in-memory fakes.
@@ -48,38 +52,52 @@ const DEFAULT_DEPS = {
   },
 };
 
+// Page → matchKey: `key` field if present in the Notion property map,
+// otherwise composite (source, jobId). Shared by reconcilePull and the
+// sync command's company-id collection so the two never drift.
+function matchKeyForPage(page, propertyMap) {
+  const keyField = propertyMap.key && propertyMap.key.field;
+  const sourceField = propertyMap.source && propertyMap.source.field;
+  const jobIdField = propertyMap.jobId && propertyMap.jobId.field;
+  const k = keyField ? page.key : null;
+  const composite =
+    sourceField && jobIdField && page.source && page.jobId
+      ? `${String(page.source).toLowerCase()}:${page.jobId}`
+      : null;
+  return k || composite;
+}
+
+// Resolve a page's company name. Profiles that store company as a Notion
+// `relation` expose it as `page.companyRelation = [companyPageId]` with NO
+// `page.companyName`; the caller resolves those ids to names up front and
+// passes them in `companyNameById`. Text-company profiles fall back to the
+// plain `page.companyName`. Returns "" when neither is available (RFC 058).
+function companyNameForPage(page, companyNameById) {
+  const relIds = Array.isArray(page.companyRelation) ? page.companyRelation : [];
+  const resolved = relIds.length ? companyNameById[String(relIds[0])] : null;
+  return resolved || page.companyName || "";
+}
+
 // Reconcile Notion → local TSV. Pure: no I/O, no Date.now(). `now` (ISO
 // string) is passed in so added rows get deterministic createdAt/updatedAt.
+// `companyNameById` (RFC 058 / BL-168) maps Companies-DB page ids → names so
+// relation-company profiles get a populated `companyName` instead of "".
 //
 // Returns { updates, adds }:
 //   updates — { before, after } pairs for existing local rows whose
-//             notion_page_id / status drifted from Notion (Notion wins).
+//             notion_page_id / status / (empty) companyName drifted from
+//             Notion (Notion wins; a populated local companyName is never
+//             overwritten).
 //   adds    — full TSV row objects for Notion pages with NO matching local
 //             row. This makes the pull additive: the fly.io cron's stale
 //             TSV picks up apps created on the operator's Mac (RFC 055).
 //
 // Idempotent: on a rerun the previously-added rows now exist locally, so
 // they match in the update pass and never re-appear in `adds`.
-function reconcilePull(apps, notionPages, propertyMap, now) {
-  // Notion is source of truth for status (and notion_page_id, naturally).
-  // We match by `key` field if present in the Notion property map; otherwise
-  // by composite (source, jobId).
-  const keyField = propertyMap.key && propertyMap.key.field;
-  const sourceField = propertyMap.source && propertyMap.source.field;
-  const jobIdField = propertyMap.jobId && propertyMap.jobId.field;
-
-  const matchKeyFor = (page) => {
-    const k = keyField ? page.key : null;
-    const composite =
-      sourceField && jobIdField && page.source && page.jobId
-        ? `${String(page.source).toLowerCase()}:${page.jobId}`
-        : null;
-    return k || composite;
-  };
-
+function reconcilePull(apps, notionPages, propertyMap, now, companyNameById = {}) {
   const byKey = new Map();
   for (const page of notionPages) {
-    const matchKey = matchKeyFor(page);
+    const matchKey = matchKeyForPage(page, propertyMap);
     if (matchKey) byKey.set(matchKey, page);
   }
 
@@ -99,6 +117,15 @@ function reconcilePull(apps, notionPages, propertyMap, now) {
       next.status = page.status;
       changed = true;
     }
+    // Backfill an empty companyName from Notion (self-heals the rows BL-154
+    // added blank). Never overwrite a name the local row already has.
+    if (!app.companyName) {
+      const resolvedName = companyNameForPage(page, companyNameById);
+      if (resolvedName) {
+        next.companyName = resolvedName;
+        changed = true;
+      }
+    }
     if (changed) updates.push({ before: app, after: next });
   }
 
@@ -112,7 +139,7 @@ function reconcilePull(apps, notionPages, propertyMap, now) {
       key: matchKey,
       source,
       jobId: page.jobId || "",
-      companyName: page.companyName || "",
+      companyName: companyNameForPage(page, companyNameById),
       title: page.title || "",
       url: page.url || "",
       locations: Array.isArray(page.locations) ? page.locations.map(String) : [],
@@ -178,7 +205,37 @@ function makeSyncCommand(overrides = {}) {
     let pullErrors = 0;
     try {
       const pages = await deps.fetchJobsFromDatabase(getClient(), databaseId, propertyMap);
-      ({ updates, adds } = reconcilePull(apps, pages, propertyMap, deps.now()));
+      // RFC 058: profiles that store company as a Notion `relation` expose it
+      // as page ids, not names. Resolve the ids we actually need — pages that
+      // will be added (no local row) or whose local row has an empty
+      // companyName — so reconcile populates the column instead of leaving it
+      // blank (which would silently drop the row from check's active set).
+      // Non-fatal: a resolver failure leaves names empty, same as before.
+      let companyNameById = {};
+      const hasRelation = propertyMap.companyRelation && propertyMap.companyRelation.field;
+      if (hasRelation) {
+        const localByKey = new Map(apps.map((a) => [a.key, a]));
+        const neededIds = new Set();
+        for (const page of pages) {
+          const relIds = Array.isArray(page.companyRelation) ? page.companyRelation : [];
+          if (!relIds.length) continue;
+          const mk = matchKeyForPage(page, propertyMap);
+          const local = mk ? localByKey.get(mk) : null;
+          if (!local || !local.companyName) neededIds.add(String(relIds[0]));
+        }
+        if (neededIds.size) {
+          try {
+            const resolver = deps.makeCompanyNameResolver({
+              client: getClient(),
+              log: (m) => ctx.stderr(`  ${m}`),
+            });
+            companyNameById = await resolver.resolveIds(Array.from(neededIds));
+          } catch (err) {
+            ctx.stderr(`  warn: company-name resolve failed: ${err.message}`);
+          }
+        }
+      }
+      ({ updates, adds } = reconcilePull(apps, pages, propertyMap, deps.now(), companyNameById));
       stdout(
         `pull plan: ${updates.length} local row(s) would change from Notion state, ` +
           `${adds.length} new row(s) would be added`
@@ -302,4 +359,5 @@ function makeSyncCommand(overrides = {}) {
 module.exports = makeSyncCommand();
 module.exports.makeSyncCommand = makeSyncCommand;
 module.exports.reconcilePull = reconcilePull;
+module.exports.matchKeyForPage = matchKeyForPage;
 module.exports.DEFAULT_PROPERTY_MAP = DEFAULT_PROPERTY_MAP;

--- a/engine/commands/sync.test.js
+++ b/engine/commands/sync.test.js
@@ -535,3 +535,126 @@ test("sync dry-run does NOT archive (mutations gated on --apply)", async () => {
   assert.equal(archiveFs.calls.rename.length, 0);
   assert.doesNotMatch(out.all(), /\[sync\] archived/);
 });
+
+// ---------------------------------------------------------------------------
+// RFC 058 / BL-168 — reconcile resolves the Company relation to a name.
+// ---------------------------------------------------------------------------
+
+const { matchKeyForPage } = require("./sync.js");
+const { makeCompanyNameResolver } = require("../core/company_resolver.js");
+
+test("reconcilePull add-path fills companyName from the relation map (RFC 058)", () => {
+  const apps = [];
+  const pages = [
+    {
+      notionPageId: "p9",
+      key: "lever:pix",
+      source: "lever",
+      jobId: "pix",
+      companyRelation: ["co-1"], // relation id, NO companyName text
+      title: "Senior PM - Pix Squad",
+      status: "Applied",
+    },
+  ];
+  const { adds } = reconcilePull(apps, pages, DEFAULT_PROPERTY_MAP, NOW, { "co-1": "dLocal" });
+  assert.equal(adds.length, 1);
+  assert.equal(adds[0].companyName, "dLocal");
+});
+
+test("reconcilePull add-path leaves companyName empty when relation unresolved", () => {
+  const pages = [
+    { notionPageId: "p9", key: "lever:pix", source: "lever", jobId: "pix", companyRelation: ["co-x"], status: "Applied" },
+  ];
+  const { adds } = reconcilePull([], pages, DEFAULT_PROPERTY_MAP, NOW, {}); // no map entry
+  assert.equal(adds[0].companyName, "");
+});
+
+test("reconcilePull backfills an existing row's empty companyName (RFC 058)", () => {
+  const apps = [fakeApp({ key: "lever:pix", source: "lever", jobId: "pix", companyName: "", status: "Applied" })];
+  const pages = [
+    { notionPageId: "p9", key: "lever:pix", source: "lever", jobId: "pix", companyRelation: ["co-1"], status: "Applied" },
+  ];
+  const { updates } = reconcilePull(apps, pages, DEFAULT_PROPERTY_MAP, NOW, { "co-1": "dLocal" });
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0].after.companyName, "dLocal");
+});
+
+test("reconcilePull never overwrites a populated companyName", () => {
+  const apps = [fakeApp({ key: "lever:pix", source: "lever", jobId: "pix", companyName: "dLocal Inc", status: "Applied" })];
+  const pages = [
+    { notionPageId: "p9", key: "lever:pix", source: "lever", jobId: "pix", companyRelation: ["co-1"], status: "Applied" },
+  ];
+  // Same status + page id → no change; companyName must stay as the local value.
+  const withPage = pages.map((p) => ({ ...p, notionPageId: "", status: "Applied" }));
+  const { updates } = reconcilePull(apps, withPage, DEFAULT_PROPERTY_MAP, NOW, { "co-1": "OtherName" });
+  assert.equal(updates.length, 0);
+});
+
+test("matchKeyForPage prefers key, falls back to composite", () => {
+  assert.equal(matchKeyForPage({ key: "lever:a" }, DEFAULT_PROPERTY_MAP), "lever:a");
+  assert.equal(matchKeyForPage({ source: "Lever", jobId: "a" }, DEFAULT_PROPERTY_MAP), "lever:a");
+});
+
+test("makeCompanyNameResolver reads the title and caches per id", async () => {
+  let retrieves = 0;
+  const client = {
+    pages: {
+      retrieve: async ({ page_id }) => {
+        retrieves += 1;
+        const names = { "co-1": "dLocal", "co-2": "Stripe" };
+        return { properties: { Name: { title: [{ plain_text: names[page_id] || "" }] } } };
+      },
+    },
+  };
+  const r = makeCompanyNameResolver({ client });
+  const map = await r.resolveIds(["co-1", "co-2", "co-1"]);
+  assert.deepEqual(map, { "co-1": "dLocal", "co-2": "Stripe" });
+  assert.equal(retrieves, 2, "deduped: one retrieve per unique id");
+});
+
+test("makeCompanyNameResolver returns null for untitled and unreadable pages", async () => {
+  const client = {
+    pages: {
+      retrieve: async ({ page_id }) => {
+        if (page_id === "boom") throw new Error("not found");
+        return { properties: { Name: { title: [] } } }; // untitled
+      },
+    },
+  };
+  const r = makeCompanyNameResolver({ client, log: () => {} });
+  const map = await r.resolveIds(["empty", "boom"]);
+  assert.equal(map.empty, null);
+  assert.equal(map.boom, null);
+});
+
+test("sync --apply resolves relation ids and persists the resolved company (RFC 058)", async () => {
+  const saved = [];
+  const resolverCalls = [];
+  const { deps } = makeDeps({
+    loadApplications: () => ({ apps: [fakeApp({ jobId: "1" })] }),
+    saveApplications: (file, apps) => saved.push({ file, apps }),
+    fetchJobsFromDatabase: async () => [
+      {
+        notionPageId: "p2",
+        key: "lever:pix",
+        source: "lever",
+        jobId: "pix",
+        companyRelation: ["co-1"], // relation only, no companyName text
+        title: "Senior PM - Pix Squad",
+        status: "Applied",
+      },
+    ],
+    makeCompanyNameResolver: () => ({
+      resolveIds: async (ids) => {
+        resolverCalls.push(ids);
+        return { "co-1": "dLocal" };
+      },
+    }),
+  });
+  const { ctx } = makeCtx({ flags: { dryRun: false, apply: true, verbose: false } });
+  const code = await makeSyncCommand(deps)(ctx);
+  assert.equal(code, 0);
+  assert.deepEqual(resolverCalls, [["co-1"]], "resolver called with the needed id");
+  const addedRow = saved[0].apps.find((a) => a.key === "lever:pix");
+  assert.equal(addedRow.companyName, "dLocal");
+});

--- a/engine/commands/sync.test.js
+++ b/engine/commands/sync.test.js
@@ -563,16 +563,38 @@ test("reconcilePull add-path fills companyName from the relation map (RFC 058)",
 
 test("reconcilePull add-path leaves companyName empty when relation unresolved", () => {
   const pages = [
-    { notionPageId: "p9", key: "lever:pix", source: "lever", jobId: "pix", companyRelation: ["co-x"], status: "Applied" },
+    {
+      notionPageId: "p9",
+      key: "lever:pix",
+      source: "lever",
+      jobId: "pix",
+      companyRelation: ["co-x"],
+      status: "Applied",
+    },
   ];
   const { adds } = reconcilePull([], pages, DEFAULT_PROPERTY_MAP, NOW, {}); // no map entry
   assert.equal(adds[0].companyName, "");
 });
 
 test("reconcilePull backfills an existing row's empty companyName (RFC 058)", () => {
-  const apps = [fakeApp({ key: "lever:pix", source: "lever", jobId: "pix", companyName: "", status: "Applied" })];
+  const apps = [
+    fakeApp({
+      key: "lever:pix",
+      source: "lever",
+      jobId: "pix",
+      companyName: "",
+      status: "Applied",
+    }),
+  ];
   const pages = [
-    { notionPageId: "p9", key: "lever:pix", source: "lever", jobId: "pix", companyRelation: ["co-1"], status: "Applied" },
+    {
+      notionPageId: "p9",
+      key: "lever:pix",
+      source: "lever",
+      jobId: "pix",
+      companyRelation: ["co-1"],
+      status: "Applied",
+    },
   ];
   const { updates } = reconcilePull(apps, pages, DEFAULT_PROPERTY_MAP, NOW, { "co-1": "dLocal" });
   assert.equal(updates.length, 1);
@@ -580,13 +602,30 @@ test("reconcilePull backfills an existing row's empty companyName (RFC 058)", ()
 });
 
 test("reconcilePull never overwrites a populated companyName", () => {
-  const apps = [fakeApp({ key: "lever:pix", source: "lever", jobId: "pix", companyName: "dLocal Inc", status: "Applied" })];
+  const apps = [
+    fakeApp({
+      key: "lever:pix",
+      source: "lever",
+      jobId: "pix",
+      companyName: "dLocal Inc",
+      status: "Applied",
+    }),
+  ];
   const pages = [
-    { notionPageId: "p9", key: "lever:pix", source: "lever", jobId: "pix", companyRelation: ["co-1"], status: "Applied" },
+    {
+      notionPageId: "p9",
+      key: "lever:pix",
+      source: "lever",
+      jobId: "pix",
+      companyRelation: ["co-1"],
+      status: "Applied",
+    },
   ];
   // Same status + page id → no change; companyName must stay as the local value.
   const withPage = pages.map((p) => ({ ...p, notionPageId: "", status: "Applied" }));
-  const { updates } = reconcilePull(apps, withPage, DEFAULT_PROPERTY_MAP, NOW, { "co-1": "OtherName" });
+  const { updates } = reconcilePull(apps, withPage, DEFAULT_PROPERTY_MAP, NOW, {
+    "co-1": "OtherName",
+  });
   assert.equal(updates.length, 0);
 });
 

--- a/engine/core/company_resolver.js
+++ b/engine/core/company_resolver.js
@@ -117,4 +117,66 @@ function makeCompanyResolver({
   return { resolve, resolveMany, _cache: cache };
 }
 
-module.exports = { makeCompanyResolver };
+// Reverse resolver (page-id → company name). The forward resolver above maps
+// a name to a Companies-DB page id when *creating* job pages. `sync`'s
+// reconcile needs the opposite: a Notion job page exposes its company only as
+// a `relation` (an array of Companies-DB page ids), and we need the human name
+// to populate `applications.tsv`'s `companyName` column. Without this, every
+// reconcile-added row lands with an empty company and is silently dropped from
+// the email matcher's active set (RFC 058 / BL-168).
+//
+// Reads the title property (`Name` by default) of each Companies-DB page.
+// In-run cache by page id; a missing / untitled / unreadable page resolves to
+// `null` (caller leaves companyName empty rather than guessing).
+function makeCompanyNameResolver({ client, titleField = "Name", log = () => {} }) {
+  if (!client) throw new Error("client is required");
+  const cache = new Map();
+
+  function extractTitle(page) {
+    const prop = page && page.properties && page.properties[titleField];
+    const rt = prop && Array.isArray(prop.title) ? prop.title : null;
+    if (!rt) return null;
+    const text = rt
+      .map((t) => (t && (t.plain_text || (t.text && t.text.content))) || "")
+      .join("")
+      .trim();
+    return text || null;
+  }
+
+  async function resolveId(pageId) {
+    if (!pageId) return null;
+    const id = String(pageId);
+    if (cache.has(id)) return cache.get(id);
+    let name = null;
+    try {
+      const page = await client.pages.retrieve({ page_id: id });
+      name = extractTitle(page);
+    } catch (err) {
+      log(`company name resolve failed for ${id}: ${err.message}`);
+      name = null;
+    }
+    cache.set(id, name);
+    return name;
+  }
+
+  // Returns a map { pageId -> name|null }. Bounded concurrency; deduped.
+  async function resolveIds(ids, { concurrency = 4 } = {}) {
+    const unique = Array.from(new Set((ids || []).filter(Boolean).map(String)));
+    const out = {};
+    let idx = 0;
+    async function worker() {
+      while (idx < unique.length) {
+        const i = idx++;
+        out[unique[i]] = await resolveId(unique[i]);
+      }
+    }
+    await Promise.all(
+      Array.from({ length: Math.min(concurrency, unique.length) || 0 }, () => worker())
+    );
+    return out;
+  }
+
+  return { resolveId, resolveIds, _cache: cache };
+}
+
+module.exports = { makeCompanyResolver, makeCompanyNameResolver };

--- a/rfc/058-reconcile-resolve-company-relation.md
+++ b/rfc/058-reconcile-resolve-company-relation.md
@@ -1,0 +1,119 @@
+# RFC 058 — Reconcile must resolve the Company relation to a name
+
+- Status: **proposed**
+- Date: 2026-06-01
+- Refs: BL-168, RFC 055 (cron TSV freshness — the incomplete fix), BL-154
+  (additive reconcile), RFC 014 (status split)
+- Tier: M
+
+## Problem
+
+Operator-reported (2026-06-01): a real dLocal rejection
+("Senior Product Manager - Pix Squad", `no-reply@hire.lever.co`, arrived
+06:50 PT) was never reflected in Notion, and the cron has been silently
+dropping responses for ~2 days.
+
+Confirmed live on the fly box (`ai-job-searcher-cron`, release v28 —
+post-BL-154, so the reconcile code IS deployed):
+
+- The Pix Squad row exists on `/data/.../applications.tsv` with
+  `status=Applied`, `notion_page_id` set — **but `companyName` is empty**.
+- `buildActiveJobsMap` ([check.js](../engine/commands/check.js)) drops any
+  row with no `companyName` (`const co = app.companyName; if (!co) continue;`).
+  So the row is excluded from the active set → the dLocal email is fetched
+  by the ATS-sender batch (Lever) but matches no active company → no action.
+- This is not one row: **215 active rows on the fly volume have an empty
+  `companyName`** (vs 117 populated). Every one is invisible to the email
+  matcher.
+
+### Root cause
+
+BL-154 made `reconcilePull` ([sync.js:63](../engine/commands/sync.js))
+additive: it appends a full v5 row for each Notion page with no local
+match. The add-row sets `companyName: page.companyName || ""`.
+
+But jared's (and lilia's) Notion stores company as a **relation**
+(`property_map.companyRelation = { field: "Company", type: "relation" }`),
+not a text field. `parseNotionPage`
+([notion_sync.js:140](../engine/core/notion_sync.js)) therefore produces
+`page.companyRelation = [companyPageId]` and **no `page.companyName`**. So
+every reconcile-added row gets `companyName: ""`.
+
+On the Mac the same rows are fine because they were created by `scan`
+(which carries `companyName` from the ATS posting); the reconcile only
+hits the *update* path there and never overwrites the existing name. On
+fly the rows never existed locally, so they hit the *add* path and land
+empty. Net: BL-154 added the rows the cron was missing, but added them
+inert — the very problem it set out to fix remains for every
+relation-company profile.
+
+## Goal / what changes for the operator
+
+- The fly cron's daily reconcile populates `companyName` on
+  reconcile-added rows (and backfills the 215 already-empty ones), so
+  every active Notion application becomes matchable again.
+- After fix + redeploy, a one-off `check --auto --apply --reprocess-since
+  <date>` recovers the rejections/invites missed during the broken window
+  (including dLocal Pix Squad → Rejected).
+- No behaviour change for text-company profiles (`_example`) or for the
+  Mac, where `companyName` is already present.
+
+## Design
+
+### 1. Reverse company resolver (id → name)
+
+`company_resolver.js` already does name → page-id. Add a thin reverse
+helper (same file or `notion_sync.js`) that, given a set of Companies-DB
+page-ids, fetches each page once and reads its title (`Name`) into a
+`{ pageId → name }` map. In-run cache; bounded concurrency; a missing /
+untitled page resolves to `null` (left empty, counted in a warn).
+
+### 2. `reconcilePull` stays pure; sync command resolves first
+
+`reconcilePull` must remain pure (no I/O — tests depend on it). Add an
+optional `companyNameById` map argument:
+
+- **Add path:** `companyName = companyNameById[firstRelationId] ||
+  page.companyName || ""`.
+- **Update path (backfill):** if the existing local row's `companyName`
+  is empty **and** a resolved name exists, set it and mark `changed`
+  (so the 215 stale rows self-heal on the next reconcile — no separate
+  migration script).
+
+The `sync` command (which owns the Notion client) collects the relation
+ids it needs — from would-be adds **and** from existing rows whose
+`companyName` is empty — resolves them via the reverse resolver, and
+passes the map into `reconcilePull`. Resolution is skipped entirely when
+the profile's `property_map` has no `companyRelation` (text-company
+profiles take the existing `page.companyName` path unchanged).
+
+### 3. Cost
+
+One `pages.retrieve` per unique company id, only for ids actually needed.
+The backfill reconcile resolves ~200 ids once; subsequent daily reconciles
+add few rows → a handful of lookups. Acceptable for a once-daily cron.
+
+## Definition of Done
+
+- Reverse resolver: unit-tested with a faked client (cache hit, missing
+  page → null, untitled page → null).
+- `reconcilePull`: add-path and empty-update-path populate `companyName`
+  from the map; non-empty existing names never overwritten; pure (no I/O);
+  idempotent on rerun; text-company path (no `companyRelation`) unchanged.
+- `sync` command: resolves only needed ids; `--no-sync` parity unaffected;
+  Notion/resolver errors are non-fatal (logged, reconcile proceeds with
+  whatever resolved).
+- Smoke: local `sync --apply` against jared backfills empty companyName on
+  reconcile-added rows; `check --auto --no-sync` then matches a Lever
+  rejection to its row.
+- Network mocked in all unit tests.
+- After merge + redeploy: empty-company active count on fly drops to ~0;
+  a `--reprocess-since` run sets dLocal Pix Squad → Rejected.
+- `incidents.md` entry (blameless): BL-154 add-path missed relation
+  resolution; 215 inert rows; how caught (live fly inspection).
+
+## Out of scope (separate follow-up BL)
+
+Monitoring robustness so a future silent miss is visible: reflect
+reconcile failure in the heartbeat, and log "ATS email fetched but
+unmatched". Tracked separately — not bundled into this fix.


### PR DESCRIPTION
## Problem

The fly cron silently dropped job-application responses for ~2 days. Operator-reported via a real dLocal rejection ("Senior Product Manager - Pix Squad") that never reached Notion.

**Root cause:** BL-154's additive `reconcilePull` writes `companyName: page.companyName || ""`, but company is stored in Notion as a **`relation`** (page-ids, not text). `parseNotionPage` never resolves it, so every reconcile-added row lands with an empty `companyName`. `buildActiveJobsMap` drops empty-company rows (`if (!app.companyName) continue`), so their response emails are fetched (ATS batch) but matched to nothing.

Confirmed live on `ai-job-searcher-cron` (v28, post-BL-154): **215 active rows with empty companyName** vs 117 populated; Pix Squad row was `Applied` + had `notion_page_id` but blank company.

## Fix

- `makeCompanyNameResolver` (Companies-DB page-id → title `Name`): cached, bounded concurrency, `null` on missing/untitled/unreadable.
- `reconcilePull` stays pure; optional `companyNameById` fills added rows **and** backfills existing rows whose `companyName` is empty — never overwriting a populated name, so the 215 stale rows self-heal on the next reconcile (no migration script).
- `sync` resolves only the ids it needs (adds + empty-company rows); skipped for text-company profiles; resolver failure is non-fatal.

## Verification

- 1978/1978 tests green; 8 new tests (reconcile add/backfill/no-overwrite, resolver cache/null/dedup, sync `--apply` relation→name integration). Network mocked.
- prettier clean.
- code-reviewer subagent: no blockers (in-scope profiles define a `key` field, so backfill matching aligns).

## After merge

Redeploy fly, then `check --auto --apply --reprocess-since <date>` to recover responses missed during the broken window (dLocal Pix Squad → Rejected).

Follow-up (separate BL): surface reconcile failure in the heartbeat + log "ATS email fetched but unmatched" so a future silent miss is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)