### PR TITLE
feat(outreach): RFC 059 phase 1 — TSV v6 outreach columns + LinkedIn search-URL helper

### DIFF
--- a/engine/core/applications_tsv.js
+++ b/engine/core/applications_tsv.js
@@ -1,9 +1,8 @@
 // Per-profile pipeline file: profiles/<id>/applications.tsv.
 //
-// Schema (header required), v5 (added 2026-05-18 for BL-93 / RFC 038 — persist
-// the full multi-element locations[] array from discovery instead of collapsing
-// to locations[0]). The on-disk column is renamed `location` → `locations` and
-// carries a JSON-encoded array of strings:
+// Schema (header required), v6 (added 2026-06-03 for BL-169 / RFC 059 — append
+// six hiring-manager / warm-contact outreach columns). The v6 columns extend v5
+// with the outreach motion tracked on the vacancy card:
 //   key <TAB> source <TAB> jobId <TAB> companyName <TAB> title <TAB> url
 //             <TAB> locations <TAB> status <TAB> notion_page_id
 //             <TAB> resume_ver <TAB> cl_key
@@ -11,6 +10,26 @@
 //             <TAB> createdAt <TAB> updatedAt
 //             <TAB> fit_score <TAB> fit_rationale <TAB> fit_evaluated_at
 //             <TAB> skip_reason
+//             <TAB> company_people_search_url <TAB> outreach_type
+//             <TAB> contact_name <TAB> contact_linkedin
+//             <TAB> hm_outreach_status <TAB> hm_outreach_date
+//
+// v6 outreach columns (RFC 059):
+//   `company_people_search_url` — LinkedIn people-search URL, engine-authored by
+//                                 `prepare --phase commit` for Medium+/Strong rows.
+//   `outreach_type`             — "warm" | "cold" | "" (operator → Notion → sync).
+//   `contact_name`              — free text (operator → Notion → sync).
+//   `contact_linkedin`          — URL (operator → Notion → sync).
+//   `hm_outreach_status`        — "to_search" | "searching" | "pending_connection"
+//                                 | "connected" | "dm_sent" | "replied" | "dead".
+//                                 Defaults to "to_search" so existing rows land in
+//                                 a valid lifecycle state (operator → Notion → sync).
+//   `hm_outreach_date`          — ISO date (operator → Notion → sync).
+//
+// v5 (added 2026-05-18 for BL-93 / RFC 038 — persist the full multi-element
+// locations[] array from discovery instead of collapsing to locations[0]). The
+// on-disk column is renamed `location` → `locations` and carries a JSON-encoded
+// array of strings.
 //
 // `key` = "<source>:<jobId>" — primary, used for dedup against the master pool.
 // New entries default to status="Inbox" (post-RFC 014, 2026-05-04). "Inbox" =
@@ -56,13 +75,18 @@
 // from v3/v4 is gone — every caller now reads the array).
 //
 // Backward compat (auto-upgrade-on-save):
+//   v5 (20 cols, 2026-05-18 — RFC 038 locations[]) → reader seeds the six v6
+//     outreach defaults (empty + hm_outreach_status="to_search").
 //   v4 (20 cols, 2026-05-05 — BL-9 fit columns, single-string `location`) →
-//     reader wraps non-empty `location` to `[location]`, empty to `[]`.
-//   v3 (16 cols, 2026-05-03 — G-5 added location) → same wrap; empty fit cols.
+//     reader wraps non-empty `location` to `[location]`, empty to `[]`, and
+//     seeds the v6 outreach defaults.
+//   v3 (16 cols, 2026-05-03 — G-5 added location) → same wrap; empty fit cols;
+//     v6 outreach defaults.
 //   v2 (15 cols, 2026-04 — Stage 13 added salary_min/max/cl_path) → empty
-//     locations array + empty fit cols.
-//   v1 (12 cols, original) → empty locations + empty v2+v3+v4 fields.
-// save() always writes v5.
+//     locations array + empty fit cols + v6 outreach defaults.
+//   v1 (12 cols, original) → empty locations + empty v2+v3+v4 fields + v6
+//     outreach defaults.
+// save() always writes v6.
 
 const fs = require("fs");
 const path = require("path");
@@ -83,6 +107,35 @@ function stripAtsPrefixes(id) {
     prev = m[2];
   }
 }
+
+const HEADER_V6 = [
+  "key",
+  "source",
+  "jobId",
+  "companyName",
+  "title",
+  "url",
+  "locations",
+  "status",
+  "notion_page_id",
+  "resume_ver",
+  "cl_key",
+  "salary_min",
+  "salary_max",
+  "cl_path",
+  "createdAt",
+  "updatedAt",
+  "fit_score",
+  "fit_rationale",
+  "fit_evaluated_at",
+  "skip_reason",
+  "company_people_search_url",
+  "outreach_type",
+  "contact_name",
+  "contact_linkedin",
+  "hm_outreach_status",
+  "hm_outreach_date",
+];
 
 const HEADER_V5 = [
   "key",
@@ -109,7 +162,22 @@ const HEADER_V5 = [
 
 // Current schema header. Aliased so legacy callers reading `HEADER` keep
 // working; readers expect this constant to track the latest version.
-const HEADER = HEADER_V5;
+const HEADER = HEADER_V6;
+
+// RFC 059: default values for the six v6 outreach fields. Older rowToApp*
+// paths seed these so an old file loads cleanly; the next save() rewrites it
+// as v6. `hm_outreach_status` defaults to "to_search" (a valid lifecycle
+// state); the rest default empty.
+function outreachDefaults() {
+  return {
+    company_people_search_url: "",
+    outreach_type: "",
+    contact_name: "",
+    contact_linkedin: "",
+    hm_outreach_status: "to_search",
+    hm_outreach_date: "",
+  };
+}
 
 const HEADER_V4 = [
   "key",
@@ -254,7 +322,77 @@ function rowFor(app) {
     escapeField(app.fit_rationale || ""),
     escapeField(app.fit_evaluated_at || ""),
     escapeField(app.skip_reason || ""),
+    escapeField(app.company_people_search_url || ""),
+    escapeField(app.outreach_type || ""),
+    escapeField(app.contact_name || ""),
+    escapeField(app.contact_linkedin || ""),
+    escapeField(app.hm_outreach_status || ""),
+    escapeField(app.hm_outreach_date || ""),
   ].join("\t");
+}
+
+function rowToAppV6(parts, lineNo) {
+  if (parts.length < HEADER_V6.length) {
+    throw new Error(
+      `applications.tsv line ${lineNo}: expected ${HEADER_V6.length} cols, got ${parts.length}`
+    );
+  }
+  const [
+    key,
+    source,
+    jobId,
+    companyName,
+    title,
+    url,
+    locationsCell,
+    status,
+    notion_page_id,
+    resume_ver,
+    cl_key,
+    salary_min,
+    salary_max,
+    cl_path,
+    createdAt,
+    updatedAt,
+    fit_score,
+    fit_rationale,
+    fit_evaluated_at,
+    skip_reason,
+    company_people_search_url,
+    outreach_type,
+    contact_name,
+    contact_linkedin,
+    hm_outreach_status,
+    hm_outreach_date,
+  ] = parts;
+  return {
+    key,
+    source,
+    jobId,
+    companyName,
+    title,
+    url,
+    locations: decodeLocations(locationsCell),
+    status,
+    notion_page_id: notion_page_id || "",
+    resume_ver: resume_ver || "",
+    cl_key: cl_key || "",
+    salary_min: salary_min || "",
+    salary_max: salary_max || "",
+    cl_path: cl_path || "",
+    createdAt,
+    updatedAt,
+    fit_score: fit_score || "",
+    fit_rationale: fit_rationale || "",
+    fit_evaluated_at: fit_evaluated_at || "",
+    skip_reason: skip_reason || "",
+    company_people_search_url: company_people_search_url || "",
+    outreach_type: outreach_type || "",
+    contact_name: contact_name || "",
+    contact_linkedin: contact_linkedin || "",
+    hm_outreach_status: hm_outreach_status || "",
+    hm_outreach_date: hm_outreach_date || "",
+  };
 }
 
 function rowToAppV5(parts, lineNo) {
@@ -306,6 +444,7 @@ function rowToAppV5(parts, lineNo) {
     fit_rationale: fit_rationale || "",
     fit_evaluated_at: fit_evaluated_at || "",
     skip_reason: skip_reason || "",
+    ...outreachDefaults(),
   };
 }
 
@@ -358,6 +497,7 @@ function rowToAppV4(parts, lineNo) {
     fit_rationale: fit_rationale || "",
     fit_evaluated_at: fit_evaluated_at || "",
     skip_reason: skip_reason || "",
+    ...outreachDefaults(),
   };
 }
 
@@ -406,6 +546,7 @@ function rowToAppV3(parts, lineNo) {
     fit_rationale: "",
     fit_evaluated_at: "",
     skip_reason: "",
+    ...outreachDefaults(),
   };
 }
 
