### PR TITLE
feat(outreach): RFC 059 phase 3 — sync round-trips Outreach status (Notion→TSV)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,12 @@ lives in `profiles/<id>/`.
 - **Prepare** — Two-phase (pre / commit) with a human review gate.
   Assigns resume archetype, drafts cover letter with per-profile
   voice, computes a salary band from Tier × Level × cost-of-living.
-- **Sync** — Push / pull against Notion. Defaults to dry-run;
-  `--apply` writes. Uses Notion SDK v5 (`dataSources.query`).
+  On commit, also emits a per-vacancy LinkedIn people-search URL for
+  hiring-manager / warm-contact outreach (RFC 059).
+- **Sync** — Pull against Notion (pull-only since 2026-05-04). Defaults
+  to dry-run; `--apply` writes. Uses Notion SDK v5 (`dataSources.query`).
+  Round-trips the operator-owned `Outreach` status back into the local
+  ledger (RFC 059).
 - **Check** — Reads Gmail replies via Claude MCP, classifies
   (rejection / interview invite / info request / recruiter
   outreach), updates Notion status and adds comments.

--- a/engine/commands/sync.js
+++ b/engine/commands/sync.js
@@ -85,9 +85,10 @@ function companyNameForPage(page, companyNameById) {
 //
 // Returns { updates, adds }:
 //   updates — { before, after } pairs for existing local rows whose
-//             notion_page_id / status / (empty) companyName drifted from
-//             Notion (Notion wins; a populated local companyName is never
-//             overwritten).
+//             notion_page_id / status / (empty) companyName / outreach status
+//             drifted from Notion (Notion wins; a populated local companyName
+//             is never overwritten; an empty Notion outreach value never
+//             clobbers the local placeholder).
 //   adds    — full TSV row objects for Notion pages with NO matching local
 //             row. This makes the pull additive: the fly.io cron's stale
 //             TSV picks up apps created on the operator's Mac (RFC 055).
@@ -126,6 +127,16 @@ function reconcilePull(apps, notionPages, propertyMap, now, companyNameById = {}
         changed = true;
       }
     }
+    // RFC 059 (BL-169): pull the operator-owned Outreach status (Notion wins).
+    // The `page.hmOutreachStatus` truthiness guard means an empty/unset Notion
+    // value never clobbers the local one — the engine-seeded "to_search"
+    // placeholder survives until the operator actually sets Outreach in Notion.
+    // `company_people_search_url` is engine-written (one-way, set at prepare
+    // commit) so it is deliberately NOT pulled back here.
+    if (page.hmOutreachStatus && app.hm_outreach_status !== page.hmOutreachStatus) {
+      next.hm_outreach_status = page.hmOutreachStatus;
+      changed = true;
+    }
     if (changed) updates.push({ before: app, after: next });
   }
 
@@ -156,6 +167,16 @@ function reconcilePull(apps, notionPages, propertyMap, now, companyNameById = {}
       fit_rationale: "",
       fit_evaluated_at: "",
       skip_reason: "",
+      // RFC 059 (BL-169): outreach columns. company_people_search_url is left
+      // empty for pulled rows (it is computed by prepare commit, not on pull);
+      // hm_outreach_status takes Notion's value when present, else the
+      // engine-default placeholder.
+      company_people_search_url: "",
+      outreach_type: "",
+      contact_name: "",
+      contact_linkedin: "",
+      hm_outreach_status: page.hmOutreachStatus || "to_search",
+      hm_outreach_date: "",
     });
   }
 

--- a/engine/commands/sync.test.js
+++ b/engine/commands/sync.test.js
@@ -292,6 +292,65 @@ test("reconcilePull adds a Notion page with no matching local row (RFC 055)", ()
   assert.equal(row.skip_reason, "");
 });
 
