### PR TITLE
feat(outreach): RFC 059 phase 2 — populate LinkedIn search URL on commit (all tiers)

### DIFF
--- a/engine/commands/prepare.js
+++ b/engine/commands/prepare.js
@@ -74,6 +74,7 @@ const { planDedup } = require("../core/tsv_dedup.js");
 const notionSync = require("../core/notion_sync.js");
 const { makeCompanyResolver } = require("../core/company_resolver.js");
 const notionJobPage = require("../core/notion_job_page.js");
+const { buildCompanyPeopleSearchUrl } = require("../core/linkedin_search_url.js");
 const {
   ENGINE_SKIP_REASONS,
   ALREADY_EVALUATED_REASONS,
@@ -828,6 +829,11 @@ function makeDefaultDeps() {
     makeCompanyResolver,
     pushJobPage: notionJobPage.pushJobPage,
     formatSalaryDisplay: notionJobPage.formatSalaryDisplay,
+    // RFC 059 (BL-169) workstream C: prefab LinkedIn people-search URL,
+    // populated for every committed row (all fit tiers). Injectable so the
+    // commit-phase tests can swap in a fake without depending on the real
+    // helper's keyword string.
+    buildCompanyPeopleSearchUrl,
     now: () => new Date().toISOString(),
   };
 }
@@ -1669,6 +1675,16 @@ function buildJobFieldsForNotion({ app, r, prepareCtxEntry, now, formatSalaryDis
   if (r.requirements) fields.requirements = r.requirements;
   else if (ctx.requirements) fields.requirements = ctx.requirements;
 
+  // RFC 059 (BL-169) workstream C — surface the prefab LinkedIn
+  // people-search URL the commit loop already wrote onto the TSV row, for
+  // EVERY tier (no fit gate). buildProperties only emits it when the
+  // profile's property_map maps `companyPeopleSearchUrl` (type url);
+  // profiles without that key (e.g. _example until phase 3) silently drop
+  // it, like any other unmapped field.
+  if (app.company_people_search_url) {
+    fields.companyPeopleSearchUrl = app.company_people_search_url;
+  }
+
   return fields;
 }
 
@@ -2034,6 +2050,19 @@ async function runCommit(ctx, deps) {
       continue;
     }
     app.status = "To Apply";
+    // RFC 059 (BL-169) workstream C — populate the prefab LinkedIn
+    // people-search URL for EVERY committed row, regardless of fit tier
+    // (Strong / Medium / Weak). Scope amended 2026-06-03 (operator
+    // decision): the URL is a cheap, harmless link; the operator decides
+    // per-row whether to act, so there is no fit-tier gate. The only gate
+    // on whether Notion sees it is property_map presence, handled by
+    // buildProperties dropping unmapped fields. `hm_outreach_status` is
+    // left at its phase-1 `to_search` default here.
+    app.company_people_search_url = deps.buildCompanyPeopleSearchUrl({
+      company: app.companyName,
+      roleTitle: app.title,
+      location: (app.locations && app.locations[0]) || undefined,
+    });
     if (r.clKey) app.cl_key = r.clKey;
     if (r.resumeVer) app.resume_ver = r.resumeVer;
     if (r.notionPageId) app.notion_page_id = r.notionPageId;

--- a/engine/commands/prepare.test.js
+++ b/engine/commands/prepare.test.js
@@ -1868,6 +1868,257 @@ test("prepare --phase commit (RFC 034): Strong + Medium + Weak all reach Notion 
   assert.equal(ctx._errLines.filter((l) => /legacy "decision" field/.test(l)).length, 0);
 });
 
