### PR TITLE
feat(profile): BL-180 — ## Awards section in master profile generator

### DIFF
--- a/scripts/build_master_profile.js
+++ b/scripts/build_master_profile.js
@@ -468,6 +468,20 @@ function renderMaster(rv, profileId, opts = {}) {
     out += "\n";
   }
 
+  // Awards
+  if (Array.isArray(rv.awards) && rv.awards.length) {
+    out += "## Awards\n\n";
+    for (const a of rv.awards) {
+      const vis = a.archetypes ? `variant-specific` : `always`;
+      out += `- Visibility: \`${vis}\`\n`;
+      if (vis === "variant-specific") out += `  - Variants: [${a.archetypes.join(", ")}]\n`;
+      out += `  - ${a.name || ""}\n`;
+      if (a.displayDate) out += `  - Date: ${a.displayDate}\n`;
+      if (a.context) out += `  - Context: ${a.context}\n`;
+    }
+    out += "\n";
+  }
+
   // Skills Inventory
   out += "## Skills Inventory\n\n";
   out +=

--- a/scripts/build_master_profile.test.js
+++ b/scripts/build_master_profile.test.js
@@ -352,6 +352,37 @@ test("renderMaster uses rv.languages when provided", () => {
   assert.ok(md.includes("- Russian — Native"));
 });
 
+test("renderMaster renders Awards section from rv.awards", () => {
+  const rv = {
+    ...fixtureRv,
+    awards: [
+      {
+        name: "FinTech Awards Russia 2024",
+        displayDate: "2024",
+        context: "Application redesign — 2-field flow.",
+        archetypes: null,
+      },
+      {
+        name: "Alfa Award 2022",
+        displayDate: "2022",
+        context: "MFI revenue.",
+        archetypes: ["ArchA"],
+      },
+    ],
+  };
+  const md = renderMaster(rv, "testprofile", { generatedAt: "2026-05-24", sourceHash: "x" });
+  assert.ok(md.includes("## Awards"));
+  assert.ok(md.includes("FinTech Awards Russia 2024"));
+  assert.ok(md.includes("Context: Application redesign — 2-field flow."));
+  // archetypes: null → always; archetypes: [...] → variant-specific with Variants line
+  assert.ok(md.includes("Variants: [ArchA]"));
+});
+
+test("renderMaster omits Awards section when rv.awards is absent", () => {
+  const md = renderMaster(fixtureRv, "testprofile", { generatedAt: "2026-05-24", sourceHash: "x" });
+  assert.ok(!md.includes("## Awards"));
+});
+
 test("renderMaster renders length_constrained_priority on roles", () => {
   const rv = {
     ...fixtureRv,


### PR DESCRIPTION
## What

Adds an `## Awards` renderer to `scripts/build_master_profile.js`. It reads a new top-level `awards[]` array from `resume_versions.json` and emits a section (visibility derived from `archetypes`, mirroring the Certifications convention). Omitted when no awards are present.

## Why

Part of **BL-180** — Credit Mentor positioning reframe (advisory → Senior AI Product Manager, ownership voice) plus attaching the **Alfa Award 2022** and **FinTech Awards Russia 2024** with context. Before this, awards only existed scattered through prose summaries; now they render as a structured section in the generated master profile.

## Scope of this PR

Tracked code only: the generator change + 2 unit tests. The profile data, storybank, `constraints.md`, and memory edits that complete BL-180 are gitignored personal data and live outside the repo.

## Tests

- +2 unit tests: renders from `rv.awards`; section omitted when absent.
- Full suite **1988/1988 green**; `prettier --check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)