### PR TITLE
feat(outreach): BL-186 — backfill-outreach-url for pre-RFC-059 rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ node engine/cli.js <command> --profile <id> [flags]
 | `indeed-prep` | One-off helper for Indeed scraping prep (manual login flow). |
 | `answer` | Generate or reuse application answers and push back to Notion Q&A DB. |
 | `retro-tailor` | Re-tailor Strong rows currently in `To Apply` whose resume predates the RFC-044 tailoring loop. |
+| `backfill-outreach-url` | One-shot: fill the LinkedIn people-search URL for existing `To Apply` / `Applied` rows that predate the RFC-059 outreach feature. Dry-run by default; `--apply` writes TSV + Notion. Idempotent. |
 
 `node engine/cli.js --help` prints the same list with full flag docs.
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -115,6 +115,18 @@ Notion-backed answer bank, deduping on question hash and categorizing
 by topic. (RFC 009 documented this command under the working name
 `application-answers`; the dispatcher exposes it as `answer`.)
 
+**`backfill-outreach-url`**. One-shot backfill (BL-186 / RFC 059
+amendment) that fills the LinkedIn people-search URL for existing
+`To Apply` / `Applied` rows committed before the RFC-059 outreach
+feature populated it. Default dry-run prints `would enrich N, skip M
+(no company), already set K`; `--apply` computes the URL with the shared
+`buildCompanyPeopleSearchUrl` helper, writes it to TSV, and pushes it to
+the Notion `LinkedIn Search` field via a targeted single-field
+`pages.update` (the same engine-authored one-way write `check` uses for
+status). Idempotent — rows that already have a URL are skipped. Does not
+break pull-only: it creates no pages and touches no operator-owned field,
+only the engine-owned URL.
+
 ## 3. Discovery adapters
 
 All adapters live in `engine/modules/discovery/` and self-register via

--- a/engine/cli.js
+++ b/engine/cli.js
@@ -23,6 +23,7 @@ const KNOWN_COMMANDS = [
   "answer",
   "reclassify",
   "retro-tailor",
+  "backfill-outreach-url",
 ];
 
 const PARSE_OPTIONS = {
@@ -87,6 +88,14 @@ Commands:
              --apply --results-file <path>, generates tailored DOCX/PDF and
              updates the existing Notion page's Resume Version. Cover letter
              is NOT regenerated. See RFC 047 / BL-133.
+  backfill-outreach-url
+             One-shot backfill of the LinkedIn people-search URL for existing
+             "To Apply" / "Applied" rows that predate the RFC-059 outreach
+             feature (empty company_people_search_url). Dry-run by default
+             (prints "would enrich N, skip M (no company), already set K");
+             --apply computes the URL, writes it to TSV, and pushes it to the
+             Notion "LinkedIn Search" field via a targeted page update.
+             Idempotent — a second run is a no-op. See RFC 059 / BL-186.
 
 Flags:
   --profile <id>       Profile id (required for all commands). Lowercase, alphanum + - _.
@@ -210,6 +219,7 @@ function defaultCommands() {
     answer: require("./commands/answer.js"),
     reclassify: require("./commands/reclassify.js"),
     "retro-tailor": require("./commands/retro_tailor.js"),
+    "backfill-outreach-url": require("./commands/backfill_outreach_url.js"),
   };
 }
 