+// --- RFC 059 (BL-169) workstream C: company_people_search_url -----------------
+
+// Phase-2 contract: EVERY committed row (Strong / Medium / Weak — no fit-tier
+// gate) gets a populated `company_people_search_url` in the TSV row AND in the
+// Notion field payload assembled by buildJobFieldsForNotion. The helper is
+// injected so we can assert it was called per-row with the right inputs without
+// coupling to the real keyword string. Whether Notion actually receives the
+// property is gated ONLY by property_map presence (buildProperties drops
+// unmapped fields) — exercised in the two property_map tests below.
+test("prepare --phase commit (RFC 059): Strong + Medium + Weak all get company_people_search_url in TSV and Notion payload", async () => {
+  const apps = [
+    makeApp({
+      key: "gh:1",
+      status: "Inbox",
+      companyName: "Affirm",
+      title: "Senior PM",
+      locations: ["San Francisco, CA"],
+    }),
+    makeApp({
+      key: "gh:2",
+      status: "Inbox",
+      companyName: "Stripe",
+      title: "Product Manager",
+      locations: ["New York, NY"],
+    }),
+    makeApp({
+      key: "gh:3",
+      status: "Inbox",
+      companyName: "Plaid",
+      title: "Group PM",
+      locations: [],
+    }),
+  ];
+  const results = {
+    profileId: "testuser",
+    results: [
+      {
+        key: "gh:1",
+        fitScore: "Strong",
+        fitRationale: "core",
+        clKey: "Affirm_PM",
+        resumeVer: "v1",
+        clParagraphs: ["P1", "P2", "P3", "P4"],
+      },
+      {
+        key: "gh:2",
+        fitScore: "Medium",
+        fitRationale: "adjacent",
+        clKey: "Stripe_PM",
+        resumeVer: "v1",
+        clParagraphs: ["P1", "P2", "P3", "P4"],
+      },
+      {
+        key: "gh:3",
+        fitScore: "Weak",
+        fitRationale: "outside core",
+      },
+    ],
+  };
+  // Fake helper: records calls, returns a deterministic, easily-asserted URL.
+  const helperCalls = [];
+  const fakeBuildUrl = (args) => {
+    helperCalls.push(args);
+    return `https://fake.search/${encodeURIComponent(args.company)}`;
+  };
+  const rec = makeClRecorder();
+  const rig = makeNotionRig();
+  const deps = makeCommitDeps(apps, {
+    readFile: () => JSON.stringify(results),
+    buildCompanyPeopleSearchUrl: fakeBuildUrl,
+    ...rec.deps,
+    ...rig.deps,
+  });
+  const cmd = makePrepareCommand(deps);
+  const ctx = makeCtx({ flags: { phase: "commit", resultsFile: "/r.json" } });
+  await cmd(ctx);
+
+  // Helper invoked once per committed row, every tier, with company/role/loc.
+  assert.equal(helperCalls.length, 3, "helper called for all three tiers");
+  const callByCompany = Object.fromEntries(helperCalls.map((c) => [c.company, c]));
+  assert.deepEqual(callByCompany["Affirm"], {
+    company: "Affirm",
+    roleTitle: "Senior PM",
+    location: "San Francisco, CA",
+  });
+  assert.deepEqual(callByCompany["Stripe"], {
+    company: "Stripe",
+    roleTitle: "Product Manager",
+    location: "New York, NY",
+  });
+  // Empty locations[] → location is undefined (company-only helper input).
+  assert.deepEqual(callByCompany["Plaid"], {
+    company: "Plaid",
+    roleTitle: "Group PM",
+    location: undefined,
+  });
+
+  // (a) TSV row carries the URL for every tier.
+  const saved = deps._getSaved();
+  const savedByKey = Object.fromEntries(saved.map((a) => [a.key, a]));
+  assert.equal(savedByKey["gh:1"].company_people_search_url, "https://fake.search/Affirm");
+  assert.equal(savedByKey["gh:2"].company_people_search_url, "https://fake.search/Stripe");
+  assert.equal(savedByKey["gh:3"].company_people_search_url, "https://fake.search/Plaid");
+  // Commit must NOT set/modify hm_outreach_status — phase 1 (the TSV loader)
+  // owns its `to_search` default. These apps are constructed directly (not
+  // loaded from a TSV), so the field is whatever makeApp produced; the point
+  // is the commit path left it untouched.
+  assert.equal("hm_outreach_status" in savedByKey["gh:1"], false);
+  assert.equal("hm_outreach_status" in savedByKey["gh:3"], false);
+
+  // (b) Notion field payload carries companyPeopleSearchUrl for every tier.
+  assert.equal(rig.pushCalls.length, 3, "all three rows pushed");
+  const pushedByCompany = Object.fromEntries(
+    rig.pushCalls.map((c) => [c.jobFields.companyName, c.jobFields])
+  );
+  assert.equal(pushedByCompany["Affirm"].companyPeopleSearchUrl, "https://fake.search/Affirm");
+  assert.equal(pushedByCompany["Stripe"].companyPeopleSearchUrl, "https://fake.search/Stripe");
+  assert.equal(pushedByCompany["Plaid"].companyPeopleSearchUrl, "https://fake.search/Plaid");
+});
+
+// The Notion property is emitted ONLY when the profile's property_map maps
+// `companyPeopleSearchUrl`. With the key present, buildProperties surfaces it.
+test("prepare --phase commit (RFC 059): Notion property emitted when property_map maps companyPeopleSearchUrl", async () => {
+  const { buildProperties, DEFAULT_PROPERTY_MAP } = require("../core/notion_sync.js");
+  const apps = [
+    makeApp({
+      key: "gh:1",
+      status: "Inbox",
+      companyName: "Affirm",
+      title: "Senior PM",
+      locations: ["San Francisco, CA"],
+    }),
+  ];
+  const results = {
+    profileId: "testuser",
+    results: [
+      {
+        key: "gh:1",
+        fitScore: "Strong",
+        fitRationale: "core",
+        clKey: "Affirm_PM",
+        resumeVer: "v1",
+        clParagraphs: ["P1", "P2", "P3", "P4"],
+      },
+    ],
+  };
+  // Profile whose property_map DOES map the new key (phase-3 shape).
+  const profileWithMap = {
+    id: "testuser",
+    filterRules: {},
+    company_tiers: {},
+    identity: {
+      name: "JARED MOORE",
+      phone: "+1 (916) 261-261-9",
+      email: "ymuromcev@gmail.com",
+      location: "Sacramento, CA",
+      linkedin: "linkedin.com/in/ymuromcev",
+    },
+    notion: {
+      jobs_pipeline_db_id: "test-jobs-db",
+      companies_db_id: "test-companies-db",
+      property_map: {
+        ...DEFAULT_PROPERTY_MAP,
+        companyPeopleSearchUrl: { field: "People Search URL", type: "url" },
+      },
+    },
+    paths: {
+      root: "/fake/profiles/testuser",
+      applicationsTsv: "/fake/profiles/testuser/applications.tsv",
+      jdCacheDir: "/fake/profiles/testuser/jd_cache",
+    },
+  };
+  const rec = makeClRecorder();
+  const rig = makeNotionRig();
+  const deps = makeCommitDeps(apps, {
+    profile: profileWithMap,
+    readFile: () => JSON.stringify(results),
+    buildCompanyPeopleSearchUrl: () => "https://fake.search/Affirm",
+    ...rec.deps,
+    ...rig.deps,
+  });
+  const cmd = makePrepareCommand(deps);
+  const ctx = makeCtx({ flags: { phase: "commit", resultsFile: "/r.json" } });
+  await cmd(ctx);
+
+  assert.equal(rig.pushCalls.length, 1);
+  const { jobFields, propertyMap } = rig.pushCalls[0];
+  // The payload carries the field, and the mapped property_map surfaces it as
+  // a Notion `url` property under the mapped field name.
+  const props = buildProperties(jobFields, propertyMap);
+  assert.deepEqual(props["People Search URL"], {
+    url: "https://fake.search/Affirm",
+  });
+});
+
+// Profiles whose property_map lacks the key (e.g. _example until phase 3)
+// silently drop the field — buildProperties iterates property_map keys, so an
+// unmapped field never reaches Notion even though it sits on the payload.
+test("prepare --phase commit (RFC 059): Notion property omitted when property_map lacks companyPeopleSearchUrl", async () => {
+  const { buildProperties } = require("../core/notion_sync.js");
+  const apps = [
+    makeApp({
+      key: "gh:1",
+      status: "Inbox",
+      companyName: "Affirm",
+      title: "Senior PM",
+      locations: ["San Francisco, CA"],
+    }),
+  ];
+  const results = {
+    profileId: "testuser",
+    results: [
+      {
+        key: "gh:1",
+        fitScore: "Strong",
+        fitRationale: "core",
+        clKey: "Affirm_PM",
+        resumeVer: "v1",
+        clParagraphs: ["P1", "P2", "P3", "P4"],
+      },
+    ],
+  };
+  const rec = makeClRecorder();
+  const rig = makeNotionRig();
+  // Default makeCommitDeps profile has NO property_map → runCommit falls back
+  // to DEFAULT_PROPERTY_MAP, which does not map companyPeopleSearchUrl.
+  const deps = makeCommitDeps(apps, {
+    readFile: () => JSON.stringify(results),
+    buildCompanyPeopleSearchUrl: () => "https://fake.search/Affirm",
+    ...rec.deps,
+    ...rig.deps,
+  });
+  const cmd = makePrepareCommand(deps);
+  const ctx = makeCtx({ flags: { phase: "commit", resultsFile: "/r.json" } });
+  await cmd(ctx);
+
+  assert.equal(rig.pushCalls.length, 1);
+  const { jobFields, propertyMap } = rig.pushCalls[0];
+  // The field IS on the in-memory payload (engine still authors it for the
+  // TSV)...
+  assert.equal(jobFields.companyPeopleSearchUrl, "https://fake.search/Affirm");
+  // ...but no mapped property carries it, and no stray Notion property
+  // matches the would-be field name.
+  assert.equal(propertyMap.companyPeopleSearchUrl, undefined);
+  const props = buildProperties(jobFields, propertyMap);
+  assert.equal(props["People Search URL"], undefined);
+  // The TSV row still persists the URL regardless of property_map.
+  const saved = deps._getSaved();
+  assert.equal(saved[0].company_people_search_url, "https://fake.search/Affirm");
+});
+
 // RFC 034: Notion failure on a Weak row reverts TSV to Inbox (existing
 // RFC 022 contract still holds — the row gets a second chance next run via
 // `filterAlreadyEvaluated` checks — but since fit_score=Weak persists, it

