### PR TITLE
feat(outreach): BL-187 / RFC 059 — auto-No-Response stale Applied vacancies

### DIFF
--- a/engine/cli.js
+++ b/engine/cli.js
@@ -347,9 +347,17 @@ async function runCli({ argv, env = process.env, stdout, stderr, commands } = {}
   // the pure helpers stay deterministic. No cron, no scheduler — lazy on CLI
   // invocation only.
   const { runAutoDeadSweep, todayLocalISO } = require("./core/auto_dead_sweep.js");
+  // Auto-No-Response lazy sweep (BL-187 / RFC 059 amendment): same lazy
+  // machinery as auto-Dead, but for the vacancy's main status. Rows that have
+  // been "Applied" for >= 14 days (anchored by `applied_date`) flip to
+  // "No Response". Independent of auto-Dead; runs second for determinism. Same
+  // injected "today", same never-throws / TSV-only-without-token contract.
+  const { runAutoNoResponseSweep } = require("./core/auto_no_response_sweep.js");
 
   try {
-    await runAutoDeadSweep(ctx.profileId, ctx, { todayStr: todayLocalISO() });
+    const todayStr = todayLocalISO();
+    await runAutoDeadSweep(ctx.profileId, ctx, { todayStr });
+    await runAutoNoResponseSweep(ctx.profileId, ctx, { todayStr });
     const preHook = PIPELINE_PRE_HOOKS[ctx.command];
     if (preHook) await preHook(ctx, handlers);
     const code = await handler(ctx);

--- a/engine/commands/sync.js
+++ b/engine/commands/sync.js
@@ -26,6 +26,7 @@ const { resolveProfilesDir } = require("../core/paths.js");
 const archiveSweep = require("../core/archive_used_artifacts.js");
 const { makeCompanyNameResolver } = require("../core/company_resolver.js");
 const { decideOutreachDate } = require("../core/auto_dead.js");
+const { decideAppliedDate } = require("../core/auto_no_response.js");
 
 // Canonical map lives in notion_sync.js — all Notion-touching commands
 // share it. Re-export here as a const so the rest of this file stays
@@ -119,6 +120,20 @@ function reconcilePull(apps, notionPages, propertyMap, now, companyNameById = {}
       next.status = page.status;
       changed = true;
     }
+    // RFC 059 amendment (BL-187 auto-No-Response): stamp the `applied_date`
+    // anchor when the resulting main status is "Applied" and the row has no
+    // anchor yet, so the lazy Applied → No Response sweep has a 14-day timer.
+    // An existing anchor is never overwritten; moving forward out of Applied
+    // (Interview / Offer / Rejected / No Response) leaves the anchor as-is —
+    // the sweep only inspects Applied rows. The "today" string is derived from
+    // the injected `now` (date portion of the ISO timestamp) so the decision
+    // stays pure / deterministic. TSV-internal anchor: NOT pushed to Notion.
+    const appliedToday = typeof now === "string" ? now.slice(0, 10) : "";
+    const appliedDecision = decideAppliedDate(next.status, next.applied_date || "", appliedToday);
+    if (appliedDecision.action !== "keep" && next.applied_date !== appliedDecision.date) {
+      next.applied_date = appliedDecision.date;
+      changed = true;
+    }
     // Backfill an empty companyName from Notion (self-heals the rows BL-154
     // added blank). Never overwrite a name the local row already has.
     if (!app.companyName) {
@@ -196,6 +211,12 @@ function reconcilePull(apps, notionPages, propertyMap, now, companyNameById = {}
       contact_linkedin: "",
       hm_outreach_status: page.hmOutreachStatus || "To do",
       hm_outreach_date: "",
+      // RFC 059 amendment (BL-187): stamp the `applied_date` anchor when the
+      // pulled page is already "Applied" (no prior local row → no anchor), so a
+      // freshly-pulled Applied row starts its 14-day No-Response timer here.
+      applied_date:
+        decideAppliedDate(page.status || "", "", typeof now === "string" ? now.slice(0, 10) : "")
+          .date || "",
     });
   }
 

--- a/engine/commands/sync.test.js
+++ b/engine/commands/sync.test.js
@@ -241,7 +241,15 @@ const NOW = "2026-04-20T00:00:00Z";
 test("reconcilePull matches by key and reports status changes", () => {
   const apps = [
     fakeApp({ key: "greenhouse:1", jobId: "1", status: "To Apply", notion_page_id: "" }),
-    fakeApp({ key: "greenhouse:2", jobId: "2", status: "Applied", notion_page_id: "p2" }),
+    // Pre-anchored so the BL-187 applied_date stamp doesn't add a spurious
+    // update for this otherwise-unchanged Applied row.
+    fakeApp({
+      key: "greenhouse:2",
+      jobId: "2",
+      status: "Applied",
+      notion_page_id: "p2",
+      applied_date: "2026-04-01",
+    }),
   ];
   const pages = [
     { notionPageId: "p1", key: "greenhouse:1", status: "Applied" },
@@ -251,6 +259,8 @@ test("reconcilePull matches by key and reports status changes", () => {
   assert.equal(updates.length, 1);
   assert.equal(updates[0].after.notion_page_id, "p1");
   assert.equal(updates[0].after.status, "Applied");
+  // To Apply → Applied with no prior anchor stamps the applied_date (BL-187).
+  assert.equal(updates[0].after.applied_date, "2026-04-20");
   assert.equal(adds.length, 0, "all pages matched existing rows → no adds");
 });
 
@@ -316,6 +326,8 @@ test("reconcilePull never clobbers a local outreach status with an empty Notion 
       status: "Applied",
       notion_page_id: "p1",
       hm_outreach_status: "Done",
+      // Pre-anchored so the BL-187 applied_date stamp doesn't create an update.
+      applied_date: "2026-04-01",
     }),
   ];
   // Notion page has no hmOutreachStatus (operator hasn't set Outreach yet).
@@ -380,6 +392,8 @@ test("reconcilePull does NOT re-stamp an existing anchor on a fresh sync while s
       notion_page_id: "p1",
       hm_outreach_status: "In flight",
       hm_outreach_date: "2026-04-01",
+      // Pre-anchored so the BL-187 applied_date stamp doesn't create an update.
+      applied_date: "2026-04-01",
     }),
   ];
   // Notion still reports In flight; the local anchor must survive untouched.