@@ -453,6 +594,7 @@ function rowToAppV2(parts, lineNo) {
     fit_rationale: "",
     fit_evaluated_at: "",
     skip_reason: "",
+    ...outreachDefaults(),
   };
 }
 
@@ -497,6 +639,7 @@ function rowToAppV1(parts, lineNo) {
     fit_rationale: "",
     fit_evaluated_at: "",
     skip_reason: "",
+    ...outreachDefaults(),
   };
 }
 
@@ -511,35 +654,37 @@ function load(filePath) {
   if (!lines.length) return { apps: [], path: filePath };
   const headerCols = lines[0].split("\t");
 
-  const isV5 = matchHeader(headerCols, HEADER_V5);
-  const isV4 = !isV5 && matchHeader(headerCols, HEADER_V4);
-  const isV3 = !isV5 && !isV4 && matchHeader(headerCols, HEADER_V3);
-  const isV2 = !isV5 && !isV4 && !isV3 && matchHeader(headerCols, HEADER_V2);
-  const isV1 = !isV5 && !isV4 && !isV3 && !isV2 && matchHeader(headerCols, HEADER_V1);
+  const isV6 = matchHeader(headerCols, HEADER_V6);
+  const isV5 = !isV6 && matchHeader(headerCols, HEADER_V5);
+  const isV4 = !isV6 && !isV5 && matchHeader(headerCols, HEADER_V4);
+  const isV3 = !isV6 && !isV5 && !isV4 && matchHeader(headerCols, HEADER_V3);
+  const isV2 = !isV6 && !isV5 && !isV4 && !isV3 && matchHeader(headerCols, HEADER_V2);
+  const isV1 = !isV6 && !isV5 && !isV4 && !isV3 && !isV2 && matchHeader(headerCols, HEADER_V1);
 
-  if (!isV5 && !isV4 && !isV3 && !isV2 && !isV1) {
+  if (!isV6 && !isV5 && !isV4 && !isV3 && !isV2 && !isV1) {
     throw new Error(
-      `applications.tsv header mismatch: expected v5 [${HEADER_V5.join(", ")}], v4 [${HEADER_V4.join(", ")}], v3 [${HEADER_V3.join(", ")}], v2 [${HEADER_V2.join(", ")}] or v1 [${HEADER_V1.join(", ")}], got [${headerCols.join(", ")}]`
+      `applications.tsv header mismatch: expected v6 [${HEADER_V6.join(", ")}], v5 [${HEADER_V5.join(", ")}], v4 [${HEADER_V4.join(", ")}], v3 [${HEADER_V3.join(", ")}], v2 [${HEADER_V2.join(", ")}] or v1 [${HEADER_V1.join(", ")}], got [${headerCols.join(", ")}]`
     );
   }
 
   const apps = [];
   for (let i = 1; i < lines.length; i += 1) {
     const parts = lines[i].split("\t");
-    if (isV5) apps.push(rowToAppV5(parts, i + 1));
+    if (isV6) apps.push(rowToAppV6(parts, i + 1));
+    else if (isV5) apps.push(rowToAppV5(parts, i + 1));
     else if (isV4) apps.push(rowToAppV4(parts, i + 1));
     else if (isV3) apps.push(rowToAppV3(parts, i + 1));
     else if (isV2) apps.push(rowToAppV2(parts, i + 1));
     else apps.push(rowToAppV1(parts, i + 1));
   }
-  const schemaVersion = isV5 ? 5 : isV4 ? 4 : isV3 ? 3 : isV2 ? 2 : 1;
+  const schemaVersion = isV6 ? 6 : isV5 ? 5 : isV4 ? 4 : isV3 ? 3 : isV2 ? 2 : 1;
   return { apps, path: filePath, schemaVersion };
 }
 
 function save(filePath, apps) {
   const dir = path.dirname(filePath);
   fs.mkdirSync(dir, { recursive: true });
-  const lines = [HEADER_V5.join("\t")];
+  const lines = [HEADER_V6.join("\t")];
   for (const a of apps) lines.push(rowFor(a));
   const tmp = `${filePath}.tmp.${process.pid}.${Date.now()}`;
   fs.writeFileSync(tmp, lines.join("\n") + "\n");
@@ -600,6 +745,7 @@ function appendNew(
       fit_rationale: "",
       fit_evaluated_at: "",
       skip_reason: "",
+      ...outreachDefaults(),
     });
   }
   return { apps: existing.concat(fresh), fresh, fuzzyDuplicates };
@@ -618,4 +764,5 @@ module.exports = {
   HEADER_V3,
   HEADER_V4,
   HEADER_V5,
+  HEADER_V6,
 };

