### PR TITLE
feat(outreach): align hm_outreach_status default to "To do" (4-state)

### DIFF
--- a/engine/commands/prepare.js
+++ b/engine/commands/prepare.js
@@ -2057,7 +2057,7 @@ async function runCommit(ctx, deps) {
     // per-row whether to act, so there is no fit-tier gate. The only gate
     // on whether Notion sees it is property_map presence, handled by
     // buildProperties dropping unmapped fields. `hm_outreach_status` is
-    // left at its phase-1 `to_search` default here.
+    // left at its phase-1 `To do` default here.
     app.company_people_search_url = deps.buildCompanyPeopleSearchUrl({
       company: app.companyName,
       roleTitle: app.title,

--- a/engine/commands/prepare.test.js
+++ b/engine/commands/prepare.test.js
@@ -1972,7 +1972,7 @@ test("prepare --phase commit (RFC 059): Strong + Medium + Weak all get company_p
   assert.equal(savedByKey["gh:2"].company_people_search_url, "https://fake.search/Stripe");
   assert.equal(savedByKey["gh:3"].company_people_search_url, "https://fake.search/Plaid");
   // Commit must NOT set/modify hm_outreach_status — phase 1 (the TSV loader)
-  // owns its `to_search` default. These apps are constructed directly (not
+  // owns its `To do` default. These apps are constructed directly (not
   // loaded from a TSV), so the field is whatever makeApp produced; the point
   // is the commit path left it untouched.
   assert.equal("hm_outreach_status" in savedByKey["gh:1"], false);

--- a/engine/commands/sync.js
+++ b/engine/commands/sync.js
@@ -129,7 +129,7 @@ function reconcilePull(apps, notionPages, propertyMap, now, companyNameById = {}
     }
     // RFC 059 (BL-169): pull the operator-owned Outreach status (Notion wins).
     // The `page.hmOutreachStatus` truthiness guard means an empty/unset Notion
-    // value never clobbers the local one — the engine-seeded "to_search"
+    // value never clobbers the local one — the engine-seeded "To do"
     // placeholder survives until the operator actually sets Outreach in Notion.
     // `company_people_search_url` is engine-written (one-way, set at prepare
     // commit) so it is deliberately NOT pulled back here.
@@ -175,7 +175,7 @@ function reconcilePull(apps, notionPages, propertyMap, now, companyNameById = {}
       outreach_type: "",
       contact_name: "",
       contact_linkedin: "",
-      hm_outreach_status: page.hmOutreachStatus || "to_search",
+      hm_outreach_status: page.hmOutreachStatus || "To do",
       hm_outreach_date: "",
     });
   }

--- a/engine/commands/sync.test.js
+++ b/engine/commands/sync.test.js
@@ -298,7 +298,7 @@ test("reconcilePull pulls Outreach status from Notion (RFC 059, Notion wins)", (
       key: "greenhouse:1",
       status: "Applied",
       notion_page_id: "p1",
-      hm_outreach_status: "to_search",
+      hm_outreach_status: "To do",
     }),
   ];
   const pages = [
@@ -341,7 +341,7 @@ test("reconcilePull add-path seeds outreach columns, taking Notion's status when
   assert.equal(byKey["lever:abc"].hm_outreach_status, "Done", "Notion value wins on add");
   assert.equal(
     byKey["lever:def"].hm_outreach_status,
-    "to_search",
+    "To do",
     "default placeholder when Notion unset"
   );
   assert.equal(byKey["lever:abc"].company_people_search_url, "", "URL left empty on pulled add");

--- a/engine/core/applications_tsv.js
+++ b/engine/core/applications_tsv.js
@@ -20,10 +20,11 @@
 //   `outreach_type`             — "warm" | "cold" | "" (operator → Notion → sync).
 //   `contact_name`              — free text (operator → Notion → sync).
 //   `contact_linkedin`          — URL (operator → Notion → sync).
-//   `hm_outreach_status`        — "to_search" | "searching" | "pending_connection"
-//                                 | "connected" | "dm_sent" | "replied" | "dead".
-//                                 Defaults to "to_search" so existing rows land in
-//                                 a valid lifecycle state (operator → Notion → sync).
+//   `hm_outreach_status`        — as-built Notion `Outreach` status, 4-state:
+//                                 "To do" | "In flight" | "Replied" | "Dead".
+//                                 Defaults to "To do" (Notion's first option) so a
+//                                 fresh row matches the value Notion auto-assigns and
+//                                 `sync` shows no spurious diff (operator → Notion → sync).
 //   `hm_outreach_date`          — ISO date (operator → Notion → sync).
 //
 // v5 (added 2026-05-18 for BL-93 / RFC 038 — persist the full multi-element
@@ -76,7 +77,7 @@
 //
 // Backward compat (auto-upgrade-on-save):
 //   v5 (20 cols, 2026-05-18 — RFC 038 locations[]) → reader seeds the six v6
-//     outreach defaults (empty + hm_outreach_status="to_search").
+//     outreach defaults (empty + hm_outreach_status="To do").
 //   v4 (20 cols, 2026-05-05 — BL-9 fit columns, single-string `location`) →
 //     reader wraps non-empty `location` to `[location]`, empty to `[]`, and
 //     seeds the v6 outreach defaults.
@@ -166,15 +167,18 @@ const HEADER = HEADER_V6;
 
 // RFC 059: default values for the six v6 outreach fields. Older rowToApp*
 // paths seed these so an old file loads cleanly; the next save() rewrites it
-// as v6. `hm_outreach_status` defaults to "to_search" (a valid lifecycle
-// state); the rest default empty.
+// as v6. `hm_outreach_status` defaults to "To do" — the first option of the
+// as-built Notion `Outreach` status (4-state: To do / In flight / Replied /
+// Dead). Matching Notion's first option means a fresh `scan` row never drifts
+// from the value Notion auto-assigns, so `sync` shows no spurious diff. The
+// other five default empty.
 function outreachDefaults() {
   return {
     company_people_search_url: "",
     outreach_type: "",
     contact_name: "",
     contact_linkedin: "",
-    hm_outreach_status: "to_search",
+    hm_outreach_status: "To do",
     hm_outreach_date: "",
   };
 }

--- a/engine/core/applications_tsv.test.js
+++ b/engine/core/applications_tsv.test.js
@@ -498,14 +498,14 @@ test("appendNew dedups when adapter returns the same id with and without prefix"
 
 // --- RFC 059 / BL-169: v6 outreach columns --------------------------------
 
-test("appendNew seeds the six v6 outreach defaults (hm_outreach_status='to_search')", () => {
+test("appendNew seeds the six v6 outreach defaults (hm_outreach_status='To do')", () => {
   const r = apps.appendNew([], [fixtureJob()], { now: "2026-06-03T00:00:00Z" });
   const a = r.apps[0];
   assert.equal(a.company_people_search_url, "");
   assert.equal(a.outreach_type, "");
   assert.equal(a.contact_name, "");
   assert.equal(a.contact_linkedin, "");
-  assert.equal(a.hm_outreach_status, "to_search");
+  assert.equal(a.hm_outreach_status, "To do");
   assert.equal(a.hm_outreach_date, "");
 });
 
@@ -617,14 +617,14 @@ test("load auto-upgrades v5 files (20 cols) with the six v6 outreach defaults", 
   assert.equal(back.apps[0].outreach_type, "");
   assert.equal(back.apps[0].contact_name, "");
   assert.equal(back.apps[0].contact_linkedin, "");
-  assert.equal(back.apps[0].hm_outreach_status, "to_search");
+  assert.equal(back.apps[0].hm_outreach_status, "To do");
   assert.equal(back.apps[0].hm_outreach_date, "");
 
   // Re-saving promotes the file to v6.
   apps.save(file, back.apps);
   const after = apps.load(file);
   assert.equal(after.schemaVersion, 6);
-  assert.equal(after.apps[0].hm_outreach_status, "to_search");
+  assert.equal(after.apps[0].hm_outreach_status, "To do");
   assert.deepEqual(after.apps[0].locations, ["San Francisco, CA"]);
 });
 
@@ -650,7 +650,7 @@ test("load auto-upgrades v1 files with the v6 outreach defaults too", () => {
 
   const back = apps.load(file);
   assert.equal(back.schemaVersion, 1);
-  assert.equal(back.apps[0].hm_outreach_status, "to_search");
+  assert.equal(back.apps[0].hm_outreach_status, "To do");
   assert.equal(back.apps[0].company_people_search_url, "");
 
   apps.save(file, back.apps);

--- a/rfc/059-hm-outreach.md
+++ b/rfc/059-hm-outreach.md
@@ -427,10 +427,17 @@ surface consistent with the "no per-person CRM" decision (BL-166/169):
 **Notion vacancy DB — what was actually created:**
 
 - **`LinkedIn Search`** (`url`) — the engine-written people-search URL.
-- **`Outreach`** (`status`, 3 options: `Not started` / `In progress` /
-  `Done`) — the operator-owned outreach state. Built as a Notion **status**
-  property, not the 7-state `select` the design sketched; the 3-state
-  lifecycle is enough for v1.
+- **`Outreach`** (`status`, 4 options: `To do` / `In flight` / `Replied` /
+  `Dead`) — the operator-owned outreach state. Built as a Notion **status**
+  property, not the 7-state `select` the design sketched. The 4-state set
+  was chosen on the principle "each status = a distinct next action / whose
+  court": `To do` (queue, my move) → `In flight` (any active outreach) →
+  `Replied` (success exit) / `Dead` (closed exit). The TSV default
+  `hm_outreach_status` is **`To do`** (Notion's first option), so a fresh
+  `scan` row never diverges from the value Notion auto-assigns and `sync`
+  shows no spurious diff. (Status options are not editable via the Notion
+  API — the operator renames them in the UI; the engine reads whatever
+  string Notion returns, so no code change is needed to re-label them.)
 - **`People`** (`rollup` over the existing `Company` relation,
   `show_unique`) — "who I know at this company", read-only.
 - `Company` was already a relation to `companies_db` (RFC 058), so the


### PR DESCRIPTION
Follow-up to #58. Finalizes the **Outreach status set** to 4 states (operator decision): **To do / In flight / Replied / Dead** — each maps to a distinct next action ("whose court is the ball in").

## Why
The smoke run of #58 surfaced a vocabulary mismatch: the TSV default `hm_outreach_status` was `"to_search"` (leftover from the original 7-state design that was never built), while Notion's `Outreach` status auto-assigns its first option to every page. That made a first `sync --apply` churn ~651 rows for no real change.

## Change
- `outreachDefaults()` default `"to_search"` → `"To do"` (Notion's first option). A fresh `scan` row now matches what Notion auto-assigns, so `sync` shows **no spurious diff**.
- `sync` add-path + comments updated.
- RFC 059 As-built records the 4-state set, rationale, and that status options are renamed in the Notion UI (not API-editable) — the engine reads whatever string Notion returns, so no code change is needed to re-label.
- Tests updated. **2007 green; prettier clean.**

## Operator step (Notion UI, not code)
Rename the `Outreach` status options: Not started→**To do**, In progress→**In flight**, Done→**Replied**, add **Dead**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)