--- a/rfc/059-hm-outreach.md
+++ b/rfc/059-hm-outreach.md
@@ -2,6 +2,12 @@
 
 - Status: **Proposed** (open question resolved 2026-06-03 → Option 1)
 - Date: 2026-06-03
+- **Scope amended 2026-06-03:** the `company_people_search_url` is
+  populated for **all fit tiers** (Strong/Medium/Weak) on commit, per
+  operator decision — superseding the original "Medium+/Strong only"
+  gate. The property_map-presence guard is unchanged: Notion still only
+  receives the field when the profile maps `companyPeopleSearchUrl`. See
+  §C and "Out of scope".
 - Refs: BL-169 (authoritative model; supersedes/merges BL-166), BL-62
   (outbound discovery; note/DM templates live in its Notion project),
   RFC 014 (status split), RFC 022 (per-row Notion push in commit),
@@ -11,8 +17,9 @@
 ## Summary
 
 Add one **job-centric outreach motion** on top of the existing ATS
-pipeline. For every Medium+/Strong vacancy the engine emits a LinkedIn
-**company people-search URL** (`company_people_search_url`). The operator
+pipeline. For **every committed vacancy** (all fit tiers — scope amended
+2026-06-03, see §C) the engine emits a LinkedIn **company people-search
+URL** (`company_people_search_url`). The operator
 opens it; LinkedIn itself surfaces "N of your connections work here" and
 the operator decides **warm** (their own contact) vs **cold** (a hiring
 manager / recruiter). Outreach state is tracked **on the vacancy card**