--- a/engine/core/applications_tsv.test.js
+++ b/engine/core/applications_tsv.test.js
@@ -101,7 +101,7 @@ test("save + load round-trips v3 fields (salary_min, salary_max, cl_path) + v5 l
   built[0].locations = ["San Francisco, CA"];
   apps.save(file, built);
   const back = apps.load(file);
-  assert.equal(back.schemaVersion, 5);
+  assert.equal(back.schemaVersion, 6);
   assert.equal(back.apps[0].salary_min, "140000");
   assert.equal(back.apps[0].salary_max, "190000");
   assert.equal(back.apps[0].cl_path, "Affirm_analyst_20260420");
@@ -120,7 +120,7 @@ test("save + load round-trips v4 fit fields (fit_score, fit_rationale, fit_evalu
   built[0].skip_reason = "weak_fit";
   apps.save(file, built);
   const back = apps.load(file);
-  assert.equal(back.schemaVersion, 5);
+  assert.equal(back.schemaVersion, 6);
   assert.equal(back.apps[0].fit_score, "Weak");
   assert.equal(back.apps[0].fit_rationale, "Energy domain — outside PM core");
   assert.equal(back.apps[0].fit_evaluated_at, "2026-05-05T14:17:47Z");
@@ -136,7 +136,7 @@ test("v5: save + load round-trips multi-element locations array", () => {
   built[0].locations = ["Remote (UK)", "United States", "New York, NY"];
   apps.save(file, built);
   const back = apps.load(file);
-  assert.equal(back.schemaVersion, 5);
+  assert.equal(back.schemaVersion, 6);
   assert.deepEqual(back.apps[0].locations, ["Remote (UK)", "United States", "New York, NY"]);
 });
 
@@ -192,10 +192,10 @@ test("load auto-upgrades v1 files (12 cols) with empty v2+v3+v4+v5 fields", () =
   assert.equal(back.apps[0].status, "To Apply");
   assert.equal(back.apps[0].notion_page_id, "abc");
 
-  // Re-saving promotes the file to v5.
+  // Re-saving promotes the file to v6.
   apps.save(file, back.apps);
   const after = apps.load(file);
-  assert.equal(after.schemaVersion, 5);
+  assert.equal(after.schemaVersion, 6);
 });
 
 test("load auto-upgrades v2 files (15 cols) with empty location and fit fields", () => {
@@ -229,10 +229,10 @@ test("load auto-upgrades v2 files (15 cols) with empty location and fit fields",
   assert.equal(back.apps[0].fit_score, "");
   assert.equal(back.apps[0].skip_reason, "");
 
-  // Re-saving promotes to v5.
+  // Re-saving promotes to v6.
   apps.save(file, back.apps);
   const after = apps.load(file);
-  assert.equal(after.schemaVersion, 5);
+  assert.equal(after.schemaVersion, 6);
 });
 
 test("load auto-upgrades v3 files (16 cols) — `location` wraps to [location]", () => {
@@ -267,10 +267,10 @@ test("load auto-upgrades v3 files (16 cols) — `location` wraps to [location]",
   assert.equal(back.apps[0].fit_evaluated_at, "");
   assert.equal(back.apps[0].skip_reason, "");
 
-  // Re-saving promotes to v5.
+  // Re-saving promotes to v6.
   apps.save(file, back.apps);
   const after = apps.load(file);
-  assert.equal(after.schemaVersion, 5);
+  assert.equal(after.schemaVersion, 6);
 });
 
 // RFC 038: v4 (single-string `location`) wraps to [location] on read.
@@ -307,10 +307,10 @@ test("load auto-upgrades v4 files (20 cols) — `location` wraps to [location]",
   assert.deepEqual(back.apps[0].locations, ["San Francisco, CA"]);
   assert.equal(back.apps[0].fit_score, "Strong");
 
-  // Re-saving promotes to v5.
+  // Re-saving promotes to v6.
   apps.save(file, back.apps);
   const after = apps.load(file);
-  assert.equal(after.schemaVersion, 5);
+  assert.equal(after.schemaVersion, 6);
   assert.deepEqual(after.apps[0].locations, ["San Francisco, CA"]);
 });
 
@@ -494,6 +494,168 @@ test("appendNew dedups when adapter returns the same id with and without prefix"
   const r = apps.appendNew(existing, incoming, { now: "2026-04-20T00:00:00Z" });
   assert.equal(r.fresh.length, 0, "prefixed jobId must collapse onto the canonical key");
   assert.equal(r.apps.length, 1);
+});
+
+// --- RFC 059 / BL-169: v6 outreach columns --------------------------------
+
+test("appendNew seeds the six v6 outreach defaults (hm_outreach_status='to_search')", () => {
+  const r = apps.appendNew([], [fixtureJob()], { now: "2026-06-03T00:00:00Z" });
+  const a = r.apps[0];
+  assert.equal(a.company_people_search_url, "");
+  assert.equal(a.outreach_type, "");
+  assert.equal(a.contact_name, "");
+  assert.equal(a.contact_linkedin, "");
+  assert.equal(a.hm_outreach_status, "to_search");
+  assert.equal(a.hm_outreach_date, "");
+});
+
+test("v6: save + load round-trips the six outreach fields", () => {
+  const file = tmp();
+  const { apps: built } = apps.appendNew([], [fixtureJob()], { now: "2026-06-03T00:00:00Z" });
+  built[0].company_people_search_url =
+    "https://www.linkedin.com/search/results/people/?keywords=Affirm";
+  built[0].outreach_type = "warm";
+  built[0].contact_name = "Jane Doe";
+  built[0].contact_linkedin = "https://www.linkedin.com/in/janedoe";
+  built[0].hm_outreach_status = "dm_sent";
+  built[0].hm_outreach_date = "2026-06-03";
+  apps.save(file, built);
+  const back = apps.load(file);
+  assert.equal(back.schemaVersion, 6);
+  assert.equal(
+    back.apps[0].company_people_search_url,
+    "https://www.linkedin.com/search/results/people/?keywords=Affirm"
+  );
+  assert.equal(back.apps[0].outreach_type, "warm");
+  assert.equal(back.apps[0].contact_name, "Jane Doe");
+  assert.equal(back.apps[0].contact_linkedin, "https://www.linkedin.com/in/janedoe");
+  assert.equal(back.apps[0].hm_outreach_status, "dm_sent");
+  assert.equal(back.apps[0].hm_outreach_date, "2026-06-03");
+});
+
+test("v6: header parses and detects as schemaVersion 6", () => {
+  const file = tmp();
+  const v6Header = apps.HEADER_V6.join("\t");
+  const v6Row = [
+    "greenhouse:1",
+    "greenhouse",
+    "1",
+    "Affirm",
+    "PM",
+    "https://x/1",
+    '["San Francisco, CA"]',
+    "To Apply",
+    "abc",
+    "Risk_Fraud",
+    "cl_key1",
+    "140000",
+    "190000",
+    "Affirm_analyst_20260420",
+    "2026-01-01",
+    "2026-01-02",
+    "Strong",
+    "Great fit",
+    "2026-05-05T00:00:00Z",
+    "",
+    "https://www.linkedin.com/search/results/people/?keywords=Affirm",
+    "cold",
+    "Jane Doe",
+    "https://www.linkedin.com/in/janedoe",
+    "connected",
+    "2026-06-02",
+  ].join("\t");
+  fs.writeFileSync(file, `${v6Header}\n${v6Row}\n`);
+
+  const back = apps.load(file);
+  assert.equal(back.schemaVersion, 6);
+  assert.equal(back.apps.length, 1);
+  assert.deepEqual(back.apps[0].locations, ["San Francisco, CA"]);
+  assert.equal(back.apps[0].fit_score, "Strong");
+  assert.equal(back.apps[0].outreach_type, "cold");
+  assert.equal(back.apps[0].contact_name, "Jane Doe");
+  assert.equal(back.apps[0].hm_outreach_status, "connected");
+  assert.equal(back.apps[0].hm_outreach_date, "2026-06-02");
+});
+
+// Auto-upgrade: a v5 file (20 cols) loads with the six v6 defaults, and the
+// next save() rewrites it as v6.
+test("load auto-upgrades v5 files (20 cols) with the six v6 outreach defaults", () => {
+  const file = tmp();
+  const v5Header = apps.HEADER_V5.join("\t");
+  const v5Row = [
+    "greenhouse:1",
+    "greenhouse",
+    "1",
+    "Affirm",
+    "PM",
+    "https://x/1",
+    '["San Francisco, CA"]',
+    "To Apply",
+    "abc",
+    "Risk_Fraud",
+    "cl_key1",
+    "140000",
+    "190000",
+    "Affirm_analyst_20260420",
+    "2026-01-01",
+    "2026-01-02",
+    "Strong",
+    "Great fit",
+    "2026-05-05T00:00:00Z",
+    "",
+  ].join("\t");
+  fs.writeFileSync(file, `${v5Header}\n${v5Row}\n`);
+
+  const back = apps.load(file);
+  assert.equal(back.schemaVersion, 5);
+  assert.equal(back.apps.length, 1);
+  // v5 fields intact
+  assert.deepEqual(back.apps[0].locations, ["San Francisco, CA"]);
+  assert.equal(back.apps[0].fit_score, "Strong");
+  // v6 defaults seeded
+  assert.equal(back.apps[0].company_people_search_url, "");
+  assert.equal(back.apps[0].outreach_type, "");
+  assert.equal(back.apps[0].contact_name, "");
+  assert.equal(back.apps[0].contact_linkedin, "");
+  assert.equal(back.apps[0].hm_outreach_status, "to_search");
+  assert.equal(back.apps[0].hm_outreach_date, "");
+
+  // Re-saving promotes the file to v6.
+  apps.save(file, back.apps);
+  const after = apps.load(file);
+  assert.equal(after.schemaVersion, 6);
+  assert.equal(after.apps[0].hm_outreach_status, "to_search");
+  assert.deepEqual(after.apps[0].locations, ["San Francisco, CA"]);
+});
+
+// Older upgrade paths (v1) must also seed the v6 outreach defaults.
+test("load auto-upgrades v1 files with the v6 outreach defaults too", () => {
+  const file = tmp();
+  const v1Header = apps.HEADER_V1.join("\t");
+  const v1Row = [
+    "greenhouse:1",
+    "greenhouse",
+    "1",
+    "Affirm",
+    "PM",
+    "https://x/1",
+    "To Apply",
+    "abc",
+    "Risk_Fraud",
+    "cl_key1",
+    "2026-01-01",
+    "2026-01-02",
+  ].join("\t");
+  fs.writeFileSync(file, `${v1Header}\n${v1Row}\n`);
+
+  const back = apps.load(file);
+  assert.equal(back.schemaVersion, 1);
+  assert.equal(back.apps[0].hm_outreach_status, "to_search");
+  assert.equal(back.apps[0].company_people_search_url, "");
+
+  apps.save(file, back.apps);
+  const after = apps.load(file);
+  assert.equal(after.schemaVersion, 6);
 });
 
 // RFC 038: decodeLocations defensive fallback — a hand-edited v5 cell that

--- a/engine/core/linkedin_search_url.js
+++ b/engine/core/linkedin_search_url.js
@@ -1,0 +1,56 @@
+// Pure. Builds a LinkedIn people-search URL for a company, optionally narrowed
+// by role keywords and location. Zero network, zero automation — it only
+// assembles a URL string a human clicks.
+//
+// RFC 059 (BL-169): the engine emits a prefab LinkedIn people-search URL for
+// Medium+/Strong vacancies. The operator opens it; LinkedIn itself surfaces
+// "N of your connections work here" and the operator decides warm vs cold.
+//
+// ToS note (load-bearing): this helper performs NO fetch, scrape, or
+// connection-send. It imports nothing network-related. A US bias is expressed
+// purely as a keyword string — never a LinkedIn `geoUrn` (those require
+// LinkedIn's internal region ids, which must not be hardcoded/scraped).
+
+const LINKEDIN_PEOPLE_SEARCH_BASE = "https://www.linkedin.com/search/results/people/";
+
+// Role-derived keyword fragments. We can't know the specific hiring manager's
+// name, so we bias the search toward the people who own the hire: the recruiter
+// and the hiring manager. Kept deliberately generic — the operator narrows by
+// hand once LinkedIn renders the results.
+const ROLE_KEYWORD_FRAGMENTS = ["recruiter", "hiring manager"];
+
+// ToS-safe US geo bias: a keyword string, not a geoUrn.
+const US_KEYWORD_BIAS = "United States";
+
+// Build the `keywords` query value: company first, then optional role-derived
+// fragments, then the US bias. Plain space-joined; URLSearchParams handles the
+// encoding of spaces / `&` / unicode.
+function buildKeywords({ company, roleTitle, location }) {
+  const parts = [String(company).trim()];
+  if (roleTitle && String(roleTitle).trim()) {
+    parts.push(...ROLE_KEYWORD_FRAGMENTS);
+  }
+  if (location && String(location).trim()) {
+    parts.push(String(location).trim());
+  }
+  parts.push(US_KEYWORD_BIAS);
+  return parts.join(" ");
+}
+
+// → "https://www.linkedin.com/search/results/people/?keywords=...&origin=..."
+//
+// - Missing `company` → throws.
+// - Missing `roleTitle` / `location` → company-only (still a valid) URL.
+function buildCompanyPeopleSearchUrl({ company, roleTitle, location } = {}) {
+  if (!company || !String(company).trim()) {
+    throw new Error("buildCompanyPeopleSearchUrl: `company` is required");
+  }
+  const params = new URLSearchParams();
+  params.set("keywords", buildKeywords({ company, roleTitle, location }));
+  // `origin` mirrors what LinkedIn appends for a globally-typed search; it has
+  // no automation effect, it just makes the prefab URL look native.
+  params.set("origin", "GLOBAL_SEARCH_HEADER");
+  return `${LINKEDIN_PEOPLE_SEARCH_BASE}?${params.toString()}`;
+}
+
+module.exports = { buildCompanyPeopleSearchUrl };

--- a/engine/core/linkedin_search_url.test.js
+++ b/engine/core/linkedin_search_url.test.js
@@ -1,0 +1,92 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const { buildCompanyPeopleSearchUrl } = require("./linkedin_search_url.js");
+
+const BASE = "https://www.linkedin.com/search/results/people/";
+
+// Parse out the `keywords` query value from a produced URL for assertions.
+function keywordsOf(url) {
+  return new URL(url).searchParams.get("keywords");
+}
+
+test("company-only: builds a valid people-search URL with the company in keywords", () => {
+  const url = buildCompanyPeopleSearchUrl({ company: "Affirm" });
+  assert.ok(url.startsWith(BASE), "must start with the LinkedIn people-search base");
+  const kw = keywordsOf(url);
+  assert.ok(kw.includes("Affirm"), "keywords include the company");
+  // US bias is always present (ToS-safe keyword bias, not a geoUrn).
+  assert.ok(kw.includes("United States"), "keywords carry the US bias");
+  assert.ok(!url.includes("geoUrn"), "must not hardcode a LinkedIn geoUrn");
+});
+
+test("company + role: keywords gain role-derived hiring keywords", () => {
+  const url = buildCompanyPeopleSearchUrl({ company: "Stripe", roleTitle: "Senior PM" });
+  const kw = keywordsOf(url);
+  assert.ok(kw.includes("Stripe"));
+  assert.ok(kw.includes("recruiter"));
+  assert.ok(kw.includes("hiring manager"));
+});
+
+test("company + role + location: keywords include the location too", () => {
+  const url = buildCompanyPeopleSearchUrl({
+    company: "Stripe",
+    roleTitle: "Senior PM",
+    location: "San Francisco, CA",
+  });
+  const kw = keywordsOf(url);
+  assert.ok(kw.includes("Stripe"));
+  assert.ok(kw.includes("recruiter"));
+  assert.ok(kw.includes("San Francisco, CA"));
+  assert.ok(kw.includes("United States"));
+});
+
+test("missing company throws a clear error", () => {
+  assert.throws(() => buildCompanyPeopleSearchUrl({}), /company.*required/i);
+  assert.throws(() => buildCompanyPeopleSearchUrl({ company: "" }), /company.*required/i);
+  assert.throws(() => buildCompanyPeopleSearchUrl({ company: "   " }), /company.*required/i);
+  assert.throws(() => buildCompanyPeopleSearchUrl(), /company.*required/i);
+});
+
+test("role/location absent → company-only is still valid", () => {
+  const url = buildCompanyPeopleSearchUrl({ company: "Affirm", roleTitle: "", location: "" });
+  const kw = keywordsOf(url);
+  assert.ok(kw.includes("Affirm"));
+  // empty role → no role fragments injected
+  assert.ok(!kw.includes("recruiter"));
+});
+
+test("encodes spaces, &, and unicode in the company name (single well-formed URL)", () => {
+  const url = buildCompanyPeopleSearchUrl({ company: "Ben & Jerry's São Paulo" });
+  // Single well-formed URL: parses without throwing and round-trips the value.
+  const parsed = new URL(url);
+  assert.equal(parsed.origin + parsed.pathname, BASE);
+  // Raw spaces and `&` must be percent/`+`-encoded, never literal in the string.
+  const query = url.slice(url.indexOf("?") + 1);
+  assert.ok(!query.includes(" "), "no raw spaces in the query string");
+  // The `&` inside the company name must not appear as a bare separator: there
+  // is exactly one `keywords` param and one `origin` param.
+  const params = parsed.searchParams;
+  assert.equal([...params.keys()].filter((k) => k === "keywords").length, 1);
+  // Decoded value preserves the unicode + ampersand verbatim.
+  assert.ok(params.get("keywords").includes("Ben & Jerry's São Paulo"));
+});
+
+test("returns a plain string", () => {
+  const url = buildCompanyPeopleSearchUrl({ company: "Affirm" });
+  assert.equal(typeof url, "string");
+});
+
+// ToS / purity guard (load-bearing per RFC 059): the module assembles a URL
+// only. It must import nothing network-related — assert by source inspection so
+// a future edit that pulls in fetch/http/https/net is caught.
+test("module imports nothing network-related", () => {
+  const src = fs.readFileSync(path.join(__dirname, "linkedin_search_url.js"), "utf8");
+  const requires = [...src.matchAll(/require\(\s*['"]([^'"]+)['"]\s*\)/g)].map((m) => m[1]);
+  assert.deepEqual(requires, [], "helper must not require any module");
+  for (const banned of ["http", "https", "net", "fetch", "node-fetch", "undici", "dns"]) {
+    assert.ok(!requires.includes(banned), `must not import ${banned}`);
+  }
+});

--- a/rfc/059-hm-outreach.md
+++ b/rfc/059-hm-outreach.md
@@ -1,0 +1,409 @@
+# RFC 059 — Hiring-manager & warm-contact outreach (job-centric, LinkedIn)
+
+- Status: **Proposed** (open question resolved 2026-06-03 → Option 1)
+- Date: 2026-06-03
+- Refs: BL-169 (authoritative model; supersedes/merges BL-166), BL-62
+  (outbound discovery; note/DM templates live in its Notion project),
+  RFC 014 (status split), RFC 022 (per-row Notion push in commit),
+  RFC 058 (relation-company resolution in reconcile)
+- Tier: M
+
+## Summary
+
+Add one **job-centric outreach motion** on top of the existing ATS
+pipeline. For every Medium+/Strong vacancy the engine emits a LinkedIn
+**company people-search URL** (`company_people_search_url`). The operator
+opens it; LinkedIn itself surfaces "N of your connections work here" and
+the operator decides **warm** (their own contact) vs **cold** (a hiring
+manager / recruiter). Outreach state is tracked **on the vacancy card**
+(jobs pipeline), not in a separate CRM. The durable human record lives in
+the personal "Люди" base (`people_db`) with its «Компания» field filled,
+linked by relation to the same `companies_db` the vacancies relate to, so
+a vacancy rollups "people at this company" read-only.
+
+No automation of LinkedIn send/scrape — the engine produces a prefab URL
+and reads/writes mapped Notion properties; the operator does every human
+action by hand.
+
+## Motivation
+
+Cold apply through ATS forms has produced **0 interviews** in the last
+month (BL-62). The outbound channel is the bet. Benchmarks gathered in
+BL-169:
+
+- Cold email/DM to a hiring manager → **15–25% reply** vs standard online
+  apply **2–5%** (~5–10× lift).
+- Sourced candidates convert to hire **4–8×** vs inbound (LinkedIn's own
+  funnel data).
+- A signal-personalized connection note referencing a specific vacancy →
+  ~**18%+ reply** vs ~3.4% generic.
+
+The same motion already worked for the operator once (added a future boss
+on LinkedIn with no explicit ask; they reached out when headcount
+opened). This RFC makes that motion **systematic and vacancy-anchored**:
+tied to a specific role with verified hiring intent, not bulk cold-adds.
+
+BL-169 and BL-166 are unified here. BL-166's "warm shared-context"
+outreach is simply the **"I have a contact here"** branch of this single
+flow. The cold-HM branch is the **"no contact"** branch. Both run through
+the same vacancy-card status; the weekly LinkedIn invite cap is shared
+between them.
+
+## Design
+
+Six workstreams (A–F). A–C are engine code. D is an operator-executed
+Notion schema change (design only here). E is engine code. F is content
+that lives in the BL-62 Notion project, not in code.
+
+### A. TSV schema extension (`engine/core/applications_tsv.js`)
+
+Six new columns are appended to `applications.tsv`, bumping the schema to
+**v6**. All write through `engine/core/applications_tsv.js` only — no
+other code path touches the TSV (per the project contract).
+
+| Column | Values | Origin |
+|---|---|---|
+| `company_people_search_url` | LinkedIn people-search URL (string) | `prepare --phase commit` (workstream B/C) |
+| `outreach_type` | `warm` \| `cold` \| `""` | operator → Notion → `sync` pull |
+| `contact_name` | free text | operator → Notion → `sync` pull |
+| `contact_linkedin` | URL | operator → Notion → `sync` pull |
+| `hm_outreach_status` | `to_search` \| `searching` \| `pending_connection` \| `connected` \| `dm_sent` \| `replied` \| `dead` | operator → Notion → `sync` pull |
+| `hm_outreach_date` | ISO date | operator → Notion → `sync` pull |
+
+**Design.** Follow the existing versioned-header pattern in
+`applications_tsv.js`: add `HEADER_V6` (the v5 columns + the six above),
+alias `HEADER = HEADER_V6`, add `rowToAppV6`, extend `rowFor` to emit the
+new cells, and add a `load()` branch (`isV6`). `save()` always writes v6.
+
+**Migration (auto-upgrade-on-save).** The same mechanism v1→v5 already
+use: `rowToAppV5` (and earlier) gains defaults for the new fields —
+`company_people_search_url: ""`, `outreach_type: ""`, `contact_name: ""`,
+`contact_linkedin: ""`, `hm_outreach_status: "to_search"`,
+`hm_outreach_date: ""`. A v5 file is read with these defaults, and the
+next `save()` rewrites it as v6. No standalone migration script; the
+first `prepare`/`sync --apply` after deploy upgrades the file in place.
+The in-memory `app` shape gains the six fields; `appendNew` seeds them on
+fresh `scan` rows (`hm_outreach_status: "to_search"`, the rest empty).
+
+**Default rationale.** `hm_outreach_status` defaults to `to_search` (not
+empty) so existing rows land in a valid lifecycle state and the Notion
+"to-do queue" view picks them up consistently. The other five default
+empty.
+
+**Files touched:** `engine/core/applications_tsv.js`,
+`engine/core/applications_tsv.test.js`.
+
+### B. `company_people_search_url` helper (`engine/core/linkedin_search_url.js`)
+
+New **pure** helper. No existing `linkedin` helper in `engine/core/`
+(confirmed — only `url_check.js` exists), so this does not duplicate
+anything.
+
+**Signature (proposed):**
+
+```js
+// engine/core/linkedin_search_url.js
+// Pure. Builds a LinkedIn people-search URL for a company, optionally
+// narrowed by role keywords and location. Zero network, zero automation.
+function buildCompanyPeopleSearchUrl({ company, roleTitle, location }) {
+  // → "https://www.linkedin.com/search/results/people/?keywords=...&origin=..."
+}
+module.exports = { buildCompanyPeopleSearchUrl };
+```
+
+**Behaviour.**
+
+- Base: `https://www.linkedin.com/search/results/people/`.
+- `keywords` = `company` plus optional role keywords (e.g. `"<Company>
+  recruiter"` / hiring-manager title fragments derived from `roleTitle`)
+  — URL-encoded.
+- Geo: bias to US via the keyword string (a `geoUrn` requires LinkedIn's
+  internal region ids, which the engine must not hardcode/scrape; a
+  US keyword bias is the ToS-safe approximation).
+- Defensive: missing `company` → throw; missing `roleTitle`/`location` →
+  company-only URL.
+- Returns a plain string; performs **no fetch** and embeds **no
+  automation** — it only assembles a URL a human clicks.
+
+**ToS note (load-bearing).** The helper produces a prefab URL only. There
+is no scraping, no connection-send, no session handling. Tests assert the
+output is a well-formed search URL and that the module imports nothing
+network-related.
+
+**Files touched:** `engine/core/linkedin_search_url.js` (new),
+`engine/core/linkedin_search_url.test.js` (new — faked inputs, no
+network: company-only, company+role, company+role+location, missing-
+company throw, encoding of spaces/`&`/unicode).
+
+### C. `prepare --phase commit` integration (`engine/commands/prepare.js`)
+
+Populate `company_people_search_url` for **Medium+/Strong rows only**
+during the commit phase, write it to the TSV row, and push it into the
+Notion page via the property map.
+
+**Design.** In `buildJobFieldsForNotion(...)`
+(`engine/commands/prepare.js`, ~L1629 — the pure field assembler that
+already maps `companyName`/`title`/`fitScore`/etc.), add a gated field:
+
+```js
+if (r.fitScore === "Medium" || r.fitScore === "Strong") {
+  fields.companyPeopleSearchUrl = buildCompanyPeopleSearchUrl({
+    company: app.companyName,
+    roleTitle: app.title,
+    location: (app.locations && app.locations[0]) || undefined,
+  });
+}
+```
+
+Weak rows are excluded (matches RFC 049 / the existing weak-fallback —
+Weak still reaches Notion but gets no outreach URL). The helper is wired
+through `deps` (like `formatSalaryDisplay`) so it stays injectable for
+tests. The same value is written to the TSV row alongside the existing
+commit write-back (`company_people_search_url` column from workstream A);
+`hm_outreach_status` is left at its `to_search` default on commit.
+
+**Property-map dependency.** The push only emits the property when the
+profile's `property_map` defines `companyPeopleSearchUrl` (workstream D).
+Profiles without it (e.g. `_example` until updated) silently skip the
+field — consistent with how `buildProperties` already drops unmapped
+fields.
+
+**Files touched:** `engine/commands/prepare.js`,
+`engine/commands/prepare.test.js` (assert Medium/Strong get a URL in both
+the TSV row and the Notion field payload; Weak gets none; helper injected
+as a fake).
+
+### D. Notion schema change (operator-executed; design only here)
+
+This is a **personal Notion mutation done by the operator via MCP after
+approval**, NOT by engine code. Engine code only reads/writes the mapped
+properties.
+
+1. **`people_db`.«Компания» → relation onto `companies_db`.** Today
+   «Компания» is a `multi_select`/text (single option) and is mostly
+   empty. Convert it to a **relation** targeting the same companies base
+   the vacancies relate to (`profile.json → notion.companies_db_id`).
+   Without this the rollup in step 3 cannot be built. (This is the
+   schema-bridge BL-169's authoritative model calls out as mandatory.)
+2. **Outreach-status properties on the vacancy/jobs DB.** Add the Notion
+   properties backing the six TSV columns: a people-search URL (`url`), an
+   `outreach_type` select (`warm`/`cold`), `contact_name` (rich_text),
+   `contact_linkedin` (url), `hm_outreach_status` (select with the seven
+   lifecycle options), `hm_outreach_date` (date).
+3. **Rollup "people at this company" on the vacancy/jobs DB.** The vacancy
+   already relates to `companies_db` (RFC 058). Add a rollup that, via that
+   relation, surfaces the related `people_db` rows for the company —
+   read-only. This is what makes "do I know someone here?" visible on the
+   vacancy card without a per-person job-CRM.
+4. **Extend `notion.property_map` in `profile.json`.** Add the new keys
+   (names are profile-local; the example uses generic English field
+   names):
+
+   ```jsonc
+   // profiles/_example/profile.example.json → notion.property_map (additions)
+   "companyPeopleSearchUrl": { "field": "People Search URL",  "type": "url" },
+   "outreachType":           { "field": "Outreach Type",      "type": "select" },
+   "contactName":            { "field": "Contact Name",       "type": "rich_text" },
+   "contactLinkedin":        { "field": "Contact LinkedIn",   "type": "url" },
+   "hmOutreachStatus":       { "field": "Outreach Status",    "type": "select" },
+   "hmOutreachDate":         { "field": "Outreach Date",      "type": "date" }
+   ```
+
+   The existing generic, type-driven `toPropertyValue` / `fromPropertyValue`
+   in `engine/core/notion_sync.js` already handle `url` / `select` /
+   `rich_text` / `date`, so no new conversion code is needed.
+
+5. **Notion "to-do queue" view (operator).** A view filtered to
+   `Fit Score ∈ {Medium, Strong}` AND `hm_outreach_status ∈ {to_search,
+   searching}` AND `Status ≠ Archived` — the weekly outreach worklist.
+   View definition is operator-side, not engine code.
+
+The `_example` template is updated to document the new property_map keys
+(synthetic field names only). Jared's real ids/field names stay in his
+gitignored `profile.json`.
+
+**Files touched (committed):** `profiles/_example/profile.example.json`
+(property_map additions), `README.md` + `docs/architecture/` (new
+workflow step). Operator-side: the Notion schema edits above.
+
+### E. `sync` round-trip (`engine/commands/sync.js`)
+
+The new outreach fields must reconcile **Notion → TSV**, preserving the
+**pull-only** model. Do **not** re-introduce a push path — `prepare`'s
+commit phase remains the only writer of new Notion pages (RFC 014 /
+2026-05-04 removal). This constraint is explicit and load-bearing.
+
+**Design.** `reconcilePull(apps, notionPages, propertyMap, now,
+companyNameById)` (`engine/commands/sync.js`, L97) currently pulls
+`notion_page_id`, `status`, and a backfilled `companyName`. Extend the
+**update path** so that, for each matched row, the five operator-owned
+outreach fields (`outreach_type`, `contact_name`, `contact_linkedin`,
+`hm_outreach_status`, `hm_outreach_date`) are pulled from Notion when they
+differ from the local row (Notion wins, mirroring the `status` rule). The
+**add path** seeds them from the page too. `company_people_search_url`
+is engine-authored in `prepare`; on pull, treat it like `companyName` —
+backfill only when the local cell is empty (never clobber an
+engine-written URL with an empty Notion value).
+
+This requires `parseNotionPage` (`engine/core/notion_sync.js`) to read the
+new mapped properties into the `page` object (it already iterates the
+property map generically via `fromPropertyValue`, so reading is automatic
+once the map has the keys; confirm the parser surfaces them under stable
+`page.*` names).
+
+`reconcilePull` stays **pure** (no I/O — tests depend on it), exactly as
+RFC 058 preserved.
+
+**Files touched:** `engine/commands/sync.js`,
+`engine/core/notion_sync.js` (parse the new props if not already generic),
+`engine/commands/sync.test.js` (update-path and add-path pull the five
+operator fields; engine-written `company_people_search_url` not
+overwritten by empty Notion; purity intact).
+
+### F. Templates (content — BL-62 Notion project, NOT in code)
+
+Three connection-note templates (≤300 chars — LinkedIn's free-tier note
+cap) plus one DM template (~350 chars). These are **content that lives in
+the BL-62 Notion project** ("Hiring manager outreach" section), not in the
+repo, so they can be tuned against live reply data without a code change.
+The RFC fixes only intent/skeleton:
+
+- **Note — High signal:** references a recent (≤30d) public post by the
+  target about the team / hiring / the role.
+- **Note — Med signal:** references a concrete JD fragment that fits
+  (e.g. "pre-revenue AI startup hiring its first Forward-Deployed PM").
+- **Note — Low signal:** company + role + one matching line from the
+  master profile.
+- **DM (after accept):** short intro + reference to the specific vacancy +
+  soft ask ("worth a 15-min call?").
+
+Note/DM **content** is out of scope for the engine; the engine only emits
+the search URL and tracks status.
+
+## Data model changes
+
+**TSV (`applications.tsv`, v5 → v6):** six appended columns —
+`company_people_search_url`, `outreach_type`, `contact_name`,
+`contact_linkedin`, `hm_outreach_status`, `hm_outreach_date`.
+
+**Notion property_map (new keys):**
+
+| property_map key | Notion field (example) | type | writer |
+|---|---|---|---|
+| `companyPeopleSearchUrl` | People Search URL | `url` | engine (`prepare` commit) |
+| `outreachType` | Outreach Type | `select` | operator |
+| `contactName` | Contact Name | `rich_text` | operator |
+| `contactLinkedin` | Contact LinkedIn | `url` | operator |
+| `hmOutreachStatus` | Outreach Status | `select` | operator |
+| `hmOutreachDate` | Outreach Date | `date` | operator |
+
+Plus (operator-side, no property_map entry needed): `people_db`.«Компания»
+relation → `companies_db`, and a rollup "people at this company" on the
+vacancy DB.
+
+## Migration
+
+- **TSV:** auto-upgrade-on-save (v5 read with defaults → next `save()`
+  writes v6). No script. `hm_outreach_status` backfills to `to_search`,
+  the rest empty.
+- **Notion:** operator runs the schema edits in workstream D via MCP after
+  approval. Order: convert «Компания» to relation → add vacancy-DB
+  properties → add rollup → extend `property_map` in `profile.json` → add
+  the to-do view. Until `property_map` carries the new keys, `prepare`
+  silently omits the URL field and `sync` ignores the outreach fields, so
+  the engine is forward/backward compatible during the rollout window.
+
+## Test plan
+
+- **A (TSV):** v5-file read yields the six defaults; round-trip
+  save→load preserves them; v6 header parses; v1→v5 upgrade paths still
+  green; `appendNew` seeds `to_search`.
+- **B (helper):** company-only, company+role, company+role+location,
+  missing-company throws, encoding of spaces/`&`/unicode; no network
+  import.
+- **C (prepare commit):** Medium and Strong rows get a populated URL in
+  both the TSV row and the Notion field payload; Weak gets none; helper
+  injected as a fake; property omitted when `property_map` lacks the key.
+- **E (sync):** update-path pulls the five operator fields when Notion
+  differs (Notion wins); add-path seeds them; engine-written
+  `company_people_search_url` is not overwritten by an empty Notion value;
+  `reconcilePull` stays pure; no push path introduced.
+- All network mocked. No real LinkedIn/Notion calls in unit tests.
+- **Smoke:** local `prepare --phase commit` on a Medium+/Strong batch
+  populates the URL + Notion field; `sync --apply` round-trips a manually
+  set `hm_outreach_status` from Notion back into the TSV.
+
+## Risks
+
+- **LinkedIn account restriction.** Bulk invites can trip anti-automation
+  limits. Mitigation: cap **50 connection adds/week for the first 2
+  weeks**, grow toward ~100/week only if accept rate > 40% (signal that
+  targeting is sane). This is an operational discipline, not engine logic.
+- **ToS.** Any automation of search-scrape or invite-send risks the
+  account. Mitigation: the engine produces a **prefab URL only**; every
+  send/scrape is a manual human action. Tests assert the helper has no
+  network dependency.
+- **Empty-URL silently dropping a row** (the RFC 058 failure mode): the
+  pull rule "backfill `company_people_search_url` only when empty" must
+  never let an empty Notion value clobber an engine-written URL.
+- **Personal-data leak.** `people_db` content is PII. Nothing about it
+  enters the repo; only the relation/rollup wiring and generic
+  property_map keys are committed. The engine reads/writes mapped Notion
+  properties only.
+
+## Open questions
+
+**[RESOLVED 2026-06-03 — operator chose Option 1: single status on the
+vacancy for v1.]** Build the single `hm_outreach_status` on the vacancy;
+do NOT build the per-person junction now. Evolution path to Option 2 is
+noted below for the future.
+
+**Multiple known contacts at one company — single status on the vacancy,
+or a per-person junction?**
+
+- *Option 1 — single `hm_outreach_status` on the vacancy (recommended for
+  v1).* Simplest; matches the "track on the vacancy card" decision; the
+  rollup already lists everyone at the company, and the operator works one
+  contact at a time per vacancy. Cost: it cannot express "DMed person A,
+  pending person B" simultaneously — the status reflects the vacancy's
+  outreach as a whole.
+- *Option 2 — per-person junction (one status row per person×vacancy).*
+  Higher fidelity; supports parallel threads to multiple contacts. Cost: a
+  junction DB + sync of a 1-to-many relationship — effectively the
+  per-person job-CRM BL-169/BL-166 explicitly ruled out of scope for now.
+
+**Recommendation:** ship **Option 1** for v1. Evolve to Option 2 later
+only if real usage shows multiple simultaneous threads per vacancy are
+common — at which point `hm_outreach_status` moves from a vacancy property
+to rows in a junction DB, and `sync` reconciles that DB instead of the
+single field. Defer; do not build the junction now.
+
+Secondary (non-blocking, from BL-169): hiring-manager vs recruiter reply
+rates; whether to surface mutual-connection count in the note; how to
+treat 3rd-party agency recruiters. These are operational tuning, not
+schema — leave to the BL-62 experiment.
+
+## Out of scope
+
+- Auto-scraping / auto-sending LinkedIn invites or DMs (ToS).
+- AI guessing a specific hiring manager's name — the engine gives the
+  search URL; the operator finds the human.
+- A full sales CRM / per-person junction DB (see Open questions — deferred).
+- Re-enabling a Notion push path. `prepare` commit stays the only creator
+  of Notion pages.
+- Outreach on Weak-fit vacancies. Medium+/Strong only.
+
+## Rollout (phased)
+
+1. **Schema + helper (A, B).** TSV v6 + auto-migration + the pure
+   `linkedin_search_url` helper, both fully tested. No behaviour change yet
+   (no field is populated until C).
+2. **prepare integration (C).** Medium+/Strong rows get
+   `company_people_search_url` in TSV and (once property_map has the key)
+   in Notion.
+3. **Notion schema + property_map + sync (D, E).** Operator runs the
+   personal-Notion edits; `property_map` gains the six keys; `sync`
+   round-trips the operator-owned outreach fields. After this the vacancy
+   card shows the URL, the rollup, and the editable status.
+4. **Templates (F).** Author the three notes + DM in the BL-62 Notion
+   project and run the first weekly worklist against the to-do view.

--- a/scripts/migrate_tsv_v4_to_v5.js
+++ b/scripts/migrate_tsv_v4_to_v5.js
@@ -55,7 +55,11 @@ function migrateOne(tsvPath, { apply, now = new Date(), fsImpl = fs } = {}) {
   }
   const result = apps.load(tsvPath);
   const { apps: rows, schemaVersion } = result;
-  if (schemaVersion === 5) {
+  // This one-shot migration only needs to wrap `location` → `locations[]`,
+  // which is satisfied at v5 and any later schema (v6+ supersedes v5 and
+  // already carries the array). Treat anything already at v5 or newer as a
+  // no-op so the script stays idempotent after later schema bumps.
+  if (schemaVersion >= 5) {
     return { path: tsvPath, status: "already_v5", rows: rows.length };
   }
   if (!apply) {

--- a/scripts/migrate_tsv_v4_to_v5.test.js
+++ b/scripts/migrate_tsv_v4_to_v5.test.js
@@ -74,9 +74,10 @@ test("migrateOne: v4 → v5, drops backup, locations wrapped to single-element a
   assert.equal(res.backupPath, `${file}.pre-v5-${todayStamp(now)}`);
   assert.ok(fs.existsSync(res.backupPath), "backup file must exist");
 
-  // File on disk now reads as v5.
+  // File on disk now reads as the current schema (v6 — save() always writes
+  // the latest header; the v4→v5 location-wrap is still applied en route).
   const back = apps.load(file);
-  assert.equal(back.schemaVersion, 5);
+  assert.equal(back.schemaVersion, 6);
   assert.deepEqual(back.apps[0].locations, ["San Francisco, CA"]);
   assert.deepEqual(back.apps[1].locations, []);
   assert.equal(back.apps[0].fit_score, "Strong");


### PR DESCRIPTION
## What

Phase 1 of RFC 059 (BL-169) — foundation for the job-centric hiring-manager / warm-contact outreach motion. **No behaviour change yet**: no field is populated until phase 2 (prepare integration).

## Changes

- **`applications.tsv` schema v5 → v6** — six outreach columns: `company_people_search_url`, `outreach_type`, `contact_name`, `contact_linkedin`, `hm_outreach_status`, `hm_outreach_date`. Auto-upgrade-on-save; older files (v1–v5) seed defaults (`hm_outreach_status="to_search"`, rest empty). No migration script.
- **`engine/core/linkedin_search_url.js`** — new pure helper building a LinkedIn people-search URL. Zero network, zero automation (ToS-safe: US bias via keyword string, never a `geoUrn`). Throws on missing company.
- **Collateral:** `migrate_tsv_v4_to_v5` idempotency check `=== 5` → `>= 5` (a v6 file is past v5, treat as no-op).
- **`rfc/059-hm-outreach.md`** (Proposed; open question resolved → Option 1 single-status-on-vacancy).

## Tests

`npm test` → **1999/1999 pass**. prettier clean. PII scan clean (RFC carries no real Notion ids / contact data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)