@@ -426,6 +440,82 @@ test("reconcilePull leaves the anchor as-is on terminal Replied", () => {
   assert.equal(updates.length, 1);
   assert.equal(updates[0].after.hm_outreach_status, "Replied");
   assert.equal(updates[0].after.hm_outreach_date, "2026-04-01", "terminal status keeps the date");
+});
+
+// ---------- RFC 059 amendment (BL-187 auto-No-Response): applied_date stamp ----------
+
+test("reconcilePull stamps applied_date today when status enters Applied (empty anchor)", () => {
+  const apps = [
+    fakeApp({
+      key: "greenhouse:1",
+      status: "To Apply",
+      notion_page_id: "p1",
+      applied_date: "",
+    }),
+  ];
+  const pages = [{ notionPageId: "p1", key: "greenhouse:1", status: "Applied" }];
+  const { updates } = reconcilePull(apps, pages, DEFAULT_PROPERTY_MAP, NOW);
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0].after.status, "Applied");
+  assert.equal(updates[0].after.applied_date, "2026-04-20", "stamped from NOW date portion");
+});
+
+test("reconcilePull does NOT overwrite an existing applied_date anchor while still Applied", () => {
+  const apps = [
+    fakeApp({
+      key: "greenhouse:1",
+      status: "Applied",
+      notion_page_id: "p1",
+      applied_date: "2026-04-01",
+    }),
+  ];
+  // Notion still reports Applied; the existing anchor must survive untouched.
+  const pages = [{ notionPageId: "p1", key: "greenhouse:1", status: "Applied" }];
+  const { updates } = reconcilePull(apps, pages, DEFAULT_PROPERTY_MAP, NOW);
+  assert.equal(updates.length, 0, "no status drift, anchor kept → no update");
+});
+
+test("reconcilePull leaves applied_date as-is when status moves forward out of Applied", () => {
+  const apps = [
+    fakeApp({
+      key: "greenhouse:1",
+      status: "Applied",
+      notion_page_id: "p1",
+      applied_date: "2026-04-01",
+    }),
+  ];
+  const pages = [{ notionPageId: "p1", key: "greenhouse:1", status: "Interview" }];
+  const { updates } = reconcilePull(apps, pages, DEFAULT_PROPERTY_MAP, NOW);
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0].after.status, "Interview");
+  assert.equal(updates[0].after.applied_date, "2026-04-01", "anchor untouched on forward move");
+});
+
+test("reconcilePull does NOT stamp applied_date for a non-Applied status (e.g. Interview)", () => {
+  const apps = [
+    fakeApp({
+      key: "greenhouse:1",
+      status: "To Apply",
+      notion_page_id: "p1",
+      applied_date: "",
+    }),
+  ];
+  const pages = [{ notionPageId: "p1", key: "greenhouse:1", status: "Interview" }];
+  const { updates } = reconcilePull(apps, pages, DEFAULT_PROPERTY_MAP, NOW);
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0].after.status, "Interview");
+  assert.equal(updates[0].after.applied_date, "", "non-Applied status never stamps the anchor");
+});
+
+test("reconcilePull add-path stamps applied_date for a pulled Applied page, empty otherwise", () => {
+  const pages = [
+    { notionPageId: "p2", key: "lever:abc", source: "lever", jobId: "abc", status: "Applied" },
+    { notionPageId: "p3", key: "lever:def", source: "lever", jobId: "def", status: "Interview" },
+  ];
+  const { adds } = reconcilePull([], pages, DEFAULT_PROPERTY_MAP, NOW);
+  const byKey = Object.fromEntries(adds.map((a) => [a.key, a]));
+  assert.equal(byKey["lever:abc"].applied_date, "2026-04-20", "Applied add stamped today");
+  assert.equal(byKey["lever:def"].applied_date, "", "non-Applied add has no anchor");
 });
 
 test("reconcilePull defaults source to 'notion' when the page has none", () => {
@@ -745,6 +835,9 @@ test("reconcilePull never overwrites a populated companyName", () => {
       jobId: "pix",
       companyName: "dLocal Inc",
       status: "Applied",
+      // Pre-seed the applied_date anchor so the BL-187 stamp doesn't fire and
+      // create an unrelated update — this test isolates companyName handling.
+      applied_date: "2026-04-01",
     }),
   ];
   const pages = [
@@ -757,7 +850,7 @@ test("reconcilePull never overwrites a populated companyName", () => {
       status: "Applied",
     },
   ];
-  // Same status + page id → no change; companyName must stay as the local value.
+  // Same status + page id + anchored → no change; companyName must stay local.
   const withPage = pages.map((p) => ({ ...p, notionPageId: "", status: "Applied" }));
   const { updates } = reconcilePull(apps, withPage, DEFAULT_PROPERTY_MAP, NOW, {
     "co-1": "OtherName",

--- a/engine/core/applications_tsv.js
+++ b/engine/core/applications_tsv.js
@@ -1,8 +1,8 @@
 // Per-profile pipeline file: profiles/<id>/applications.tsv.
 //
-// Schema (header required), v6 (added 2026-06-03 for BL-169 / RFC 059 — append
-// six hiring-manager / warm-contact outreach columns). The v6 columns extend v5
-// with the outreach motion tracked on the vacancy card:
+// Schema (header required), v7 (added 2026-06-03 for BL-187 / RFC 059 amendment
+// — append the `applied_date` anchor column for the auto-No-Response sweep). The
+// v7 column extends v6 with the moment a vacancy entered `status="Applied"`:
 //   key <TAB> source <TAB> jobId <TAB> companyName <TAB> title <TAB> url
 //             <TAB> locations <TAB> status <TAB> notion_page_id
 //             <TAB> resume_ver <TAB> cl_key
@@ -13,6 +13,21 @@
 //             <TAB> company_people_search_url <TAB> outreach_type
 //             <TAB> contact_name <TAB> contact_linkedin
 //             <TAB> hm_outreach_status <TAB> hm_outreach_date
+//             <TAB> applied_date
+//
+// v7 column (RFC 059 amendment, BL-187):
+//   `applied_date` — ISO date (`YYYY-MM-DD`) the row entered `status="Applied"`.
+//                    TSV-internal anchor; NOT a Notion field, NOT in
+//                    property_map. Stamped by `sync`'s `reconcilePull` on the
+//                    To Apply → Applied transition (the moment Notion reports
+//                    "Applied" with no anchor yet). Drives the lazy
+//                    Applied → No Response sweep: a row that has carried this
+//                    anchor for >= 14 days flips to "No Response". Empty when
+//                    the row has never reached Applied. Defaults to "".
+//
+// v6 (added 2026-06-03 for BL-169 / RFC 059 — append six hiring-manager /
+// warm-contact outreach columns). The v6 columns extend v5 with the outreach
+// motion tracked on the vacancy card.
 //
 // v6 outreach columns (RFC 059):
 //   `company_people_search_url` — LinkedIn people-search URL, engine-authored by
@@ -76,18 +91,22 @@
 // from v3/v4 is gone — every caller now reads the array).
 //
 // Backward compat (auto-upgrade-on-save):
+//   v6 (26 cols, 2026-06-03 — RFC 059 outreach columns) → reader seeds the v7
+//     `applied_date` default (empty).
 //   v5 (20 cols, 2026-05-18 — RFC 038 locations[]) → reader seeds the six v6
-//     outreach defaults (empty + hm_outreach_status="To do").
+//     outreach defaults (empty + hm_outreach_status="To do") + the v7
+//     `applied_date` default (empty).
 //   v4 (20 cols, 2026-05-05 — BL-9 fit columns, single-string `location`) →
 //     reader wraps non-empty `location` to `[location]`, empty to `[]`, and
-//     seeds the v6 outreach defaults.
+//     seeds the v6 outreach defaults + the v7 `applied_date` default.
 //   v3 (16 cols, 2026-05-03 — G-5 added location) → same wrap; empty fit cols;
-//     v6 outreach defaults.
+//     v6 outreach defaults + v7 `applied_date` default.
 //   v2 (15 cols, 2026-04 — Stage 13 added salary_min/max/cl_path) → empty
-//     locations array + empty fit cols + v6 outreach defaults.
+//     locations array + empty fit cols + v6 outreach defaults + v7
+//     `applied_date` default.
 //   v1 (12 cols, original) → empty locations + empty v2+v3+v4 fields + v6
-//     outreach defaults.
-// save() always writes v6.
+//     outreach defaults + v7 `applied_date` default.
+// save() always writes v7.
 
 const fs = require("fs");
 const path = require("path");
@@ -108,6 +127,36 @@ function stripAtsPrefixes(id) {
     prev = m[2];
   }
 }
+
+const HEADER_V7 = [
+  "key",
+  "source",
+  "jobId",
+  "companyName",
+  "title",
+  "url",
+  "locations",
+  "status",
+  "notion_page_id",
+  "resume_ver",
+  "cl_key",
+  "salary_min",
+  "salary_max",
+  "cl_path",
+  "createdAt",
+  "updatedAt",
+  "fit_score",
+  "fit_rationale",
+  "fit_evaluated_at",
+  "skip_reason",
+  "company_people_search_url",
+  "outreach_type",
+  "contact_name",
+  "contact_linkedin",
+  "hm_outreach_status",
+  "hm_outreach_date",
+  "applied_date",
+];
 
 const HEADER_V6 = [
   "key",
@@ -163,7 +212,7 @@ const HEADER_V5 = [
 
 // Current schema header. Aliased so legacy callers reading `HEADER` keep
 // working; readers expect this constant to track the latest version.
-const HEADER = HEADER_V6;
+const HEADER = HEADER_V7;
 
 // RFC 059: default values for the six v6 outreach fields. Older rowToApp*
 // paths seed these so an old file loads cleanly; the next save() rewrites it
@@ -181,6 +230,13 @@ function outreachDefaults() {
     hm_outreach_status: "To do",
     hm_outreach_date: "",
   };
+}
+
+// RFC 059 amendment (BL-187): default value for the v7 `applied_date` anchor.
+// Older rowToApp* paths (v6 and below) seed this so an old file loads cleanly;
+// the next save() rewrites it as v7. Empty until the row enters Applied.
+function appliedDateDefaults() {
+  return { applied_date: "" };
 }
 
 const HEADER_V4 = [
@@ -332,7 +388,74 @@ function rowFor(app) {
     escapeField(app.contact_linkedin || ""),
     escapeField(app.hm_outreach_status || ""),
     escapeField(app.hm_outreach_date || ""),
+    escapeField(app.applied_date || ""),
   ].join("\t");
+}
+
+function rowToAppV7(parts, lineNo) {
+  if (parts.length < HEADER_V7.length) {
+    throw new Error(
+      `applications.tsv line ${lineNo}: expected ${HEADER_V7.length} cols, got ${parts.length}`
+    );
+  }
+  const [
+    key,
+    source,
+    jobId,
+    companyName,
+    title,
+    url,
+    locationsCell,
+    status,
+    notion_page_id,
+    resume_ver,
+    cl_key,
+    salary_min,
+    salary_max,
+    cl_path,
+    createdAt,
+    updatedAt,
+    fit_score,
+    fit_rationale,
+    fit_evaluated_at,
+    skip_reason,
+    company_people_search_url,
+    outreach_type,
+    contact_name,
+    contact_linkedin,
+    hm_outreach_status,
+    hm_outreach_date,
+    applied_date,
+  ] = parts;
+  return {
+    key,
+    source,
+    jobId,
+    companyName,
+    title,
+    url,
+    locations: decodeLocations(locationsCell),
+    status,
+    notion_page_id: notion_page_id || "",
+    resume_ver: resume_ver || "",
+    cl_key: cl_key || "",
+    salary_min: salary_min || "",
+    salary_max: salary_max || "",
+    cl_path: cl_path || "",
+    createdAt,
+    updatedAt,
+    fit_score: fit_score || "",
+    fit_rationale: fit_rationale || "",
+    fit_evaluated_at: fit_evaluated_at || "",
+    skip_reason: skip_reason || "",
+    company_people_search_url: company_people_search_url || "",
+    outreach_type: outreach_type || "",
+    contact_name: contact_name || "",
+    contact_linkedin: contact_linkedin || "",
+    hm_outreach_status: hm_outreach_status || "",
+    hm_outreach_date: hm_outreach_date || "",
+    applied_date: applied_date || "",
+  };
 }
 
 function rowToAppV6(parts, lineNo) {
@@ -396,6 +519,7 @@ function rowToAppV6(parts, lineNo) {
     contact_linkedin: contact_linkedin || "",
     hm_outreach_status: hm_outreach_status || "",
     hm_outreach_date: hm_outreach_date || "",
+    ...appliedDateDefaults(),
   };
 }
 
@@ -449,6 +573,7 @@ function rowToAppV5(parts, lineNo) {
     fit_evaluated_at: fit_evaluated_at || "",
     skip_reason: skip_reason || "",
     ...outreachDefaults(),
+    ...appliedDateDefaults(),
   };
 }
 
@@ -502,6 +627,7 @@ function rowToAppV4(parts, lineNo) {
     fit_evaluated_at: fit_evaluated_at || "",
     skip_reason: skip_reason || "",
     ...outreachDefaults(),
+    ...appliedDateDefaults(),
   };
 }
 
@@ -551,6 +677,7 @@ function rowToAppV3(parts, lineNo) {
     fit_evaluated_at: "",
     skip_reason: "",
     ...outreachDefaults(),
+    ...appliedDateDefaults(),
   };
 }
 
@@ -599,6 +726,7 @@ function rowToAppV2(parts, lineNo) {
     fit_evaluated_at: "",
     skip_reason: "",
     ...outreachDefaults(),
+    ...appliedDateDefaults(),
   };
 }
 