@@ -137,30 +144,38 @@ company throw, encoding of spaces/`&`/unicode).
 
 ### C. `prepare --phase commit` integration (`engine/commands/prepare.js`)
 
-Populate `company_people_search_url` for **Medium+/Strong rows only**
-during the commit phase, write it to the TSV row, and push it into the
-Notion page via the property map.
+> **Scope amended 2026-06-03 (operator decision):** the search URL is
+> populated for **all fit tiers** (Strong / Medium / Weak), superseding
+> the original Medium+/Strong gate. Rationale: the people-search URL is a
+> cheap, harmless link — a human clicks it, nothing is sent or scraped.
+> The operator decides per-row whether to actually act on it; excluding
+> Weak rows throws away that cheap optionality for no benefit. The only
+> gate on whether Notion sees the field is **property_map presence** (see
+> below), not fit tier.
 
-**Design.** In `buildJobFieldsForNotion(...)`
-(`engine/commands/prepare.js`, ~L1629 — the pure field assembler that
-already maps `companyName`/`title`/`fitScore`/etc.), add a gated field:
+Populate `company_people_search_url` for **all committed rows
+(Strong/Medium/Weak) — no fit-tier gate** during the commit phase, write
+it to the TSV row, and push it into the Notion page via the property map.
+
+**Design.** The commit-phase per-row loop (`engine/commands/prepare.js`,
+where each promoted row gets `app.status = "To Apply"`) computes the URL
+for **every** committed row and writes it onto the in-memory `app` (and
+thus the TSV column `company_people_search_url` from workstream A):
 
 ```js
-if (r.fitScore === "Medium" || r.fitScore === "Strong") {
-  fields.companyPeopleSearchUrl = buildCompanyPeopleSearchUrl({
-    company: app.companyName,
-    roleTitle: app.title,
-    location: (app.locations && app.locations[0]) || undefined,
-  });
-}
+app.company_people_search_url = deps.buildCompanyPeopleSearchUrl({
+  company: app.companyName,
+  roleTitle: app.title,
+  location: (app.locations && app.locations[0]) || undefined,
+});
 ```
 