--- a/engine/cli.test.js
+++ b/engine/cli.test.js
@@ -200,6 +200,7 @@ test("runCli reports missing handler with a clear error", async () => {
 test("KNOWN_COMMANDS lists exactly the supported commands", () => {
   assert.deepEqual([...KNOWN_COMMANDS].sort(), [
     "answer",
+    "backfill-outreach-url",
     "check",
     "indeed-prep",
     "prepare",

--- a/engine/commands/backfill_outreach_url.js
+++ b/engine/commands/backfill_outreach_url.js
@@ -1,0 +1,198 @@
+// `backfill-outreach-url` command (BL-186 / RFC 059 amendment).
+//
+// One-shot backfill of the LinkedIn people-search URL for vacancies that
+// predate the RFC-059 outreach feature. RFC 059's `prepare --phase commit`
+// only populates `company_people_search_url` for rows committed AFTER the
+// feature shipped — every older `To Apply` / `Applied` row has an empty
+// `LinkedIn Search` field in Notion and an empty `company_people_search_url`
+// in TSV. This command computes the URL for those rows and writes it to both.
+//
+// Selection (pure, see `selectBackfillCandidates`):
+//   status ∈ {"To Apply", "Applied"} AND empty company_people_search_url
+//   AND non-empty companyName → candidate.
+//   Same status + empty url but empty companyName → skipped (no company to
+//   search on). Non-empty url → alreadySet (idempotency: a second run is a
+//   no-op).
+//
+// Default is dry-run: prints "would enrich N, skip M (no company),
+// already set K" and writes nothing. With `--apply`:
+//   1. Compute the URL via `buildCompanyPeopleSearchUrl`.
+//   2. Write it to TSV through `applications_tsv.js` (the only TSV writer).
+//   3. Push it to the Notion `LinkedIn Search` field via the SAME targeted
+//      `pages.update` pattern as `check`'s `updatePageStatus`.
+//
+// Notion write classification: `company_people_search_url` is engine-authored
+// one-way data (same class as the `prepare` commit-phase write that created
+// it on new rows). This is a targeted single-field `pages.update`, NOT a page
+// create and NOT a pull. It does not re-introduce a push path in the
+// pull-only sense — `sync` still never pushes, and Notion remains the source
+// of truth for operator-owned fields (status, outreach status). See the
+// "Amendment — BL-186 backfill" section of `rfc/059-hm-outreach.md`.
+
+const path = require("path");
+
+const profileLoader = require("../core/profile_loader.js");
+const { secretEnvName } = profileLoader;
+const applications = require("../core/applications_tsv.js");
+const notion = require("../core/notion_sync.js");
+const { resolveProfilesDir } = require("../core/paths.js");
+const { buildCompanyPeopleSearchUrl } = require("../core/linkedin_search_url.js");
+
+// Statuses eligible for backfill. Intentionally narrow (BL-186 NOT-in-scope:
+// Inbox / Rejected / Archived / Closed / No Response / Interview / Offer are
+// excluded — only the two states where the operator actively wants outreach).
+const BACKFILL_STATUSES = new Set(["To Apply", "Applied"]);
+
+const DEFAULT_DEPS = {
+  loadProfile: profileLoader.loadProfile,
+  loadSecrets: profileLoader.loadSecrets,
+  loadApplications: applications.load,
+  saveApplications: applications.save,
+  makeClient: notion.makeClient,
+  // Targeted single-field write — the engine-authored one-way pattern used by
+  // `check`'s status update. Injected so tests mock the network.
+  updatePageUrl: notion.updateJobPage,
+  buildCompanyPeopleSearchUrl,
+};
+
+// Pure. Partition loaded apps into the three backfill buckets. No I/O, no
+// network, no Date. Returns shallow references to the original app objects so
+// the caller can mutate the chosen candidates in place before saving.
+//
+//   candidates — eligible status, empty url, non-empty companyName.
+//   skipped    — eligible status, empty url, but empty companyName.
+//   alreadySet — eligible status, non-empty url (idempotency target).
+//
+// Rows in a non-eligible status are ignored entirely (not counted in any
+// bucket) — they are out of scope per BL-186.
+function selectBackfillCandidates(apps) {
+  const candidates = [];
+  const skipped = [];
+  const alreadySet = [];
+  for (const app of apps || []) {
+    if (!BACKFILL_STATUSES.has(app.status)) continue;
+    const hasUrl = Boolean(
+      app.company_people_search_url && String(app.company_people_search_url).trim()
+    );
+    if (hasUrl) {
+      alreadySet.push(app);
+      continue;
+    }
+    const hasCompany = Boolean(app.companyName && String(app.companyName).trim());
+    if (!hasCompany) {
+      skipped.push(app);
+      continue;
+    }
+    candidates.push(app);
+  }
+  return { candidates, skipped, alreadySet };
+}
+
+function makeBackfillOutreachUrlCommand(overrides = {}) {
+  const deps = { ...DEFAULT_DEPS, ...overrides };
+
+  return async function backfillOutreachUrlCommand(ctx) {
+    const { profileId, flags, env, stdout, stderr } = ctx;
+    const profilesDir = resolveProfilesDir(ctx, ctx.env || process.env);
+
+    const profile = deps.loadProfile(profileId, { profilesDir });
+    const applicationsPath = path.join(profile.paths.root, "applications.tsv");
+    const { apps } = deps.loadApplications(applicationsPath);
+
+    const { candidates, skipped, alreadySet } = selectBackfillCandidates(apps);
+
+    stdout(
+      `backfill plan: would enrich ${candidates.length}, ` +
+        `skip ${skipped.length} (no company), already set ${alreadySet.length}`
+    );
+
+    if (!flags.apply) {
+      stdout(`(dry-run — pass --apply to write TSV + Notion)`);
+      return 0;
+    }
+
+    if (candidates.length === 0) {
+      stdout(`nothing to backfill — no eligible rows with empty LinkedIn Search`);
+      return 0;
+    }
+
+    // Notion push requires a token + a configured property map that actually
+    // maps the URL field. Without the `companyPeopleSearchUrl` key the URL
+    // would only ever land in TSV and never in Notion — warn loudly but still
+    // write the TSV (the local ledger is canonical; Notion is a view).
+    const secrets = (deps.loadSecrets && deps.loadSecrets(profileId, env)) || {};
+    const token = secrets.NOTION_TOKEN || null;
+    const propertyMap =
+      (profile.notion && profile.notion.property_map) || notion.DEFAULT_PROPERTY_MAP;
+    const hasUrlMapping = Boolean(
+      propertyMap.companyPeopleSearchUrl && propertyMap.companyPeopleSearchUrl.field
+    );
+
+    let client = null;
+    const getClient = () => {
+      if (!client) client = deps.makeClient(token);
+      return client;
+    };
+
+    const canPushNotion = Boolean(token && hasUrlMapping);
+    if (!token) {
+      stderr(
+        `warn: missing ${secretEnvName(profileId, "NOTION_TOKEN")} in env — ` +
+          `writing TSV only, Notion LinkedIn Search not updated`
+      );
+    } else if (!hasUrlMapping) {
+      stderr(
+        `warn: profile.notion.property_map has no "companyPeopleSearchUrl" key — ` +
+          `writing TSV only, Notion LinkedIn Search not updated`
+      );
+    }
+
+    let enriched = 0;
+    let notionPushed = 0;
+    let notionErrors = 0;
+
+    for (const app of candidates) {
+      const url = deps.buildCompanyPeopleSearchUrl({
+        company: app.companyName,
+        roleTitle: app.title,
+        location: (app.locations && app.locations[0]) || undefined,
+      });
+      // TSV mutation in memory — saved once after the loop through the single
+      // TSV writer module. We do NOT bump updatedAt: this is a backfill of a
+      // derived field, not a state change, and bumping the timestamp would make
+      // every old row look freshly touched.
+      app.company_people_search_url = url;
+      enriched += 1;
+
+      if (canPushNotion && app.notion_page_id) {
+        try {
+          await deps.updatePageUrl(
+            getClient(),
+            app.notion_page_id,
+            { companyPeopleSearchUrl: url },
+            propertyMap
+          );
+          notionPushed += 1;
+        } catch (err) {
+          notionErrors += 1;
+          stderr(`  notion error for ${app.key} (${app.notion_page_id}): ${err.message}`);
+        }
+      }
+    }
+
+    deps.saveApplications(applicationsPath, apps);
+
+    const notionNote = canPushNotion
+      ? `${notionPushed} Notion page(s) updated` +
+        (notionErrors ? `, ${notionErrors} Notion error(s)` : "")
+      : `Notion push skipped`;
+    stdout(`applied: enriched ${enriched} TSV row(s), ${notionNote}`);
+
+    return notionErrors > 0 ? 1 : 0;
+  };
+}
+
+module.exports = makeBackfillOutreachUrlCommand();
+module.exports.makeBackfillOutreachUrlCommand = makeBackfillOutreachUrlCommand;
+module.exports.selectBackfillCandidates = selectBackfillCandidates;
+module.exports.BACKFILL_STATUSES = BACKFILL_STATUSES;

--- a/engine/commands/backfill_outreach_url.test.js
+++ b/engine/commands/backfill_outreach_url.test.js
@@ -1,0 +1,319 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  makeBackfillOutreachUrlCommand,
+  selectBackfillCandidates,
+  BACKFILL_STATUSES,
+} = require("./backfill_outreach_url.js");
+
+function captureOut() {
+  const stdout = [];
+  const stderr = [];
+  return {
+    stdout: (s) => stdout.push(s),
+    stderr: (s) => stderr.push(s),
+    lines: stdout,
+    errLines: stderr,
+    all: () => stdout.concat(stderr).join("\n"),
+  };
+}
+
+function fakeApp(overrides = {}) {
+  return {
+    key: "greenhouse:1",
+    source: "greenhouse",
+    jobId: "1",
+    companyName: "Affirm",
+    title: "PM",
+    url: "https://x/1",
+    locations: ["Remote, US"],
+    status: "To Apply",
+    notion_page_id: "page-1",
+    company_people_search_url: "",
+    ...overrides,
+  };
+}
+
+const URL_PROPERTY_MAP = {
+  companyPeopleSearchUrl: { field: "LinkedIn Search", type: "url" },
+};
+
+function makeDeps(overrides = {}) {
+  const calls = { saveApplications: [], updatePageUrl: [] };
+  const deps = {
+    loadProfile: () => ({
+      id: "jared",
+      paths: { root: "/tmp/profiles/jared" },
+      notion: { jobs_pipeline_db_id: "db-123", property_map: URL_PROPERTY_MAP },
+    }),
+    loadSecrets: () => ({ NOTION_TOKEN: "tok" }),
+    loadApplications: () => ({
+      apps: [fakeApp({ jobId: "1", notion_page_id: "page-1" })],
+    }),
+    saveApplications: (file, apps) => {
+      calls.saveApplications.push({ file, apps });
+    },
+    makeClient: () => ({}),
+    updatePageUrl: async (client, pageId, updates, propertyMap) => {
+      calls.updatePageUrl.push({ pageId, updates, propertyMap });
+      return { id: pageId };
+    },
+    ...overrides,
+  };
+  return { deps, calls };
+}
+
+function makeCtx(overrides = {}) {
+  const out = captureOut();
+  return {
+    out,
+    ctx: {
+      command: "backfill-outreach-url",
+      profileId: "jared",
+      flags: { dryRun: false, apply: false, verbose: false },
+      env: { JARED_NOTION_TOKEN: "tok" },
+      stdout: out.stdout,
+      stderr: out.stderr,
+      profilesDir: "/tmp/profiles",
+      ...overrides,
+    },
+  };
+}
+
+// ---------- selectBackfillCandidates (pure) ----------
+
+test("selectBackfillCandidates: picks To Apply / Applied with empty url + company", () => {
+  const apps = [
+    fakeApp({ key: "a", status: "To Apply", company_people_search_url: "" }),
+    fakeApp({ key: "b", status: "Applied", company_people_search_url: "" }),
+  ];
+  const { candidates, skipped, alreadySet } = selectBackfillCandidates(apps);
+  assert.deepEqual(
+    candidates.map((c) => c.key),
+    ["a", "b"]
+  );
+  assert.equal(skipped.length, 0);
+  assert.equal(alreadySet.length, 0);
+});
+
+test("selectBackfillCandidates: empty company → skipped, not enriched", () => {
+  const apps = [
+    fakeApp({ key: "a", status: "To Apply", companyName: "", company_people_search_url: "" }),
+    fakeApp({ key: "b", status: "Applied", companyName: "   ", company_people_search_url: "" }),
+  ];
+  const { candidates, skipped } = selectBackfillCandidates(apps);
+  assert.equal(candidates.length, 0);
+  assert.deepEqual(
+    skipped.map((s) => s.key),
+    ["a", "b"]
+  );
+});
+
+test("selectBackfillCandidates: non-empty url → alreadySet (idempotency)", () => {
+  const apps = [
+    fakeApp({
+      key: "a",
+      status: "To Apply",
+      company_people_search_url: "https://www.linkedin.com/search/results/people/?keywords=Affirm",
+    }),
+  ];
+  const { candidates, alreadySet } = selectBackfillCandidates(apps);
+  assert.equal(candidates.length, 0);
+  assert.deepEqual(
+    alreadySet.map((a) => a.key),
+    ["a"]
+  );
+});
+
+test("selectBackfillCandidates: ignores out-of-scope statuses entirely", () => {
+  const apps = [
+    fakeApp({ key: "inbox", status: "Inbox", company_people_search_url: "" }),
+    fakeApp({ key: "rej", status: "Rejected", company_people_search_url: "" }),
+    fakeApp({ key: "arch", status: "Archived", company_people_search_url: "" }),
+    fakeApp({ key: "intv", status: "Interview", company_people_search_url: "" }),
+    fakeApp({ key: "keep", status: "To Apply", company_people_search_url: "" }),
+  ];
+  const { candidates, skipped, alreadySet } = selectBackfillCandidates(apps);
+  assert.deepEqual(
+    candidates.map((c) => c.key),
+    ["keep"]
+  );
+  assert.equal(skipped.length, 0);
+  assert.equal(alreadySet.length, 0);
+});
+
+test("BACKFILL_STATUSES is exactly To Apply + Applied", () => {
+  assert.deepEqual([...BACKFILL_STATUSES].sort(), ["Applied", "To Apply"]);
+});
+
+// ---------- command: dry-run ----------
+
+test("dry-run defaults: prints counts, writes nothing, no Notion calls", async () => {
+  const { deps, calls } = makeDeps({
+    loadApplications: () => ({
+      apps: [
+        fakeApp({ key: "a", status: "To Apply", company_people_search_url: "" }),
+        fakeApp({ key: "b", status: "Applied", companyName: "", company_people_search_url: "" }),
+        fakeApp({
+          key: "c",
+          status: "Applied",
+          company_people_search_url: "https://www.linkedin.com/x",
+        }),
+      ],
+    }),
+  });
+  const { ctx, out } = makeCtx();
+  const code = await makeBackfillOutreachUrlCommand(deps)(ctx);
+  assert.equal(code, 0);
+  assert.equal(calls.saveApplications.length, 0);
+  assert.equal(calls.updatePageUrl.length, 0);
+  assert.match(out.all(), /would enrich 1, skip 1 \(no company\), already set 1/);
+  assert.match(out.all(), /\(dry-run/);
+});
+
+// ---------- command: --apply writes TSV + Notion (mocked) ----------
+
+test("--apply writes URL to TSV and pushes to Notion via targeted update", async () => {
+  const { deps, calls } = makeDeps();
+  const { ctx } = makeCtx({ flags: { dryRun: false, apply: true, verbose: false } });
+  const code = await makeBackfillOutreachUrlCommand(deps)(ctx);
+  assert.equal(code, 0);
+
+  // TSV saved once with the URL filled in.
+  assert.equal(calls.saveApplications.length, 1);
+  const saved = calls.saveApplications[0].apps;
+  assert.equal(saved.length, 1);
+  assert.match(saved[0].company_people_search_url, /linkedin\.com\/search\/results\/people/);
+  assert.match(saved[0].company_people_search_url, /Affirm/);
+
+  // Notion targeted update called once with the URL field only.
+  assert.equal(calls.updatePageUrl.length, 1);
+  assert.equal(calls.updatePageUrl[0].pageId, "page-1");
+  assert.match(
+    calls.updatePageUrl[0].updates.companyPeopleSearchUrl,
+    /linkedin\.com\/search\/results\/people/
+  );
+});
+
+test("--apply does not bump updatedAt (derived-field backfill, not a state change)", async () => {
+  const { deps, calls } = makeDeps({
+    loadApplications: () => ({
+      apps: [fakeApp({ key: "a", updatedAt: "2026-01-01T00:00:00Z" })],
+    }),
+  });
+  const { ctx } = makeCtx({ flags: { dryRun: false, apply: true, verbose: false } });
+  await makeBackfillOutreachUrlCommand(deps)(ctx);
+  assert.equal(calls.saveApplications[0].apps[0].updatedAt, "2026-01-01T00:00:00Z");
+});
+
+// ---------- idempotency: second run is a no-op ----------
+
+test("idempotent: second --apply run enriches nothing and skips Notion", async () => {
+  // Simulate a TSV where the row already has a URL (i.e. the state after a
+  // first run). The command should treat it as alreadySet and do no writes.
+  const { deps, calls } = makeDeps({
+    loadApplications: () => ({
+      apps: [
+        fakeApp({
+          key: "a",
+          status: "To Apply",
+          company_people_search_url:
+            "https://www.linkedin.com/search/results/people/?keywords=Affirm",
+        }),
+      ],
+    }),
+  });
+  const { ctx, out } = makeCtx({ flags: { dryRun: false, apply: true, verbose: false } });
+  const code = await makeBackfillOutreachUrlCommand(deps)(ctx);
+  assert.equal(code, 0);
+  assert.equal(calls.saveApplications.length, 0);
+  assert.equal(calls.updatePageUrl.length, 0);
+  assert.match(out.all(), /already set 1/);
+  assert.match(out.all(), /nothing to backfill/);
+});
+
+// ---------- skip on empty company under --apply ----------
+
+test("--apply skips empty-company rows (no URL computed, no write)", async () => {
+  const { deps, calls } = makeDeps({
+    loadApplications: () => ({
+      apps: [fakeApp({ key: "a", companyName: "", company_people_search_url: "" })],
+    }),
+  });
+  const { ctx, out } = makeCtx({ flags: { dryRun: false, apply: true, verbose: false } });
+  const code = await makeBackfillOutreachUrlCommand(deps)(ctx);
+  assert.equal(code, 0);
+  // No candidates → no save, no Notion call.
+  assert.equal(calls.saveApplications.length, 0);
+  assert.equal(calls.updatePageUrl.length, 0);
+  assert.match(out.all(), /skip 1 \(no company\)/);
+});
+
+// ---------- Notion-skip paths ----------
+
+test("--apply writes TSV but skips Notion when token missing", async () => {
+  const { deps, calls } = makeDeps({ loadSecrets: () => ({}) });
+  const { ctx, out } = makeCtx({ flags: { dryRun: false, apply: true, verbose: false } });
+  const code = await makeBackfillOutreachUrlCommand(deps)(ctx);
+  assert.equal(code, 0);
+  assert.equal(calls.saveApplications.length, 1);
+  assert.equal(calls.updatePageUrl.length, 0);
+  assert.match(out.all(), /NOTION_TOKEN/);
+  assert.match(out.all(), /Notion push skipped/);
+});
+
+test("--apply writes TSV but skips Notion when property_map lacks the URL key", async () => {
+  const { deps, calls } = makeDeps({
+    loadProfile: () => ({
+      id: "jared",
+      paths: { root: "/tmp/profiles/jared" },
+      notion: { jobs_pipeline_db_id: "db-123", property_map: {} },
+    }),
+  });
+  const { ctx, out } = makeCtx({ flags: { dryRun: false, apply: true, verbose: false } });
+  const code = await makeBackfillOutreachUrlCommand(deps)(ctx);
+  assert.equal(code, 0);
+  assert.equal(calls.saveApplications.length, 1);
+  assert.equal(calls.updatePageUrl.length, 0);
+  assert.match(out.all(), /companyPeopleSearchUrl/);
+});
+
+test("--apply: Notion error on one row is counted and yields exit code 1, TSV still saved", async () => {
+  const { deps, calls } = makeDeps({
+    loadApplications: () => ({
+      apps: [
+        fakeApp({ key: "a", notion_page_id: "page-a" }),
+        fakeApp({ key: "b", notion_page_id: "page-b" }),
+      ],
+    }),
+    updatePageUrl: async (client, pageId) => {
+      if (pageId === "page-b") throw new Error("rate limited");
+      return { id: pageId };
+    },
+  });
+  const { ctx, out } = makeCtx({ flags: { dryRun: false, apply: true, verbose: false } });
+  const code = await makeBackfillOutreachUrlCommand(deps)(ctx);
+  assert.equal(code, 1);
+  // TSV still saved with both URLs (TSV is canonical; Notion is a view).
+  assert.equal(calls.saveApplications.length, 1);
+  assert.equal(calls.saveApplications[0].apps.length, 2);
+  assert.ok(calls.saveApplications[0].apps.every((a) => a.company_people_search_url));
+  assert.match(out.all(), /1 Notion error/);
+});
+
+test("--apply skips Notion push for candidate rows without a notion_page_id", async () => {
+  const { deps, calls } = makeDeps({
+    loadApplications: () => ({
+      apps: [fakeApp({ key: "a", notion_page_id: "" })],
+    }),
+  });
+  const { ctx } = makeCtx({ flags: { dryRun: false, apply: true, verbose: false } });
+  const code = await makeBackfillOutreachUrlCommand(deps)(ctx);
+  assert.equal(code, 0);
+  // URL still written to TSV.
+  assert.equal(calls.saveApplications.length, 1);
+  assert.ok(calls.saveApplications[0].apps[0].company_people_search_url);
+  // No Notion call — no page to target.
+  assert.equal(calls.updatePageUrl.length, 0);
+});

--- a/rfc/059-hm-outreach.md
+++ b/rfc/059-hm-outreach.md
@@ -482,3 +482,62 @@ in the BL-62 Notion project and are authored by hand, tracked there.
    card shows the URL, the rollup, and the editable status.
 4. **Templates (F).** Author the three notes + DM in the BL-62 Notion
    project and run the first weekly worklist against the to-do view.
+
+## Amendment — BL-186 backfill (2026-06-03)
+
+**Problem.** Phase 2 (§C) populates `company_people_search_url` only on
+`prepare --phase commit`, i.e. only for vacancies committed *after* the
+feature shipped. Every vacancy that reached `To Apply` / `Applied`
+*before* phase 2 has an empty `company_people_search_url` in TSV and an
+empty `LinkedIn Search` field in Notion. Those are exactly the rows the
+operator wants to run outreach on, and there are hundreds of them.
+
+**Solution.** A one-shot CLI command `backfill-outreach-url` (BL-186,
+tier M):
+
+- Selects rows whose `status ∈ {"To Apply", "Applied"}` **and**
+  `company_people_search_url` is empty **and** `companyName` is non-empty.
+  Empty-company rows are reported as *skipped* (no company to search on),
+  not processed. Rows already carrying a URL are *already set* and left
+  untouched — so a second run is a strict no-op (idempotent).
+- Default **dry-run**: prints `would enrich N, skip M (no company),
+  already set K` and writes nothing.
+- With `--apply`: computes the URL via the existing pure helper
+  `buildCompanyPeopleSearchUrl({company, roleTitle, location})` (reused,
+  not reimplemented — same code path that phase 2 uses on commit), writes
+  it to the TSV through `applications_tsv.js` (the single TSV writer), and
+  pushes it to the Notion `LinkedIn Search` field.
+
+**Notion write — same class as the commit-phase write, NOT a new push
+path.** The Notion update is a *targeted single-field* `pages.update`
+(`updateJobPage` with `{ companyPeopleSearchUrl }` only), structurally
+identical to `check`'s `updatePageStatus`. `company_people_search_url`
+is **engine-authored, one-way** data: the engine is the sole writer of
+this field, it is never read back from Notion (`sync`'s `reconcilePull`
+pulls `hm_outreach_status` only, never the URL — see workstream E). The
+backfill therefore writes exactly the same field, in the same direction,
+that phase 2 already writes on commit. It is the missing first write for
+old rows, not a second source of truth.
+
+**Pull-only invariant is preserved.** "Pull-only" (since 2026-05-04,
+commit `4f85ed2`) means `sync` never *creates or mutates operator-owned
+Notion state from local TSV*. This backfill does neither: it creates no
+pages (those are still created exclusively by `prepare --phase commit`),
+and it touches no operator-owned field (status, `Outreach` status,
+contact fields). It writes only the engine-owned `LinkedIn Search` URL —
+the same engine-authored class as the commit-phase write and the
+`check` status write, both of which already coexist with the pull-only
+`sync`. No push phase, no `push_manifest.json`, no Inbox callout writer
+is reintroduced.
+
+**Guards.** Missing `NOTION_TOKEN` or a `property_map` without the
+`companyPeopleSearchUrl` key → the URL is still written to TSV (the
+canonical ledger) and the Notion push is skipped with a warning. A
+per-row Notion error is counted and surfaced (non-zero exit) but never
+blocks the TSV write or the remaining rows. `updatedAt` is **not** bumped
+— this is a backfill of a derived field, not a state change, so old rows
+do not all appear freshly touched.
+
+**Out of scope (unchanged from BL-186).** Outreach status logic, the
+auto-Dead timer, per-person contact fields, and any status other than
+`To Apply` / `Applied`.


### PR DESCRIPTION
## What

Adds a one-shot `backfill-outreach-url` CLI command (BL-186, tier M) that fills the LinkedIn people-search URL for **existing** `To Apply` / `Applied` vacancies that predate the RFC-059 outreach feature. Those rows have an empty `company_people_search_url` in TSV and an empty `LinkedIn Search` field in Notion because RFC 059 phase 2 only populates the URL on `prepare --phase commit` (new rows only).

## How

- **Pure** `selectBackfillCandidates(apps)` → `{ candidates, skipped, alreadySet }`:
  - `candidates` — status ∈ {To Apply, Applied}, empty url, non-empty company.
  - `skipped` — eligible status, empty url, **empty company** (nothing to search on).
  - `alreadySet` — eligible status, non-empty url (idempotency target).
  - Non-eligible statuses (Inbox / Rejected / Archived / Interview / …) are ignored entirely.
- **Default dry-run**: prints `would enrich N, skip M (no company), already set K`, writes nothing.
- **`--apply`**: computes the URL with the existing pure `buildCompanyPeopleSearchUrl` helper (reused, not reimplemented), writes to TSV via `applications_tsv.js` (the single TSV writer), and pushes to the Notion `LinkedIn Search` field via a targeted single-field `pages.update` (`updateJobPage`) — the same engine-authored one-way write pattern as `check`'s `updatePageStatus`. `updatedAt` is not bumped (derived-field backfill, not a state change).
- **Idempotent**: a second run is a strict no-op.
- **Guards**: missing `NOTION_TOKEN` or a `property_map` without `companyPeopleSearchUrl` → TSV-only write + warning; a per-row Notion error is counted, never blocks the TSV write or remaining rows, and yields a non-zero exit.

## Pull-only

The Notion write is engine-authored one-way data (the same field `prepare` commit already writes). It creates no pages and touches no operator-owned field, so it does not re-introduce a push path. Documented in the new **"Amendment — BL-186 backfill"** section of `rfc/059-hm-outreach.md`.

## Tests / checks

- `engine/commands/backfill_outreach_url.test.js` — 14 cases (selection, dry-run, `--apply` TSV+Notion, idempotency, skip-on-empty-company, token/property_map skip paths, per-row Notion error, no-page rows). Network mocked.
- `cli.test.js` KNOWN_COMMANDS assertion updated.
- Full suite green (2021 pass). `prettier --check .` clean.

## Docs

- README command table + `docs/architecture/overview.md` — bullet for the new command.

## Out of scope (per BL-186)

Outreach status logic, auto-Dead timers, per-person contact fields, and any status other than `To Apply` / `Applied`.

## Not done in this PR (human-gated)

- Smoke on the `jared` profile (needs the operator's private profile + token).
- Merge — final approval is the user's; this PR is **not** to be merged by the agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)