@@ -644,6 +772,7 @@ function rowToAppV1(parts, lineNo) {
     fit_evaluated_at: "",
     skip_reason: "",
     ...outreachDefaults(),
+    ...appliedDateDefaults(),
   };
 }
 
@@ -658,37 +787,40 @@ function load(filePath) {
   if (!lines.length) return { apps: [], path: filePath };
   const headerCols = lines[0].split("\t");
 
-  const isV6 = matchHeader(headerCols, HEADER_V6);
-  const isV5 = !isV6 && matchHeader(headerCols, HEADER_V5);
-  const isV4 = !isV6 && !isV5 && matchHeader(headerCols, HEADER_V4);
-  const isV3 = !isV6 && !isV5 && !isV4 && matchHeader(headerCols, HEADER_V3);
-  const isV2 = !isV6 && !isV5 && !isV4 && !isV3 && matchHeader(headerCols, HEADER_V2);
-  const isV1 = !isV6 && !isV5 && !isV4 && !isV3 && !isV2 && matchHeader(headerCols, HEADER_V1);
+  const isV7 = matchHeader(headerCols, HEADER_V7);
+  const isV6 = !isV7 && matchHeader(headerCols, HEADER_V6);
+  const isV5 = !isV7 && !isV6 && matchHeader(headerCols, HEADER_V5);
+  const isV4 = !isV7 && !isV6 && !isV5 && matchHeader(headerCols, HEADER_V4);
+  const isV3 = !isV7 && !isV6 && !isV5 && !isV4 && matchHeader(headerCols, HEADER_V3);
+  const isV2 = !isV7 && !isV6 && !isV5 && !isV4 && !isV3 && matchHeader(headerCols, HEADER_V2);
+  const isV1 =
+    !isV7 && !isV6 && !isV5 && !isV4 && !isV3 && !isV2 && matchHeader(headerCols, HEADER_V1);
 
-  if (!isV6 && !isV5 && !isV4 && !isV3 && !isV2 && !isV1) {
+  if (!isV7 && !isV6 && !isV5 && !isV4 && !isV3 && !isV2 && !isV1) {
     throw new Error(
-      `applications.tsv header mismatch: expected v6 [${HEADER_V6.join(", ")}], v5 [${HEADER_V5.join(", ")}], v4 [${HEADER_V4.join(", ")}], v3 [${HEADER_V3.join(", ")}], v2 [${HEADER_V2.join(", ")}] or v1 [${HEADER_V1.join(", ")}], got [${headerCols.join(", ")}]`
+      `applications.tsv header mismatch: expected v7 [${HEADER_V7.join(", ")}], v6 [${HEADER_V6.join(", ")}], v5 [${HEADER_V5.join(", ")}], v4 [${HEADER_V4.join(", ")}], v3 [${HEADER_V3.join(", ")}], v2 [${HEADER_V2.join(", ")}] or v1 [${HEADER_V1.join(", ")}], got [${headerCols.join(", ")}]`
     );
   }
 
   const apps = [];
   for (let i = 1; i < lines.length; i += 1) {
     const parts = lines[i].split("\t");
-    if (isV6) apps.push(rowToAppV6(parts, i + 1));
+    if (isV7) apps.push(rowToAppV7(parts, i + 1));
+    else if (isV6) apps.push(rowToAppV6(parts, i + 1));
     else if (isV5) apps.push(rowToAppV5(parts, i + 1));
     else if (isV4) apps.push(rowToAppV4(parts, i + 1));
     else if (isV3) apps.push(rowToAppV3(parts, i + 1));
     else if (isV2) apps.push(rowToAppV2(parts, i + 1));
     else apps.push(rowToAppV1(parts, i + 1));
   }
-  const schemaVersion = isV6 ? 6 : isV5 ? 5 : isV4 ? 4 : isV3 ? 3 : isV2 ? 2 : 1;
+  const schemaVersion = isV7 ? 7 : isV6 ? 6 : isV5 ? 5 : isV4 ? 4 : isV3 ? 3 : isV2 ? 2 : 1;
   return { apps, path: filePath, schemaVersion };
 }
 
 function save(filePath, apps) {
   const dir = path.dirname(filePath);
   fs.mkdirSync(dir, { recursive: true });
-  const lines = [HEADER_V6.join("\t")];
+  const lines = [HEADER_V7.join("\t")];
   for (const a of apps) lines.push(rowFor(a));
   const tmp = `${filePath}.tmp.${process.pid}.${Date.now()}`;
   fs.writeFileSync(tmp, lines.join("\n") + "\n");
@@ -750,6 +882,7 @@ function appendNew(
       fit_evaluated_at: "",
       skip_reason: "",
       ...outreachDefaults(),
+      ...appliedDateDefaults(),
     });
   }
   return { apps: existing.concat(fresh), fresh, fuzzyDuplicates };
@@ -769,4 +902,5 @@ module.exports = {
   HEADER_V4,
   HEADER_V5,
   HEADER_V6,
+  HEADER_V7,
 };