-Weak rows are excluded (matches RFC 049 / the existing weak-fallback —
-Weak still reaches Notion but gets no outreach URL). The helper is wired
-through `deps` (like `formatSalaryDisplay`) so it stays injectable for
-tests. The same value is written to the TSV row alongside the existing
-commit write-back (`company_people_search_url` column from workstream A);
-`hm_outreach_status` is left at its `to_search` default on commit.
+`buildJobFieldsForNotion(...)` (the pure field assembler, ~L1629) then
+surfaces that value into the Notion payload as
+`fields.companyPeopleSearchUrl` — for every tier, with no
+`if (fitScore === ...)` gate. The helper is wired through `deps` (like
+`formatSalaryDisplay`) so it stays injectable for tests.
+`hm_outreach_status` is left at its phase-1 `to_search` default on commit.
 
 **Property-map dependency.** The push only emits the property when the
 profile's `property_map` defines `companyPeopleSearchUrl` (workstream D).
@@ -169,9 +184,10 @@ field — consistent with how `buildProperties` already drops unmapped
 fields.
 
 **Files touched:** `engine/commands/prepare.js`,
-`engine/commands/prepare.test.js` (assert Medium/Strong get a URL in both
-the TSV row and the Notion field payload; Weak gets none; helper injected
-as a fake).
+`engine/commands/prepare.test.js` (assert Strong, Medium, AND Weak each
+get a URL in both the TSV row and the Notion field payload; helper
+injected as a fake; the Notion property is omitted when `property_map`
+lacks `companyPeopleSearchUrl`).
 
 ### D. Notion schema change (operator-executed; design only here)
 