+test("reconcilePull pulls Outreach status from Notion (RFC 059, Notion wins)", () => {
+  const apps = [
+    fakeApp({
+      key: "greenhouse:1",
+      status: "Applied",
+      notion_page_id: "p1",
+      hm_outreach_status: "to_search",
+    }),
+  ];
+  const pages = [
+    { notionPageId: "p1", key: "greenhouse:1", status: "Applied", hmOutreachStatus: "In progress" },
+  ];
+  const { updates } = reconcilePull(apps, pages, DEFAULT_PROPERTY_MAP, NOW);
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0].after.hm_outreach_status, "In progress");
+});
+
+test("reconcilePull never clobbers a local outreach status with an empty Notion value (RFC 059)", () => {
+  const apps = [
+    fakeApp({
+      key: "greenhouse:1",
+      status: "Applied",
+      notion_page_id: "p1",
+      hm_outreach_status: "Done",
+    }),
+  ];
+  // Notion page has no hmOutreachStatus (operator hasn't set Outreach yet).
+  const pages = [{ notionPageId: "p1", key: "greenhouse:1", status: "Applied" }];
+  const { updates } = reconcilePull(apps, pages, DEFAULT_PROPERTY_MAP, NOW);
+  assert.equal(updates.length, 0, "no drift → no update; local 'Done' survives");
+});
+
+test("reconcilePull add-path seeds outreach columns, taking Notion's status when present (RFC 059)", () => {
+  const pages = [
+    {
+      notionPageId: "p2",
+      key: "lever:abc",
+      source: "lever",
+      jobId: "abc",
+      status: "Interview",
+      hmOutreachStatus: "Done",
+    },
+    { notionPageId: "p3", key: "lever:def", source: "lever", jobId: "def", status: "To Apply" },
+  ];
+  const { adds } = reconcilePull([], pages, DEFAULT_PROPERTY_MAP, NOW);
+  const byKey = Object.fromEntries(adds.map((a) => [a.key, a]));
+  assert.equal(byKey["lever:abc"].hm_outreach_status, "Done", "Notion value wins on add");
+  assert.equal(
+    byKey["lever:def"].hm_outreach_status,
+    "to_search",
+    "default placeholder when Notion unset"
+  );
+  assert.equal(byKey["lever:abc"].company_people_search_url, "", "URL left empty on pulled add");
+  assert.equal(byKey["lever:abc"].outreach_type, "");
+  assert.equal(byKey["lever:abc"].contact_name, "");
+  assert.equal(byKey["lever:abc"].contact_linkedin, "");
+  assert.equal(byKey["lever:abc"].hm_outreach_date, "");
+});
+
 test("reconcilePull defaults source to 'notion' when the page has none", () => {
   const apps = [];
   const pages = [{ notionPageId: "p9", key: "manual-entry", status: "Applied" }];

--- a/profiles/_example/profile.example.json
+++ b/profiles/_example/profile.example.json
@@ -44,7 +44,9 @@
       "jobId":       { "field": "JobID",   "type": "rich_text" },
       "url":         { "field": "URL",     "type": "url" },
       "status":      { "field": "Status",  "type": "status" },
-      "key":         { "field": "Key",     "type": "rich_text" }
+      "key":         { "field": "Key",     "type": "rich_text" },
+      "companyPeopleSearchUrl": { "field": "LinkedIn Search", "type": "url" },
+      "hmOutreachStatus":       { "field": "Outreach",        "type": "status" }
     }
   }
 }

--- a/rfc/059-hm-outreach.md
+++ b/rfc/059-hm-outreach.md
@@ -1,6 +1,7 @@
 # RFC 059 — Hiring-manager & warm-contact outreach (job-centric, LinkedIn)
 
-- Status: **Proposed** (open question resolved 2026-06-03 → Option 1)
+- Status: **Implemented** (phases 1–3 shipped 2026-06-03; phase 4 =
+  content, tracked in BL-62). Open question resolved → Option 1.
 - Date: 2026-06-03
 - **Scope amended 2026-06-03:** the `company_people_search_url` is
   populated for **all fit tiers** (Strong/Medium/Weak) on commit, per