--- a/engine/core/applications_tsv.test.js
+++ b/engine/core/applications_tsv.test.js
@@ -101,7 +101,7 @@ test("save + load round-trips v3 fields (salary_min, salary_max, cl_path) + v5 l
   built[0].locations = ["San Francisco, CA"];
   apps.save(file, built);
   const back = apps.load(file);
-  assert.equal(back.schemaVersion, 6);
+  assert.equal(back.schemaVersion, 7);
   assert.equal(back.apps[0].salary_min, "140000");
   assert.equal(back.apps[0].salary_max, "190000");
   assert.equal(back.apps[0].cl_path, "Affirm_analyst_20260420");
@@ -120,7 +120,7 @@ test("save + load round-trips v4 fit fields (fit_score, fit_rationale, fit_evalu
   built[0].skip_reason = "weak_fit";
   apps.save(file, built);
   const back = apps.load(file);
-  assert.equal(back.schemaVersion, 6);
+  assert.equal(back.schemaVersion, 7);
   assert.equal(back.apps[0].fit_score, "Weak");
   assert.equal(back.apps[0].fit_rationale, "Energy domain — outside PM core");
   assert.equal(back.apps[0].fit_evaluated_at, "2026-05-05T14:17:47Z");
@@ -136,7 +136,7 @@ test("v5: save + load round-trips multi-element locations array", () => {
   built[0].locations = ["Remote (UK)", "United States", "New York, NY"];
   apps.save(file, built);
   const back = apps.load(file);
-  assert.equal(back.schemaVersion, 6);
+  assert.equal(back.schemaVersion, 7);
   assert.deepEqual(back.apps[0].locations, ["Remote (UK)", "United States", "New York, NY"]);
 });
 
@@ -192,10 +192,10 @@ test("load auto-upgrades v1 files (12 cols) with empty v2+v3+v4+v5 fields", () =
   assert.equal(back.apps[0].status, "To Apply");
   assert.equal(back.apps[0].notion_page_id, "abc");
 
-  // Re-saving promotes the file to v6.
+  // Re-saving promotes the file to v7.
   apps.save(file, back.apps);
   const after = apps.load(file);
-  assert.equal(after.schemaVersion, 6);
+  assert.equal(after.schemaVersion, 7);
 });
 
 test("load auto-upgrades v2 files (15 cols) with empty location and fit fields", () => {
@@ -229,10 +229,10 @@ test("load auto-upgrades v2 files (15 cols) with empty location and fit fields",
   assert.equal(back.apps[0].fit_score, "");
   assert.equal(back.apps[0].skip_reason, "");
 
-  // Re-saving promotes to v6.
+  // Re-saving promotes to v7.
   apps.save(file, back.apps);
   const after = apps.load(file);
-  assert.equal(after.schemaVersion, 6);
+  assert.equal(after.schemaVersion, 7);
 });
 
 test("load auto-upgrades v3 files (16 cols) — `location` wraps to [location]", () => {
@@ -267,10 +267,10 @@ test("load auto-upgrades v3 files (16 cols) — `location` wraps to [location]",
   assert.equal(back.apps[0].fit_evaluated_at, "");
   assert.equal(back.apps[0].skip_reason, "");
 
-  // Re-saving promotes to v6.
+  // Re-saving promotes to v7.
   apps.save(file, back.apps);
   const after = apps.load(file);
-  assert.equal(after.schemaVersion, 6);
+  assert.equal(after.schemaVersion, 7);
 });
 
 // RFC 038: v4 (single-string `location`) wraps to [location] on read.
@@ -307,10 +307,10 @@ test("load auto-upgrades v4 files (20 cols) — `location` wraps to [location]",
   assert.deepEqual(back.apps[0].locations, ["San Francisco, CA"]);
   assert.equal(back.apps[0].fit_score, "Strong");
 
-  // Re-saving promotes to v6.
+  // Re-saving promotes to v7.
   apps.save(file, back.apps);
   const after = apps.load(file);
-  assert.equal(after.schemaVersion, 6);
+  assert.equal(after.schemaVersion, 7);
   assert.deepEqual(after.apps[0].locations, ["San Francisco, CA"]);
 });
 
@@ -521,7 +521,7 @@ test("v6: save + load round-trips the six outreach fields", () => {
   built[0].hm_outreach_date = "2026-06-03";
   apps.save(file, built);
   const back = apps.load(file);
-  assert.equal(back.schemaVersion, 6);
+  assert.equal(back.schemaVersion, 7);
   assert.equal(
     back.apps[0].company_people_search_url,
     "https://www.linkedin.com/search/results/people/?keywords=Affirm"
@@ -620,10 +620,10 @@ test("load auto-upgrades v5 files (20 cols) with the six v6 outreach defaults", 
   assert.equal(back.apps[0].hm_outreach_status, "To do");
   assert.equal(back.apps[0].hm_outreach_date, "");
 
-  // Re-saving promotes the file to v6.
+  // Re-saving promotes the file to v7.
   apps.save(file, back.apps);
   const after = apps.load(file);
-  assert.equal(after.schemaVersion, 6);
+  assert.equal(after.schemaVersion, 7);
   assert.equal(after.apps[0].hm_outreach_status, "To do");
   assert.deepEqual(after.apps[0].locations, ["San Francisco, CA"]);
 });
@@ -655,7 +655,153 @@ test("load auto-upgrades v1 files with the v6 outreach defaults too", () => {
 
   apps.save(file, back.apps);
   const after = apps.load(file);
-  assert.equal(after.schemaVersion, 6);
+  assert.equal(after.schemaVersion, 7);
+});
+
+// --- RFC 059 amendment / BL-187: v7 applied_date column -------------------
+
+test("appendNew seeds the v7 applied_date default (empty)", () => {
+  const r = apps.appendNew([], [fixtureJob()], { now: "2026-06-03T00:00:00Z" });
+  assert.equal(r.apps[0].applied_date, "");
+});
+
+test("v7: save + load round-trips the applied_date anchor", () => {
+  const file = tmp();
+  const { apps: built } = apps.appendNew([], [fixtureJob()], { now: "2026-06-03T00:00:00Z" });
+  built[0].status = "Applied";
+  built[0].applied_date = "2026-06-03";
+  apps.save(file, built);
+  const back = apps.load(file);
+  assert.equal(back.schemaVersion, 7);
+  assert.equal(back.apps[0].status, "Applied");
+  assert.equal(back.apps[0].applied_date, "2026-06-03");
+});
+
+test("v7: header parses and detects as schemaVersion 7", () => {
+  const file = tmp();
+  const v7Header = apps.HEADER_V7.join("\t");
+  const v7Row = [
+    "greenhouse:1",
+    "greenhouse",
+    "1",
+    "Affirm",
+    "PM",
+    "https://x/1",
+    '["San Francisco, CA"]',
+    "Applied",
+    "abc",
+    "Risk_Fraud",
+    "cl_key1",
+    "140000",
+    "190000",
+    "Affirm_analyst_20260420",
+    "2026-01-01",
+    "2026-01-02",
+    "Strong",
+    "Great fit",
+    "2026-05-05T00:00:00Z",
+    "",
+    "https://www.linkedin.com/search/results/people/?keywords=Affirm",
+    "cold",
+    "Jane Doe",
+    "https://www.linkedin.com/in/janedoe",
+    "To do",
+    "",
+    "2026-06-03",
+  ].join("\t");
+  fs.writeFileSync(file, `${v7Header}\n${v7Row}\n`);
+
+  const back = apps.load(file);
+  assert.equal(back.schemaVersion, 7);
+  assert.equal(back.apps.length, 1);
+  assert.equal(back.apps[0].status, "Applied");
+  assert.equal(back.apps[0].applied_date, "2026-06-03");
+  // v6 outreach fields still intact under v7.
+  assert.equal(back.apps[0].outreach_type, "cold");
+  assert.equal(back.apps[0].hm_outreach_status, "To do");
+});
+
+// Auto-upgrade: a v6 file (26 cols, no applied_date) loads with the v7 default
+// (applied_date="") and the next save() rewrites it as v7.
+test("load auto-upgrades v6 files (26 cols) with the v7 applied_date default", () => {
+  const file = tmp();
+  const v6Header = apps.HEADER_V6.join("\t");
+  const v6Row = [
+    "greenhouse:1",
+    "greenhouse",
+    "1",
+    "Affirm",
+    "PM",
+    "https://x/1",
+    '["San Francisco, CA"]',
+    "Applied",
+    "abc",
+    "Risk_Fraud",
+    "cl_key1",
+    "140000",
+    "190000",
+    "Affirm_analyst_20260420",
+    "2026-01-01",
+    "2026-01-02",
+    "Strong",
+    "Great fit",
+    "2026-05-05T00:00:00Z",
+    "",
+    "https://www.linkedin.com/search/results/people/?keywords=Affirm",
+    "cold",
+    "Jane Doe",
+    "https://www.linkedin.com/in/janedoe",
+    "To do",
+    "2026-06-02",
+  ].join("\t");
+  fs.writeFileSync(file, `${v6Header}\n${v6Row}\n`);
+
+  const back = apps.load(file);
+  assert.equal(back.schemaVersion, 6);
+  assert.equal(back.apps.length, 1);
+  // v6 fields intact.
+  assert.equal(back.apps[0].status, "Applied");
+  assert.equal(back.apps[0].hm_outreach_status, "To do");
+  assert.equal(back.apps[0].hm_outreach_date, "2026-06-02");
+  // v7 default seeded.
+  assert.equal(back.apps[0].applied_date, "");
+
+  // Re-saving promotes the file to v7.
+  apps.save(file, back.apps);
+  const after = apps.load(file);
+  assert.equal(after.schemaVersion, 7);
+  assert.equal(after.apps[0].applied_date, "");
+  assert.equal(after.apps[0].hm_outreach_date, "2026-06-02");
+});
+
+// Older upgrade paths (v1) must also seed the v7 applied_date default.
+test("load auto-upgrades v1 files with the v7 applied_date default too", () => {
+  const file = tmp();
+  const v1Header = apps.HEADER_V1.join("\t");
+  const v1Row = [
+    "greenhouse:1",
+    "greenhouse",
+    "1",
+    "Affirm",
+    "PM",
+    "https://x/1",
+    "Applied",
+    "abc",
+    "Risk_Fraud",
+    "cl_key1",
+    "2026-01-01",
+    "2026-01-02",
+  ].join("\t");
+  fs.writeFileSync(file, `${v1Header}\n${v1Row}\n`);
+
+  const back = apps.load(file);
+  assert.equal(back.schemaVersion, 1);
+  assert.equal(back.apps[0].applied_date, "");
+
+  apps.save(file, back.apps);
+  const after = apps.load(file);
+  assert.equal(after.schemaVersion, 7);
+  assert.equal(after.apps[0].applied_date, "");
 });
 
 // RFC 038: decodeLocations defensive fallback — a hand-edited v5 cell that

--- a/engine/core/auto_no_response.js
+++ b/engine/core/auto_no_response.js
@@ -1,0 +1,95 @@
+// Auto-No-Response — pure helpers (BL-187 / RFC 059 amendment).
+//
+// Mirror of auto-Dead (BL-169), but for the vacancy's MAIN status instead of
+// the outreach status. Two deterministic decisions, both date-injected so they
+// never call `Date.now()` themselves (the CLI glue computes "today" once as a
+// `YYYY-MM-DD` string and passes it down — see RFC 059 "Amendment — BL-187
+// auto-No-Response").
+//
+//   1. decideAppliedDate — when `sync` pulls `status="Applied"` from Notion and
+//      the row has no `applied_date` anchor yet, the engine stamps "today" so
+//      the 14-day timer has a start point. An existing anchor is never
+//      overwritten (re-stamping would silently reset the timer). Any other
+//      status leaves the anchor as-is — the sweep only ever inspects Applied
+//      rows, so a stale anchor on a row that moved forward is harmless.
+//
+//   2. selectStaleApplied — rows that have been Applied for >= 14 days (with a
+//      non-empty, well-formed anchor) are the auto-No-Response candidates.
+//
+// The date math (`daysBetween` / `epochDay`) is shared with auto-Dead — we
+// reuse it rather than duplicate it. Both helpers below are pure over
+// in-memory objects: no I/O, no network, no Date.
+
+const { daysBetween, epochDay } = require("./auto_dead.js");
+
+const APPLIED = "Applied";
+const NO_RESPONSE = "No Response";
+
+const DEFAULT_THRESHOLD_DAYS = 14;
+
+// Decide the `applied_date` value after a main-status transition.
+//
+//   newStatus   — the status just pulled from Notion.
+//   currentDate — existing `applied_date` on the row ("" if unset).
+//   todayStr    — injected "today" as `YYYY-MM-DD`.
+//
+// Returns one of:
+//   { action: "stamp", date: todayStr }     — entered Applied with no anchor.
+//   { action: "keep",  date: currentDate }  — no change (already anchored, or
+//                                              any non-Applied status).
+//
+// The caller applies the returned date only when action !== "keep", so a
+// "keep" is a cheap no-op. Unlike auto-Dead's outreach helper there is no
+// "clear" branch: moving forward out of Applied (Interview / Offer / Rejected /
+// No Response) deliberately leaves the anchor in place — the sweep only looks
+// at Applied rows, so the stale value never matters and we avoid losing the
+// stamp on a future re-entry. Pure: no Date, no I/O.
+function decideAppliedDate(newStatus, currentDate, todayStr) {
+  const current = currentDate ? String(currentDate).trim() : "";
+  if (newStatus === APPLIED) {
+    // Stamp only when there is no anchor yet — never overwrite an existing one
+    // (re-stamping would silently reset the 14-day timer on every sync).
+    if (!current) return { action: "stamp", date: todayStr };
+    return { action: "keep", date: current };
+  }
+  // Any non-Applied status → leave the anchor as-is.
+  return { action: "keep", date: current };
+}
+
+// Select rows that have been Applied at least `thresholdDays` days.
+//
+//   apps          — loaded TSV rows.
+//   todayStr      — injected "today" as `YYYY-MM-DD`.
+//   thresholdDays — staleness cutoff (default 14).
+//
+// A row is stale iff:
+//   status === "Applied"  AND
+//   applied_date is a well-formed non-empty date  AND
+//   (today - applied_date) >= thresholdDays days.
+//
+// Empty / malformed anchor → skipped (no timer). "No Response" (already
+// terminal) and every other status → never selected. Returns shallow
+// references to the original app objects so the caller can flip status in
+// place. Pure: no Date, no I/O.
+function selectStaleApplied(apps, todayStr, thresholdDays = DEFAULT_THRESHOLD_DAYS) {
+  const stale = [];
+  for (const app of apps || []) {
+    if (!app || app.status !== APPLIED) continue;
+    const anchor = app.applied_date ? String(app.applied_date).trim() : "";
+    if (!anchor) continue;
+    const age = daysBetween(anchor, todayStr);
+    if (age === null) continue;
+    if (age >= thresholdDays) stale.push(app);
+  }
+  return stale;
+}
+
+module.exports = {
+  APPLIED,
+  NO_RESPONSE,
+  DEFAULT_THRESHOLD_DAYS,
+  epochDay,
+  daysBetween,
+  decideAppliedDate,
+  selectStaleApplied,
+};

--- a/engine/core/auto_no_response.test.js
+++ b/engine/core/auto_no_response.test.js
@@ -1,0 +1,136 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  daysBetween,
+  decideAppliedDate,
+  selectStaleApplied,
+  epochDay,
+  DEFAULT_THRESHOLD_DAYS,
+} = require("./auto_no_response.js");
+
+// ---------- shared date math (re-exported from auto_dead) ----------
+
+test("daysBetween / epochDay are the shared auto_dead helpers", () => {
+  assert.equal(daysBetween("2026-06-01", "2026-06-15"), 14);
+  assert.equal(epochDay("not-a-date"), null);
+});
+
+// ---------- selectStaleApplied ----------
+
+const today = "2026-06-15";
+
+function row(overrides) {
+  return {
+    key: "lever:abc",
+    status: "Applied",
+    applied_date: "2026-06-01",
+    notion_page_id: "page-1",
+    ...overrides,
+  };
+}
+
+test("selectStaleApplied: exactly 14 days is stale (boundary inclusive)", () => {
+  const apps = [row({ applied_date: "2026-06-01" })]; // 14 days before 06-15
+  const stale = selectStaleApplied(apps, today);
+  assert.equal(stale.length, 1);
+});
+
+test("selectStaleApplied: 15 days is stale", () => {
+  const apps = [row({ applied_date: "2026-05-31" })]; // 15 days
+  assert.equal(selectStaleApplied(apps, today).length, 1);
+});
+
+test("selectStaleApplied: 13 days is NOT stale (below threshold)", () => {
+  const apps = [row({ applied_date: "2026-06-02" })]; // 13 days
+  assert.equal(selectStaleApplied(apps, today).length, 0);
+});
+
+test("selectStaleApplied: empty anchor date is skipped (no timer)", () => {
+  const apps = [row({ applied_date: "" })];
+  assert.equal(selectStaleApplied(apps, today).length, 0);
+});
+
+test("selectStaleApplied: malformed anchor date is skipped", () => {
+  const apps = [row({ applied_date: "garbage" })];
+  assert.equal(selectStaleApplied(apps, today).length, 0);
+});
+
+test("selectStaleApplied: No Response is never selected (idempotent)", () => {
+  const apps = [row({ status: "No Response", applied_date: "2026-01-01" })];
+  assert.equal(selectStaleApplied(apps, today).length, 0);
+});
+
+test("selectStaleApplied: non-Applied statuses are never selected", () => {
+  for (const status of ["Interview", "Offer", "Rejected", "To Apply", "Inbox", "Archived"]) {
+    const apps = [row({ status, applied_date: "2026-01-01" })];
+    assert.equal(selectStaleApplied(apps, today).length, 0, `${status} must never be selected`);
+  }
+});
+
+test("selectStaleApplied: returns references to the original objects", () => {
+  const r = row({ applied_date: "2026-06-01" });
+  const stale = selectStaleApplied([r], today);
+  assert.equal(stale[0], r); // same reference, caller mutates in place
+});
+
+test("selectStaleApplied: mixed batch picks only the stale Applied rows", () => {
+  const apps = [
+    row({ key: "a", applied_date: "2026-06-01" }), // 14d → stale
+    row({ key: "b", status: "Interview", applied_date: "2026-01-01" }),
+    row({ key: "c", applied_date: "2026-06-10" }), // 5 days, fresh
+    row({ key: "d", applied_date: "" }), // no anchor
+    row({ key: "e", status: "No Response", applied_date: "2026-01-01" }),
+  ];
+  const stale = selectStaleApplied(apps, today);
+  assert.deepEqual(
+    stale.map((s) => s.key),
+    ["a"]
+  );
+});
+
+test("selectStaleApplied: custom threshold respected", () => {
+  const apps = [row({ applied_date: "2026-06-13" })]; // 2 days
+  assert.equal(selectStaleApplied(apps, today, 2).length, 1);
+  assert.equal(selectStaleApplied(apps, today, 3).length, 0);
+});
+
+test("selectStaleApplied: empty / null input is a no-op", () => {
+  assert.deepEqual(selectStaleApplied([], today), []);
+  assert.deepEqual(selectStaleApplied(null, today), []);
+  assert.deepEqual(selectStaleApplied(undefined, today), []);
+});
+
+test("DEFAULT_THRESHOLD_DAYS is 14", () => {
+  assert.equal(DEFAULT_THRESHOLD_DAYS, 14);
+});
+
+// ---------- decideAppliedDate (transition stamp) ----------
+
+test("decideAppliedDate: entering Applied with no anchor stamps today", () => {
+  const d = decideAppliedDate("Applied", "", today);
+  assert.deepEqual(d, { action: "stamp", date: today });
+});
+
+test("decideAppliedDate: entering Applied with an existing anchor keeps it", () => {
+  const d = decideAppliedDate("Applied", "2026-06-01", today);
+  assert.deepEqual(d, { action: "keep", date: "2026-06-01" });
+});
+
+test("decideAppliedDate: non-Applied status with empty anchor is a no-op keep", () => {
+  const d = decideAppliedDate("To Apply", "", today);
+  assert.deepEqual(d, { action: "keep", date: "" });
+});
+
+test("decideAppliedDate: moving forward out of Applied leaves the anchor as-is", () => {
+  for (const status of ["Interview", "Offer", "Rejected", "No Response"]) {
+    const d = decideAppliedDate(status, "2026-06-01", today);
+    assert.deepEqual(d, { action: "keep", date: "2026-06-01" }, `${status} keeps the anchor`);
+  }
+});
+
+test("decideAppliedDate: never re-stamps even if today differs from the anchor", () => {
+  const d = decideAppliedDate("Applied", "2026-05-01", today);
+  assert.equal(d.action, "keep");
+  assert.equal(d.date, "2026-05-01");
+});

--- a/engine/core/auto_no_response_sweep.js
+++ b/engine/core/auto_no_response_sweep.js
@@ -1,0 +1,153 @@
+// Auto-No-Response lazy sweep (BL-187 / RFC 059 amendment).
+//
+// Runs at the START of every engine CLI command (scan / prepare / check /
+// sync / validate — wired once in `engine/cli.js` so it fires regardless of
+// which command the operator runs), right next to the auto-Dead sweep. The
+// worklist self-cleans exactly when the operator is working with the engine —
+// no cron, no scheduler (explicitly rejected, paid-plan / infra-free design).
+//
+// Mechanism (mirror of auto-Dead, but for the vacancy's main status):
+//   1. Load the profile's TSV.
+//   2. `selectStaleApplied(apps, todayStr, 14)` — pure scan for rows that have
+//      been "Applied" for >= 14 days with a non-empty `applied_date` anchor.
+//   3. For each stale row: set status = "No Response", write the TSV via the
+//      single writer (`applications_tsv.js`), and push "No Response" to Notion
+//      via the same targeted `updatePageStatus` pattern `check` uses. This is
+//      engine-authored status data (same class as `check`'s write) — it does
+//      NOT reintroduce a push path; "sync pull-only" is preserved.
+//
+// Properties:
+//   - Idempotent: a "No Response" row is never re-selected; only "Applied" is
+//     touched; an empty / malformed anchor is a no-op (no timer).
+//   - Cheap: pure scan first; only writes when something is actually stale.
+//   - Resilient: no NOTION_TOKEN → mark No Response in TSV only + a stderr
+//     warn, never fail the command. Notion calls are wrapped per-row in
+//     try/catch so a Notion outage can never break the underlying command
+//     (scan / validate must still run offline). The sweep never throws out of
+//     the CLI entry — `runAutoNoResponseSweep` catches and logs.
+//   - The Applied → No Response flip feeds the existing terminal handling
+//     (`archive_used_artifacts`) downstream — expected / desired side effect.
+//
+// "today" is injected as a `YYYY-MM-DD` string by the CLI glue (computed
+// once), so the pure helpers stay deterministic and unit-testable.
+
+const path = require("path");
+
+const profileLoader = require("../core/profile_loader.js");
+const { secretEnvName } = profileLoader;
+const applications = require("../core/applications_tsv.js");
+const notion = require("../core/notion_sync.js");
+const { resolveProfilesDir } = require("../core/paths.js");
+const {
+  selectStaleApplied,
+  NO_RESPONSE,
+  DEFAULT_THRESHOLD_DAYS,
+} = require("./auto_no_response.js");
+
+const DEFAULT_DEPS = {
+  loadProfile: profileLoader.loadProfile,
+  loadSecrets: profileLoader.loadSecrets,
+  loadApplications: applications.load,
+  saveApplications: applications.save,
+  makeClient: notion.makeClient,
+  // Targeted single-field status write — the engine-authored pattern used by
+  // `check`'s status update. Injected so tests mock the network.
+  updatePageStatus: notion.updatePageStatus,
+};
+
+// Compute today's date as a `YYYY-MM-DD` string in local time. The single
+// `Date` read for the whole sweep — kept out of the pure helpers. Exported so
+// the CLI can compute "today" once and inject it.
+function todayLocalISO(now = new Date()) {
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+// Run the Applied → No Response sweep for `profileId`.
+//
+//   profileId — profile to sweep.
+//   ctx       — { stdout, stderr, env, profilesDir? }.
+//   options   — { todayStr?, thresholdDays?, deps? }. `todayStr` is injected
+//               by the CLI (defaults to local today if omitted, for manual
+//               callers). `deps` overrides the I/O / Notion functions in tests.
+//
+// Returns { swept, notionPushed, notionErrors } for callers that care; the
+// CLI ignores the return (fire-and-forget). Never throws — any unexpected
+// error is caught and logged so the underlying command always proceeds.
+async function runAutoNoResponseSweep(profileId, ctx, options = {}) {
+  const deps = { ...DEFAULT_DEPS, ...(options.deps || {}) };
+  const todayStr = options.todayStr || todayLocalISO();
+  const thresholdDays = options.thresholdDays || DEFAULT_THRESHOLD_DAYS;
+  const result = { swept: 0, notionPushed: 0, notionErrors: 0 };
+
+  try {
+    const profilesDir = resolveProfilesDir(ctx, ctx.env || process.env);
+    const profile = deps.loadProfile(profileId, { profilesDir });
+    const applicationsPath = path.join(profile.paths.root, "applications.tsv");
+    const { apps } = deps.loadApplications(applicationsPath);
+
+    const stale = selectStaleApplied(apps, todayStr, thresholdDays);
+    if (stale.length === 0) return result; // cheap no-op — nothing stale
+
+    // Resolve Notion creds once. Without a token (or a status mapping) we still
+    // mark No Response in the TSV — the local ledger is canonical, Notion is a
+    // view.
+    const secrets = (deps.loadSecrets && deps.loadSecrets(profileId, ctx.env)) || {};
+    const token = secrets.NOTION_TOKEN || null;
+    const propertyMap =
+      (profile.notion && profile.notion.property_map) || notion.DEFAULT_PROPERTY_MAP;
+
+    let client = null;
+    const getClient = () => {
+      if (!client) client = deps.makeClient(token);
+      return client;
+    };
+
+    if (!token) {
+      ctx.stderr(
+        `[auto-no-response] warn: missing ${secretEnvName(profileId, "NOTION_TOKEN")} in env — ` +
+          `marking ${stale.length} stale row(s) No Response in TSV only, Notion not updated`
+      );
+    }
+
+    for (const app of stale) {
+      app.status = NO_RESPONSE;
+      result.swept += 1;
+
+      if (token && app.notion_page_id) {
+        try {
+          await deps.updatePageStatus(getClient(), app.notion_page_id, NO_RESPONSE, propertyMap);
+          result.notionPushed += 1;
+        } catch (err) {
+          result.notionErrors += 1;
+          ctx.stderr(
+            `[auto-no-response] notion error for ${app.key} (${app.notion_page_id}): ${err.message}`
+          );
+        }
+      }
+    }
+
+    deps.saveApplications(applicationsPath, apps);
+
+    const notionNote = token
+      ? `, ${result.notionPushed} pushed to Notion` +
+        (result.notionErrors ? `, ${result.notionErrors} Notion error(s)` : "")
+      : ` (TSV only)`;
+    ctx.stdout(
+      `[auto-no-response] swept ${result.swept} stale Applied row(s) → No Response${notionNote}`
+    );
+  } catch (err) {
+    // The sweep must never break the underlying command. Log and move on.
+    ctx.stderr(`[auto-no-response] warn: sweep skipped: ${err.message}`);
+  }
+
+  return result;
+}
+
+module.exports = {
+  runAutoNoResponseSweep,
+  todayLocalISO,
+  DEFAULT_DEPS,
+};

--- a/engine/core/auto_no_response_sweep.test.js
+++ b/engine/core/auto_no_response_sweep.test.js
@@ -1,0 +1,228 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { runAutoNoResponseSweep, todayLocalISO } = require("./auto_no_response_sweep.js");
+
+// Minimal ctx with captured stdout/stderr.
+function makeCtx() {
+  const out = [];
+  const err = [];
+  return {
+    ctx: {
+      env: {},
+      profilesDir: "/fake/profiles",
+      stdout: (s) => out.push(s),
+      stderr: (s) => err.push(s),
+    },
+    out,
+    err,
+  };
+}
+
+const PROFILE = {
+  paths: { root: "/fake/profiles/jared" },
+  notion: { property_map: { status: { field: "Status", type: "status" } } },
+};
+
+function appsFixture() {
+  return [
+    {
+      key: "lever:stale",
+      status: "Applied",
+      applied_date: "2026-06-01", // 14 days before 2026-06-15 → stale
+      notion_page_id: "page-stale",
+    },
+    {
+      key: "lever:fresh",
+      status: "Applied",
+      applied_date: "2026-06-10", // 5 days → fresh
+      notion_page_id: "page-fresh",
+    },
+    {
+      key: "lever:interview",
+      status: "Interview",
+      applied_date: "2026-01-01",
+      notion_page_id: "page-interview",
+    },
+  ];
+}
+
+const TODAY = "2026-06-15";
+
+test("sweep: flips stale Applied rows to No Response in TSV + pushes to Notion", async () => {
+  const { ctx, out } = makeCtx();
+  const apps = appsFixture();
+  let savedApps = null;
+  const statusCalls = [];
+
+  await runAutoNoResponseSweep("jared", ctx, {
+    todayStr: TODAY,
+    deps: {
+      loadProfile: () => PROFILE,
+      loadSecrets: () => ({ NOTION_TOKEN: "secret_token" }),
+      loadApplications: () => ({ apps }),
+      saveApplications: (_path, a) => {
+        savedApps = a;
+      },
+      makeClient: (token) => ({ token }),
+      updatePageStatus: async (client, pageId, status) => {
+        statusCalls.push({ pageId, status, token: client.token });
+      },
+    },
+  });
+
+  // Only the stale row flips.
+  assert.equal(apps.find((a) => a.key === "lever:stale").status, "No Response");
+  assert.equal(apps.find((a) => a.key === "lever:fresh").status, "Applied");
+  assert.equal(apps.find((a) => a.key === "lever:interview").status, "Interview");
+
+  // TSV saved once with the mutated rows.
+  assert.equal(savedApps, apps);
+
+  // Exactly one targeted Notion status write, for the stale page, value
+  // No Response.
+  assert.equal(statusCalls.length, 1);
+  assert.deepEqual(statusCalls[0], {
+    pageId: "page-stale",
+    status: "No Response",
+    token: "secret_token",
+  });
+
+  assert.ok(out.some((l) => l.includes("swept 1")));
+});
+
+test("sweep: no stale rows → no save, no Notion call, no output (cheap no-op)", async () => {
+  const { ctx, out, err } = makeCtx();
+  const apps = [
+    { key: "a", status: "Applied", applied_date: "2026-06-10", notion_page_id: "p" },
+    { key: "b", status: "To Apply", applied_date: "", notion_page_id: "p2" },
+  ];
+  let saved = false;
+  let notionCalled = false;
+
+  const res = await runAutoNoResponseSweep("jared", ctx, {
+    todayStr: TODAY,
+    deps: {
+      loadProfile: () => PROFILE,
+      loadSecrets: () => ({ NOTION_TOKEN: "t" }),
+      loadApplications: () => ({ apps }),
+      saveApplications: () => {
+        saved = true;
+      },
+      makeClient: () => ({}),
+      updatePageStatus: async () => {
+        notionCalled = true;
+      },
+    },
+  });
+
+  assert.equal(res.swept, 0);
+  assert.equal(saved, false);
+  assert.equal(notionCalled, false);
+  assert.equal(out.length, 0);
+  assert.equal(err.length, 0);
+});
+
+test("sweep: no NOTION_TOKEN → marks No Response in TSV only + warns, never fails", async () => {
+  const { ctx, err } = makeCtx();
+  const apps = appsFixture();
+  let saved = false;
+  let notionCalled = false;
+
+  const res = await runAutoNoResponseSweep("jared", ctx, {
+    todayStr: TODAY,
+    deps: {
+      loadProfile: () => PROFILE,
+      loadSecrets: () => ({}), // no token
+      loadApplications: () => ({ apps }),
+      saveApplications: () => {
+        saved = true;
+      },
+      makeClient: () => {
+        throw new Error("makeClient should not be called without a token");
+      },
+      updatePageStatus: async () => {
+        notionCalled = true;
+      },
+    },
+  });
+
+  assert.equal(res.swept, 1);
+  assert.equal(res.notionPushed, 0);
+  assert.equal(apps.find((a) => a.key === "lever:stale").status, "No Response");
+  assert.equal(saved, true);
+  assert.equal(notionCalled, false);
+  assert.ok(err.some((l) => l.includes("TSV only")));
+});
+
+test("sweep: Notion error on one row is counted, TSV still saved, no throw", async () => {
+  const { ctx, err } = makeCtx();
+  const apps = appsFixture();
+  let saved = false;
+
+  const res = await runAutoNoResponseSweep("jared", ctx, {
+    todayStr: TODAY,
+    deps: {
+      loadProfile: () => PROFILE,
+      loadSecrets: () => ({ NOTION_TOKEN: "t" }),
+      loadApplications: () => ({ apps }),
+      saveApplications: () => {
+        saved = true;
+      },
+      makeClient: () => ({}),
+      updatePageStatus: async () => {
+        throw new Error("notion 503");
+      },
+    },
+  });
+
+  assert.equal(res.swept, 1);
+  assert.equal(res.notionErrors, 1);
+  assert.equal(apps.find((a) => a.key === "lever:stale").status, "No Response");
+  assert.equal(saved, true); // TSV write not blocked by Notion error
+  assert.ok(err.some((l) => l.includes("notion error")));
+});
+
+test("sweep: stale row without notion_page_id is marked No Response in TSV, no Notion call", async () => {
+  const { ctx } = makeCtx();
+  const apps = [{ key: "x", status: "Applied", applied_date: "2026-06-01", notion_page_id: "" }];
+  let notionCalled = false;
+
+  const res = await runAutoNoResponseSweep("jared", ctx, {
+    todayStr: TODAY,
+    deps: {
+      loadProfile: () => PROFILE,
+      loadSecrets: () => ({ NOTION_TOKEN: "t" }),
+      loadApplications: () => ({ apps }),
+      saveApplications: () => {},
+      makeClient: () => ({}),
+      updatePageStatus: async () => {
+        notionCalled = true;
+      },
+    },
+  });
+
+  assert.equal(res.swept, 1);
+  assert.equal(apps[0].status, "No Response");
+  assert.equal(notionCalled, false);
+});
+
+test("sweep: unexpected error (e.g. loadProfile throws) is caught, never propagates", async () => {
+  const { ctx, err } = makeCtx();
+  const res = await runAutoNoResponseSweep("jared", ctx, {
+    todayStr: TODAY,
+    deps: {
+      loadProfile: () => {
+        throw new Error("profile boom");
+      },
+    },
+  });
+  assert.equal(res.swept, 0);
+  assert.ok(err.some((l) => l.includes("sweep skipped")));
+});
+
+test("todayLocalISO: formats a Date as YYYY-MM-DD (local)", () => {
+  const d = new Date(2026, 5, 3); // June 3, 2026 local
+  assert.equal(todayLocalISO(d), "2026-06-03");
+  assert.match(todayLocalISO(), /^\d{4}-\d{2}-\d{2}$/);
+});

--- a/rfc/059-hm-outreach.md
+++ b/rfc/059-hm-outreach.md
@@ -644,3 +644,96 @@ field.
 **Out of scope (this amendment).** Cron / scheduler, the 4-state status
 set (unchanged), per-person contact fields, any backfill, and exposing
 the threshold as a CLI flag.
+
+## Amendment — BL-187 auto-No-Response (2026-06-03)
+
+**Problem.** The auto-Dead amendment above self-cleans the *outreach*
+status (`Outreach: In flight → Dead`). The same problem exists one level
+up, on the vacancy's **main** status: a job the operator applied to and
+then heard nothing back on sits in `Applied` indefinitely and clutters
+the live worklist. The operator wants an `Applied` vacancy with no
+movement for two weeks to drop to `No Response` automatically — the exact
+mirror of auto-Dead, but for the main status and a 14-day window.
+
+**Образ (operator-approved).** The operator applies and works exactly as
+before — no extra step. The engine then:
+
+1. **Stamps a date anchor on transition.** When `sync`'s `reconcilePull`
+   pulls a main status of `Applied` and the row's `applied_date` is
+   empty, it stamps "today". An existing anchor is **never** overwritten
+   (re-stamping would silently reset the 14-day timer). Unlike auto-Dead
+   there is **no clear branch**: moving forward out of `Applied`
+   (`Interview` / `Offer` / `Rejected` / `No Response`) leaves the anchor
+   as-is — the sweep only ever inspects `Applied` rows, so a stale anchor
+   on a moved-on row is harmless, and keeping it avoids losing the stamp.
+2. **Lazily sweeps on every CLI invocation.** At the start of every
+   command (wired once in `engine/cli.js`, immediately after the
+   auto-Dead sweep — independent, deterministic order), the engine scans
+   the TSV for rows that are `Applied` with a non-empty anchor older than
+   the 14-day threshold, flips them to `No Response`, writes the TSV, and
+   pushes `No Response` to Notion.
+
+**New TSV anchor column — `applied_date` (schema v7).** The anchor lives
+in a **new** TSV column `applied_date` (`YYYY-MM-DD`), appended as schema
+v7 using the same auto-upgrade-on-save mechanism v6 used for the outreach
+columns: every older `rowToApp*` path seeds `applied_date: ""`, `save()`
+always writes the v7 header, and a pre-v7 file silently upgrades on the
+next write. The anchor is **TSV-internal**: it is **not** a Notion field
+and **not** in `property_map` (it differs from auto-Dead, which reused the
+already-existing `hm_outreach_date` column — there was no main-status
+anchor column to reuse, so one is added here). The 14-day timer does not
+need the anchor in Notion.
+
+**14-day threshold.** Fixed at 14 calendar days (two weeks), matching the
+operator's mental model ("applied, two weeks of silence → no response").
+Configurable via a helper parameter (`thresholdDays`, default 14) but not
+exposed as a CLI flag — there is no use case for per-run tuning. Constant
+`DEFAULT_THRESHOLD_DAYS = 14` in `engine/core/auto_no_response.js`.
+
+**Source status = `Applied` only.** `No Response` semantically means
+"applied and heard nothing". `To Apply` (not yet applied) and every other
+status are a different meaning and are never swept. `Interview` / `Offer`
+/ `Rejected` / `To Apply` / `Inbox` / `Archived` are never touched.
+
+**No cron / no scheduler.** Same lazy-on-CLI design as auto-Dead (cron /
+Notion-native automation explicitly rejected). Pure scan first → cheap
+no-op when nothing is stale, safe to run on every command.
+
+**Notion `No Response` write — same class as auto-Dead / `check`, NOT a
+new push path.** The sweep writes a single targeted `updatePageStatus`
+(`status` property only), engine-authored status data of the same class
+as `check`'s status write and auto-Dead's `Dead` write. It does **not**
+reintroduce the removed Stage-16 push path; `sync` stays pull-only.
+
+**Implementation = sibling modules (DRY only the date math).** Two new
+pure-helper / sweep siblings mirror auto-Dead 1:1:
+
+- `engine/core/auto_no_response.js` — `selectStaleApplied(apps, todayStr,
+  thresholdDays = 14)` and `decideAppliedDate(newStatus, currentDate,
+  todayStr)`. Both pure, date-injected. The date math (`daysBetween` /
+  `epochDay`) is **reused** from `auto_dead.js`, not duplicated.
+- `engine/core/auto_no_response_sweep.js` — `runAutoNoResponseSweep`,
+  the same DI deps / TSV-only-without-token / per-row try/catch /
+  never-throws-out contract as `auto_dead_sweep.js`.
+
+**Terminal-handling side effect (desired).** The `Applied → No Response`
+flip feeds the existing terminal-status handling
+(`archive_used_artifacts`) downstream — an expected, desired effect, not
+fought.
+
+**Edge rules / resilience.** Identical to auto-Dead: empty / malformed
+`applied_date` → no timer (skipped); `No Response` is never re-selected
+(idempotent); only `Applied` is touched; no `NOTION_TOKEN` → mark
+`No Response` in the TSV with a single stderr warn, skip the push; every
+Notion call wrapped per-row; the whole sweep wrapped so it can never
+throw out of the CLI entry (`scan` / `validate` must still run offline).
+
+**Stamp-precision note.** As with auto-Dead, the anchor is stamped at the
+first `sync` that observes `Applied` (using the UTC date portion of the
+sync timestamp), not at the exact submission moment. A ±1-day drift is
+acceptable for a 14-day timer.
+
+**Out of scope (this amendment).** Cron / scheduler, auto-transitions
+from any status other than `Applied`, a per-profile / CLI-flag threshold,
+any new Notion field, and any change to the auto-Dead or backfill logic
+(only the pure date helpers are reused).

--- a/scripts/migrate_tsv_v4_to_v5.test.js
+++ b/scripts/migrate_tsv_v4_to_v5.test.js
@@ -74,10 +74,10 @@ test("migrateOne: v4 → v5, drops backup, locations wrapped to single-element a
   assert.equal(res.backupPath, `${file}.pre-v5-${todayStamp(now)}`);
   assert.ok(fs.existsSync(res.backupPath), "backup file must exist");
 
-  // File on disk now reads as the current schema (v6 — save() always writes
+  // File on disk now reads as the current schema (v7 — save() always writes
   // the latest header; the v4→v5 location-wrap is still applied en route).
   const back = apps.load(file);
-  assert.equal(back.schemaVersion, 6);
+  assert.equal(back.schemaVersion, 7);
   assert.deepEqual(back.apps[0].locations, ["San Francisco, CA"]);
   assert.deepEqual(back.apps[1].locations, []);
   assert.equal(back.apps[0].fit_score, "Strong");


### PR DESCRIPTION
## What

Mirror of the just-merged auto-Dead feature (PR #61), one level up on the vacancy's **main** status. An `Applied` vacancy whose `applied_date` anchor is >= **14 days** old flips to `No Response` automatically, via the same lazy-on-CLI sweep (no cron, no scheduler).

Closes BL-187 (tier M, RFC 059 amendment).

## How it works (operator view)

- Operator applies and works as before — no extra step.
- On the first `sync` that sees a vacancy in `Applied` with no anchor, the engine stamps `applied_date = today`.
- At the start of **every** CLI command, a lazy sweep flips `Applied` rows older than 14 days to `No Response` in the TSV and pushes `No Response` to Notion (pull-only preserved — same targeted `updatePageStatus` as `check` / auto-Dead).
- Idempotent: `No Response` is never re-selected; only `Applied` is swept; empty/malformed anchor = no timer.

## Changes

| File | What |
|---|---|
| `engine/core/applications_tsv.js` | Schema **v7**: append TSV-internal `applied_date` column (auto-upgrade-on-save, default `""`), mirroring the v6 outreach bump. Not a Notion field, not in `property_map`. |
| `engine/core/auto_no_response.js` | **New.** Pure helpers `selectStaleApplied` + `decideAppliedDate`; reuses `daysBetween`/`epochDay` from `auto_dead.js`. `DEFAULT_THRESHOLD_DAYS = 14`. |
| `engine/core/auto_no_response_sweep.js` | **New.** `runAutoNoResponseSweep` — DI deps, TSV-only-without-token + warn, per-row try/catch, never throws out. |
| `engine/cli.js` | Wired right after `runAutoDeadSweep` with the same injected `today`. |
| `engine/commands/sync.js` | `reconcilePull` stamps `applied_date` when the pulled status is `Applied` and the anchor is empty (update + add paths). |
| `rfc/059-hm-outreach.md` | `## Amendment — BL-187 auto-No-Response (2026-06-03)`. |
| `*.test.js` | New + updated coverage. |

## Design notes

- **Sibling, not generalized** (per RFC decision): minimal blast radius on just-merged auto-Dead. Only the pure date math is reused.
- **No `clear` branch** (differs from auto-Dead): moving forward out of `Applied` leaves the anchor as-is — the sweep only inspects `Applied` rows, so a stale anchor is harmless and we avoid losing the stamp.
- **New column** (differs from auto-Dead, which reused `hm_outreach_date`): there was no main-status anchor to reuse.

## Tests

`npm test` → **2089 pass / 0 fail**. `prettier --check .` clean.

Edge cases covered: 14d (stale) / 13d (fresh) / 15d (stale), empty + malformed anchor skip, non-Applied never selected, idempotent `No Response` skip; transition stamp (entering Applied stamps, existing anchor not overwritten, non-Applied no stamp, forward-move keeps anchor); schema v7 round-trip + auto-upgrade from v6/v1; sweep (no-token TSV-only, Notion-error non-blocking, missing page-id, never-throws).

🤖 Generated with [Claude Code](https://claude.com/claude-code)