@@ -321,17 +337,19 @@ vacancy DB.
 - **B (helper):** company-only, company+role, company+role+location,
   missing-company throws, encoding of spaces/`&`/unicode; no network
   import.
-- **C (prepare commit):** Medium and Strong rows get a populated URL in
-  both the TSV row and the Notion field payload; Weak gets none; helper
-  injected as a fake; property omitted when `property_map` lacks the key.
+- **C (prepare commit):** Strong, Medium, AND Weak rows each get a
+  populated URL in both the TSV row and the Notion field payload (no
+  fit-tier gate); helper injected as a fake; property omitted when
+  `property_map` lacks the key.
 - **E (sync):** update-path pulls the five operator fields when Notion
   differs (Notion wins); add-path seeds them; engine-written
   `company_people_search_url` is not overwritten by an empty Notion value;
   `reconcilePull` stays pure; no push path introduced.
 - All network mocked. No real LinkedIn/Notion calls in unit tests.
-- **Smoke:** local `prepare --phase commit` on a Medium+/Strong batch
-  populates the URL + Notion field; `sync --apply` round-trips a manually
-  set `hm_outreach_status` from Notion back into the TSV.
+- **Smoke:** local `prepare --phase commit` on a mixed-tier batch
+  (Strong/Medium/Weak) populates the URL + Notion field on every row;
+  `sync --apply` round-trips a manually set `hm_outreach_status` from
+  Notion back into the TSV.
 
 ## Risks
 
@@ -391,16 +409,22 @@ schema — leave to the BL-62 experiment.
 - A full sales CRM / per-person junction DB (see Open questions — deferred).
 - Re-enabling a Notion push path. `prepare` commit stays the only creator
   of Notion pages.
-- Outreach on Weak-fit vacancies. Medium+/Strong only.
+- Note: the search URL itself is populated for **all fit tiers**
+  (Strong/Medium/Weak — scope amended 2026-06-03). What stays
+  operator-prioritized is the **actual outreach effort** (which rows are
+  worth a connection note / DM this week), not whether the URL exists. The
+  engine emits the link everywhere; the operator chooses where to spend
+  invites (see the to-do-queue view in workstream D and the weekly cap in
+  Risks).
 
 ## Rollout (phased)
 
 1. **Schema + helper (A, B).** TSV v6 + auto-migration + the pure
    `linkedin_search_url` helper, both fully tested. No behaviour change yet
    (no field is populated until C).
-2. **prepare integration (C).** Medium+/Strong rows get
-   `company_people_search_url` in TSV and (once property_map has the key)
-   in Notion.
+2. **prepare integration (C).** All committed rows (Strong/Medium/Weak —
+   no fit-tier gate) get `company_people_search_url` in TSV and (once
+   property_map has the key) in Notion.
 3. **Notion schema + property_map + sync (D, E).** Operator runs the
    personal-Notion edits; `property_map` gains the six keys; `sync`
    round-trips the operator-owned outreach fields. After this the vacancy


### PR DESCRIPTION
## What

Phase 2 of RFC 059 (BL-169). `prepare --phase commit` now writes a prefab LinkedIn people-search URL onto **every committed row, all fit tiers** (Strong/Medium/Weak) — scope amended per operator decision (was Medium+/Strong).

## Changes
- `runCommit`: `app.company_people_search_url = buildCompanyPeopleSearchUrl({company,roleTitle,location})` for every promoted row, no fit gate. `hm_outreach_status` left at phase-1 `to_search` default.
- `buildJobFieldsForNotion`: surfaces it as `companyPeopleSearchUrl`; `buildProperties` emits it only when the profile's `property_map` maps the key — profiles without it (e.g. `_example` until phase 3) silently drop it. **No profile modified here.**
- Helper injected via `makeDefaultDeps` for test fakes.
- RFC 059 §C amended to all-tier; out-of-scope Weak-exclusion removed; dated scope-amended note.

## Tests
`npm test` → **2004/2004 pass**. prettier `--check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)