@@ -416,6 +417,49 @@ schema — leave to the BL-62 experiment.
   engine emits the link everywhere; the operator chooses where to spend
   invites (see the to-do-queue view in workstream D and the weekly cap in
   Risks).
+
+## As-built (2026-06-03)
+
+Phases 1–3 shipped. The Notion-side schema (workstream D) was deliberately
+built **leaner** than the design above — the operator chose a minimal
+surface consistent with the "no per-person CRM" decision (BL-166/169):
+
+**Notion vacancy DB — what was actually created:**
+
+- **`LinkedIn Search`** (`url`) — the engine-written people-search URL.
+- **`Outreach`** (`status`, 3 options: `Not started` / `In progress` /
+  `Done`) — the operator-owned outreach state. Built as a Notion **status**
+  property, not the 7-state `select` the design sketched; the 3-state
+  lifecycle is enough for v1.
+- **`People`** (`rollup` over the existing `Company` relation,
+  `show_unique`) — "who I know at this company", read-only.
+- `Company` was already a relation to `companies_db` (RFC 058), so the
+  `people_db`.«Компания» relation bridge was already in place.
+
+**Deferred (not created):** `outreach_type`, `contact_name`,
+`contact_linkedin`, `hm_outreach_date`. Per-contact detail lives in the
+LinkedIn UI + the `People` rollup, not in Notion columns. The TSV still
+carries these as v6 columns (empty placeholders) so the schema is stable
+if they are added later.
+
+**property_map (Jared's profile) — 2 keys added, not 6:**
+
+| key | Notion field | type | writer |
+|---|---|---|---|
+| `companyPeopleSearchUrl` | `LinkedIn Search` | `url` | engine (`prepare` commit) |
+| `hmOutreachStatus` | `Outreach` | `status` | operator → `sync` pull |
+
+**`sync` round-trip (workstream E, as-built):** `reconcilePull` pulls the
+single operator-owned field `hm_outreach_status` from Notion's `Outreach`
+status (Notion wins; an empty/unset Notion value never clobbers the local
+placeholder). `company_people_search_url` is engine-authored at `prepare`
+commit and is **not** pulled back. The add-path seeds all six v6 outreach
+columns, taking Notion's `Outreach` value when present. Pull-only model
+preserved; no push path added.
+
+**Not done (intentionally, content not code):** the Notion "to-do queue"
+view (workstream D.5) and the note/DM templates (workstream F) — both live
+in the BL-62 Notion project and are authored by hand, tracked there.
 
 ## Rollout (phased)
 


### PR DESCRIPTION
Completes the engine side of **RFC 059 / BL-169** (job-centric LinkedIn outreach). Phases 1–2 (TSV v6 columns + LinkedIn search-URL helper + prepare-commit population) already merged (#56, #57); this is **phase 3**: the `sync` round-trip + property_map wiring.

## What changed
- **`sync.reconcilePull`** now pulls the operator-owned `hm_outreach_status` from Notion's `Outreach` status. Notion wins; an empty/unset Notion value never clobbers the local placeholder. The add-path seeds all six v6 outreach columns, taking Notion's value when present.
- `company_people_search_url` is engine-authored at prepare-commit and is **not** pulled back (one-way). Pull-only model preserved — **no push path added**.
- `_example/profile.example.json` documents the two as-built property_map keys.
- **RFC 059** marked Implemented + an "As-built" section recording the leaner Notion schema actually built (URL + 3-state `Outreach` status + `People` rollup; per-contact fields deferred, consistent with the no-per-person-CRM decision).
- README updated.

## Notion side (operator-executed, done)
- Added `LinkedIn Search` (url) field on the vacancy DB.
- `Outreach` status (Not started / In progress / Done) and `People` rollup were already created by the operator.
- Jared's `profile.json` property_map gained the 2 keys (gitignored; not in this PR).

## Tests
- update-path pull (Notion wins), no-clobber-on-empty, add-path seeds outreach columns.
- **2007 tests green; prettier clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)