### PR TITLE
feat(sourcing): BL-200 / RFC 061 — repeatable relokant sweet-zone sourcing sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ profiles/
   <id>/              personal profile (gitignored)
 data/                shared master pool (jobs.tsv, companies.tsv) — gitignored
 scripts/stage18/     onboarding wizard for new profiles
+scripts/relokant/    dedup helper for the relokant sourcing sweep
 skills/job-pipeline/ Claude skill that drives the flow
+skills/relokant-sweep/ Claude skill — CIS-rooted company sourcing sweep
 rfc/                 design docs (001-core split, 002-check, 004-onboarding)
 ```
 
@@ -101,6 +103,19 @@ lives in `profiles/<id>/`.
   templates / per-profile Notion databases by invoking the Stage 18
   engine under the hood. Scripted onboarding (without Claude) remains
   available as a technical reference in `scripts/stage18/`.
+- **Relokant sourcing sweep** — `/relokant-sweep` is a manual-launch
+  Claude skill that sources a hard-to-find channel: CIS-rooted companies
+  whose product+engineering team is still Russian-speaking, selling into
+  US/EU, mid-size, not globalized. One run does web research over a
+  rotating set of sources, classifies each company by a four-part
+  "sweet-zone" test + soft US-viability signal, dedups against two
+  per-profile ledgers (`ru_friendly_targets.tsv` already taken,
+  `ru_friendly_rejects.tsv` already rejected) so it never re-researches
+  the same company, appends new finds, and drafts founder outreach. The
+  dedup is enforced on code (`scripts/relokant/sweep_dedup.js`), not on
+  the model. Run it every 2–4 weeks; see
+  [skills/relokant-sweep/SKILL.md](skills/relokant-sweep/SKILL.md) and
+  [RFC 061](rfc/061-relokant-sourcing-process.md).
 
 ## What this tool does NOT do
 

--- a/rfc/061-relokant-sourcing-process.md
+++ b/rfc/061-relokant-sourcing-process.md
@@ -1,0 +1,157 @@
+# RFC 061 — Повторяемый процесс сорсинга relokant-sweet-zone компаний
+
+- **Status:** Accepted (mechanism chosen by candidate 2026-06-23)
+- **Created:** 2026-06-23
+- **Tier:** M (новый skill + pure-хелпер + новый артефакт + docs; PII-данные в profiles/)
+- **Related backlog:** BL-200 (этот RFC), BL-66 (outreach-канал), BL-199 (target-лист e-com), BL-201 (LinkedIn-нетворк-слой, потребитель targets.tsv)
+
+## Problem
+
+Канал «relokant sweet zone» (CIS-rooted, команда продукта+инженеров
+по-прежнему русскоязычная, продаёт в US/EU, mid-size, НЕ глобализована)
+дал первый невод 2026-06-22: 9 компаний в `ru_friendly_targets.tsv`.
+
+Один ресёрч-пасс — не дно рынка. Чтобы канал жил, нужен **повторяемый
+свип** по ещё-не-тронутым источникам с дедупом против двух списков:
+уже-взятых (`ru_friendly_targets.tsv`) и уже-отсеянных
+(`ru_friendly_rejects.tsv`, которого пока нет). Без памяти отсева каждый
+прогон заново «открывает» Miro/Wrike и жжёт токены.
+
+## Decision (механизм — выбран кандидатом 2026-06-23)
+
+**Standalone Claude skill `relokant-sweep` с ручным запуском.** Не cron,
+не engine CLI-команда. Причины:
+
+- Свип — это **LLM-driven web-research + суждение** (классификация по
+  sweet-zone, US-viability «сделает ли исключение как Virto»), а не
+  детерминированный fetch. Не ложится на `engine/` discovery-паттерн
+  (BL-200 явно выводит scan-движок из scope).
+- Авто-cloud-агент крутил бы токен-тяжёлый research+LLM без глаза
+  кандидата в моменте → риск галлюцинированных компаний. Ручной запуск
+  держит человека в петле на дешёвой стадии.
+- `/schedule` поверх того же скилла можно навесить позже как опцию, не
+  меняя механику (каденс-напоминание раз в 2–4 недели — в docs, не в код).
+
+**Дедуп — на коде, не на доверии к модели.** Маленький pure-хелпер
+гарантирует, что LLM физически не дописывает уже-известное имя.
+
+## Образ результата (наследует BL-200)
+
+### 1. Новый артефакт `profiles/jared/ru_friendly_rejects.tsv`
+
+Память отсева. Схема (TAB-separated, с заголовком):
+
+```
+name	reason	note	date
+```
+
+- `reason` ∈ `too_globalized | wrong_market | other`.
+- Заполняется текущим отсевом (см. §Seed ниже).
+- Гитигнорится как весь `profiles/jared/` (контракт репо).
+
+### 2. Pure дедуп-хелпер `scripts/relokant/sweep_dedup.js`
+
+Чистая функция + тонкий CLI. Никакого engine/, никакой сети.
+
+- `normalizeName(s)` — lowercase, trim, схлопывание пробелов, отрезание
+  легальных суффиксов (`inc`, `ltd`, `gmbh`), снятие диакритики — чтобы
+  «Virto Commerce» == «virto commerce, inc.».
+- `partitionCandidates(candidateNames, knownNames)` →
+  `{ fresh: [...], dupes: [...] }`. Чистая, тестируемая.
+- `loadKnownNames(targetsPath, rejectsPath)` — читает первую колонку
+  обоих TSV (rejects может отсутствовать → пустой набор), возвращает
+  нормализованный Set. Единственная I/O-точка.
+- CLI: `node scripts/relokant/sweep_dedup.js <name1> <name2> ...`
+  печатает, какие из переданных имён `FRESH`, какие `DUP`. Скилл зовёт
+  его перед дозаписью.
+
+Тест `scripts/relokant/sweep_dedup.test.js` — нормализация + партиция на
+фикстурах (без файловой системы для чистых функций).
+
+### 3. Skill `skills/relokant-sweep/SKILL.md`
+
+Документированный workflow одного прогона:
+
+1. **Load** — прочитать оба TSV → набор известных имён (через хелпер).
+2. **Source rotation** — взять следующую пачку источников из ротации
+   (трекать пройденное в `notes`-секции скилла или коротком state-файле
+   `profiles/jared/.relokant-state/sources_log.md`):
+   - релокант-трекеры;
+   - VC-портфели с CIS-корнями (Runa Capital, Begin Capital,
+     ex-Yandex/JetBrains/Wrike spinouts);
+   - Crunchbase-фильтр founder-education CIS + HQ US/EU;
+   - комьюнити (RAIN, RusBase, Telegram, tech-хабы Ереван/Тбилиси/Белград);
+   - LinkedIn founder-search;
+   - Habr-блоги компаний, выходящих global.
+   Веб-ресёрч через `firecrawl_search` / `web_search_exa`.
+3. **Classify** — каждый кандидат по 4 критериям sweet-zone + US-viability
+   (софт-сигнал «сделает исключение как Virto», не «постит ли US-remote»).
+4. **Dedup** — прогнать имена через хелпер; `DUP` отбросить молча.
+5. **Append** —
+   - sweet-zone (`FRESH`) → `ru_friendly_targets.tsv` (та же 10-колоночная
+     схема), US-viable флагуется в `us_viability`;
+   - отсев (`FRESH`) → `ru_friendly_rejects.tsv` с `reason`.
+6. **Outreach** — по каждому новому US-viable: контакт (фаундер / Head of
+   Product) + outreach-драфт (формат как для топ-3). **Только драфт,
+   отправку делает юзер руками.**
+7. **Report** — кратко: N исследовано, K новых sweet-zone, M отсеяно,
+   сколько DUP отфильтровано.
+
+### 4. Каденс
+
+Раз в 2–4 недели, **ручной запуск** `/relokant-sweep`. В docs — пометка,
+что при желании можно навесить `/schedule` поверх скилла. Авто-cron в
+scope этого RFC не входит.
+
+### 5. Docs
+
+- `README.md` / `ARCHITECTURE.md` — упомянуть канал relokant + как
+  запускать свип.
+- Кросс-ссылка из `profiles/jared/job-search-strategy.md` (столп
+  таргетинга) и `outbound-strategy.md`, если уместно.
+
+## Seed для ru_friendly_rejects.tsv (текущий отсев)
+
+| name | reason |
+|---|---|
+| Miro | too_globalized |
+| Wrike | too_globalized |
+| Ecwid (Lightspeed) | too_globalized |
+| Preply | too_globalized |
+| People.ai | too_globalized |
+| inDrive | wrong_market |
+| ID Finance | wrong_market |
+| Skyeng | wrong_market |
+| Refocus | wrong_market |
+| YouTravel | wrong_market |
+| Mate academy | wrong_market |
+
+(UA-компании исключены из таргетинга решением юзера 2026-06-22 — Mate
+academy сюда попадает как wrong_market/UA.)
+
+## Out of scope
+
+- Авто-отправка outreach (драфты да, отправка руками).
+- Изменение scan-движка / discovery-адаптеров (`engine/`). Если свип
+  потребует engine — отдельный RFC.
+- Авто-cron через `/schedule` (опция на потом, не в этом RFC).
+- Per-person CRM (это BL-201/BL-62).
+
+## Definition of Done (= BL-200 DoD)
+
+- [x] RFC с выбором механизма + approve.
+- [ ] `ru_friendly_rejects.tsv` создан и заполнен seed-отсевом.
+- [ ] `scripts/relokant/sweep_dedup.js` + тест (дедуп против обоих списков).
+- [ ] `skills/relokant-sweep/SKILL.md` написан.
+- [ ] Свип прогнан ≥1 раз, дедуп проверен, дал ≥1 новую sweet-zone компанию.
+- [ ] Каденс задокументирован (ручной + опция /schedule).
+- [ ] README / docs обновлены.
+
+## Tests
+
+- `sweep_dedup.test.js` — normalize (суффиксы, диакритика, регистр) +
+  partition (fresh/dup на пересечении с known). Сеть не трогаем.
+
+## Open questions
+
+Нет. Механизм выбран; остальное — реализация.

--- a/scripts/relokant/sweep_dedup.js
+++ b/scripts/relokant/sweep_dedup.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+// BL-200 / RFC 061 — dedup helper for the relokant-sweep skill.
+//
+// The sweep is LLM-driven web research. To guarantee — on code, not on the
+// model's good behaviour — that a run never re-adds a company we already took
+// (ru_friendly_targets.tsv) or already rejected (ru_friendly_rejects.tsv),
+// the skill pipes its candidate names through this helper before appending.
+//
+// Pure functions over in-memory strings; a single I/O point (loadKnownNames)
+// reads the two TSVs. No network.
+//
+// Usage:
+//   node scripts/relokant/sweep_dedup.js --profile <id> <name1> <name2> ...
+//   node scripts/relokant/sweep_dedup.js --profile jared "Virto Commerce" "New Co"
+//
+// Prints one line per input name: "FRESH\t<name>" or "DUP\t<name>".
+// Exit code is always 0 — this is an advisory filter, not a gate.
+
+const fs = require("fs");
+const path = require("path");
+
+// Legal-entity suffixes stripped before comparison so "Virto Commerce, Inc."
+// matches "Virto Commerce". Order-independent; applied as a trailing-token set.
+const LEGAL_SUFFIXES = new Set([
+  "inc",
+  "llc",
+  "ltd",
+  "limited",
+  "gmbh",
+  "corp",
+  "co",
+  "company",
+  "plc",
+  "ag",
+  "sa",
+  "bv",
+  "oy",
+  "ab",
+]);
+
+// Normalize a company name to a comparison key:
+//   - strip diacritics (José -> jose)
+//   - lowercase
+//   - drop punctuation (keep alnum + spaces)
+//   - collapse whitespace
+//   - drop trailing legal-entity suffix tokens
+function normalizeName(raw) {
+  if (typeof raw !== "string") return "";
+  let s = raw.normalize("NFKD").replace(/[̀-ͯ]/g, ""); // strip Latin diacritics
+  s = s.toLowerCase();
+  // Drop punctuation but KEEP Unicode letters/digits — many CIS company
+  // names are Cyrillic; stripping to ASCII would normalize "Яндекс" to ""
+  // and the helper would then mislabel a genuinely new company as a dup.
+  s = s.replace(/[^\p{L}\p{N}\s]/gu, " "); // punctuation -> space
+  s = s.replace(/\s+/g, " ").trim();
+  if (!s) return "";
+  let tokens = s.split(" ");
+  // Peel trailing legal suffixes (e.g. "... inc", "... co ltd").
+  while (tokens.length > 1 && LEGAL_SUFFIXES.has(tokens[tokens.length - 1])) {
+    tokens.pop();
+  }
+  return tokens.join(" ");
+}
+
+// Partition candidate names into fresh (unknown) and dupes (already known).
+// `knownNames` is a Set of *normalized* names. Preserves the original casing
+// of the candidate in the output and dedups within the candidate list itself.
+function partitionCandidates(candidateNames, knownNames) {
+  const fresh = [];
+  const dupes = [];
+  const seenThisRun = new Set();
+  for (const name of candidateNames) {
+    const key = normalizeName(name);
+    if (!key) continue; // empty / junk
+    if (knownNames.has(key) || seenThisRun.has(key)) {
+      dupes.push(name);
+    } else {
+      fresh.push(name);
+      seenThisRun.add(key);
+    }
+  }
+  return { fresh, dupes };
+}
+
+// Read the first (name) column of a TSV, skipping the header row.
+// Missing file -> empty array (rejects.tsv may not exist on first run).
+function readNameColumn(filePath) {
+  if (!filePath || !fs.existsSync(filePath)) return [];
+  const text = fs.readFileSync(filePath, "utf8");
+  const lines = text.split(/\r?\n/).filter((l) => l.length > 0);
+  if (lines.length <= 1) return []; // header only or empty
+  return lines.slice(1).map((line) => line.split("\t")[0]);
+}
+
+// Single I/O point: load both ledgers into one normalized Set.
+function loadKnownNames(targetsPath, rejectsPath) {
+  const known = new Set();
+  for (const name of [...readNameColumn(targetsPath), ...readNameColumn(rejectsPath)]) {
+    const key = normalizeName(name);
+    if (key) known.add(key);
+  }
+  return known;
+}
+
+function profilePaths(profileId) {
+  // Resolve relative to CWD (repo root), matching profile_loader's
+  // `path.resolve("profiles")` convention — NOT __dirname. This decouples
+  // the script's location from the data's location, so the same script
+  // works from main checkout, a worktree, or the installed ~/.ai-job-searcher.
+  const base = path.resolve("profiles", profileId);
+  return {
+    targets: path.join(base, "ru_friendly_targets.tsv"),
+    rejects: path.join(base, "ru_friendly_rejects.tsv"),
+  };
+}
+
+function main(argv) {
+  const args = argv.slice(2);
+  let profileId = null;
+  const names = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--profile") {
+      profileId = args[++i];
+    } else {
+      names.push(args[i]);
+    }
+  }
+  if (!profileId) {
+    console.error("usage: sweep_dedup.js --profile <id> <name> [<name> ...]");
+    process.exit(2);
+  }
+  const { targets, rejects } = profilePaths(profileId);
+  const known = loadKnownNames(targets, rejects);
+  const { fresh, dupes } = partitionCandidates(names, known);
+  const verdict = new Map();
+  for (const n of fresh) verdict.set(n, "FRESH");
+  for (const n of dupes) verdict.set(n, "DUP");
+  for (const n of names) {
+    const v = verdict.get(n) || "DUP"; // empty/junk treated as DUP (skip)
+    console.log(`${v}\t${n}`);
+  }
+}
+
+if (require.main === module) {
+  main(process.argv);
+}
+
+module.exports = {
+  normalizeName,
+  partitionCandidates,
+  readNameColumn,
+  loadKnownNames,
+  LEGAL_SUFFIXES,
+};

--- a/scripts/relokant/sweep_dedup.test.js
+++ b/scripts/relokant/sweep_dedup.test.js
@@ -1,0 +1,77 @@
+const test = require("node:test");
+const assert = require("node:assert");
+
+const { normalizeName, partitionCandidates } = require("./sweep_dedup.js");
+
+test("normalizeName lowercases and trims", () => {
+  assert.strictEqual(normalizeName("  Krisp  "), "krisp");
+  assert.strictEqual(normalizeName("SuperAnnotate"), "superannotate");
+});
+
+test("normalizeName strips diacritics", () => {
+  assert.strictEqual(normalizeName("José"), "jose");
+  assert.strictEqual(normalizeName("Café Möller"), "cafe moller");
+});
+
+test("normalizeName drops punctuation and collapses whitespace", () => {
+  assert.strictEqual(normalizeName("Virto   Commerce"), "virto commerce");
+  assert.strictEqual(normalizeName("ID-Finance!!"), "id finance");
+});
+
+test("normalizeName peels trailing legal suffixes", () => {
+  assert.strictEqual(normalizeName("Virto Commerce, Inc."), "virto commerce");
+  assert.strictEqual(normalizeName("Acme Co Ltd"), "acme");
+  // suffix-only name is kept (don't strip down to empty)
+  assert.strictEqual(normalizeName("Inc"), "inc");
+});
+
+test("normalizeName matches across legal-suffix / casing variants", () => {
+  assert.strictEqual(normalizeName("Virto Commerce"), normalizeName("virto commerce  inc"));
+});
+
+test("normalizeName keeps Cyrillic (CIS-domain names) instead of emptying them", () => {
+  // CIS company names are often Cyrillic — must survive normalization so a
+  // genuinely new company is not mislabeled DUP and silently dropped.
+  assert.strictEqual(normalizeName("Яндекс"), "яндекс");
+  assert.strictEqual(normalizeName("  ВкусВилл!! "), "вкусвилл");
+  assert.notStrictEqual(normalizeName("Яндекс"), normalizeName("Озон"));
+});
+
+test("partitionCandidates treats a fresh Cyrillic name as fresh, not dup", () => {
+  const known = new Set([normalizeName("Яндекс")]);
+  const { fresh, dupes } = partitionCandidates(["Озон", "яндекс"], known);
+  assert.deepStrictEqual(fresh, ["Озон"]);
+  assert.deepStrictEqual(dupes, ["яндекс"]);
+});
+
+test("normalizeName returns empty for junk", () => {
+  assert.strictEqual(normalizeName(""), "");
+  assert.strictEqual(normalizeName("!!!"), "");
+  assert.strictEqual(normalizeName(null), "");
+});
+
+test("partitionCandidates splits fresh vs known dupes", () => {
+  const known = new Set([normalizeName("Miro"), normalizeName("Wrike")]);
+  const { fresh, dupes } = partitionCandidates(["New Co", "miro", "WRIKE", "Another"], known);
+  assert.deepStrictEqual(fresh, ["New Co", "Another"]);
+  assert.deepStrictEqual(dupes, ["miro", "WRIKE"]);
+});
+
+test("partitionCandidates dedups within the candidate batch", () => {
+  const { fresh, dupes } = partitionCandidates(["New Co", "new co, inc", "New Co"], new Set());
+  assert.deepStrictEqual(fresh, ["New Co"]);
+  assert.deepStrictEqual(dupes, ["new co, inc", "New Co"]);
+});
+
+test("partitionCandidates skips junk names entirely", () => {
+  const { fresh, dupes } = partitionCandidates(["", "!!!", "Real Co"], new Set());
+  assert.deepStrictEqual(fresh, ["Real Co"]);
+  assert.deepStrictEqual(dupes, []);
+});
+
+test("partitionCandidates matches a known company through its legal suffix", () => {
+  const known = new Set([normalizeName("Virto Commerce")]);
+  const { fresh, dupes } = partitionCandidates(["Virto Commerce, LLC"], known);
+  assert.deepStrictEqual(fresh, []);
+  assert.deepStrictEqual(dupes, ["Virto Commerce, LLC"]);
+});

--- a/skills/relokant-sweep/SKILL.md
+++ b/skills/relokant-sweep/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: relokant-sweep
+description: "Repeatable sourcing sweep for the relokant sweet-zone channel — CIS-rooted companies whose product+engineering team is still Russian-speaking, selling into US/EU, mid-size, not globalized (gold standard Virto Commerce, anti-pattern Miro). One run: pull a fresh batch of candidates from not-yet-swept sources, classify by sweet-zone + US-viability, dedup against both ledgers on code, append new sweet-zone to ru_friendly_targets.tsv and rejects to ru_friendly_rejects.tsv, and draft outreach for each new US-viable target. Trigger on: /relokant-sweep, or when the user asks to source / sweep / find more relokant / CIS-rooted / ru-friendly companies for a profile."
+---
+
+# relokant-sweep — CIS-rooted company sourcing sweep
+
+Repeatable, **manual-launch** sourcing for the "relokant sweet zone"
+channel (BL-200 / RFC 061). The engine's scan adapters are deliberately
+out of scope — this is LLM-driven web research + judgement, not a
+deterministic fetch. You run it; you keep the human in the loop on the
+cheap stage (candidate review) before any outreach.
+
+**Default profile: `jared`.** All file paths below are under
+`profiles/<id>/`. Run from the repo root.
+
+---
+
+## What one run produces
+
+1. New sweet-zone companies appended to `profiles/<id>/ru_friendly_targets.tsv`.
+2. Rejected companies appended to `profiles/<id>/ru_friendly_rejects.tsv`
+   with a reason (memory of the sweep — next run won't re-research them).
+3. An outreach draft for each **new US-viable** target (contact +
+   message). **Drafts only — the user sends them by hand.**
+4. A short run report + an updated source-rotation log.
+
+---
+
+## Classification — the sweet zone
+
+A company **passes** only if ALL four hold:
+
+1. Founded in CIS / post-Soviet.
+2. Product + engineering team still predominantly Russian-speaking
+   (hubs: Yerevan, Tbilisi, Belgrade, Limassol/Cyprus, Warsaw, Lisbon,
+   Almaty, Tashkent).
+3. Sells into US/EU (western comp band, remote-friendly).
+4. Mid-size, NOT globalized (US-HQ + English-internal + "we hire anyone"
+   = drops out).
+
+Two rejection modes (record in rejects with the reason):
+
+- **`too_globalized`** — Miro, Wrike, Preply, People.ai, Ecwid/Lightspeed.
+  Already American, the ru-signal is dead.
+- **`wrong_market`** — Russian-speaking team but sells into CIS/LatAm/SEA,
+  i.e. non-western comp band (inDrive, ID Finance, Skyeng, Refocus,
+  YouTravel, Mate academy). UA-companies are excluded from targeting
+  (user decision 2026-06-22) — record them here too.
+
+**US-viability is a SOFT signal, not a hard filter.** The question is not
+"does this company post a US-remote product role" but "would it make an
+EXCEPTION the way Virto did": the company has a US client → on-the-ground
+US management is valuable + the candidate is already in the US (no
+relocation) + green card (no visa friction). The mechanism is outreach to
+the founder / Head of Product, not an ATS apply. Flag the level in the
+`us_viability` column (HIGH / exception / WEAK / unverified) — never drop
+a company just because it has no public US-remote posting.
+
+---
+
+## Run steps
+
+### 1. Load the ledgers
+
+Read both TSVs into a known-names set so you never re-surface a company.
+This is on code, not on your memory:
+
+```
+node scripts/relokant/sweep_dedup.js --profile <id> "Name A" "Name B" ...
+```
+
+It prints `FRESH\t<name>` or `DUP\t<name>` per input. You pass candidate
+names here in step 4 before appending. (`ru_friendly_rejects.tsv` may not
+exist on the very first run — the helper treats a missing file as empty.)
+
+### 2. Pick the next source batch
+
+Rotate through sources so a run covers new ground instead of re-opening
+relokant trackers every time. **Read the rotation log first:**
+
+```
+profiles/<id>/.relokant-state/sources_log.md
+```
+
+It records which sources each past run covered and the date. Pick the
+2–3 sources that are stalest (or never touched). Source pool:
+
+- relocant trackers / "relocation" startup lists;
+- VC portfolios with CIS roots (Runa Capital, Begin Capital,
+  ex-Yandex / JetBrains / Wrike spinouts);
+- Crunchbase filter: founder-education CIS + HQ US/EU;
+- communities (RAIN, RusBase, Telegram tech channels, Yerevan / Tbilisi /
+  Belgrade tech hubs);
+- LinkedIn founder-search (CIS-educated founders, US/EU HQ);
+- Habr company blogs of teams going global.
+
+Do the actual research with `firecrawl_search` / `web_search_exa`. Keep
+queries specific (founder name + city + "product", VC + "portfolio", etc.).
+
+### 3. Classify each candidate
+
+For every company you surface, apply the 4 sweet-zone criteria and assign
+a US-viability level. Capture: website, ru_signal (founder + city),
+market, us_viability, candidate contact (founder / Head of Product),
+open_roles_url, ATS slug if any, notes.
+
+### 4. Dedup
+
+Collect all candidate names and pass them through the helper (step 1).
+Drop everything marked `DUP` silently — those are already in targets or
+rejects. Only `FRESH` names proceed.
+
+### 5. Append
+
+- **Sweet-zone (FRESH)** → append a row to `ru_friendly_targets.tsv`.
+  Match the existing 10-column schema exactly (header in the file):
+  `name`, `website`, `ru_signal`, `market`, `us_viability`, `channel`,
+  `ats`, `contact`, `open_roles_url`, `notes`. Tab-separated. Set
+  `us_viability` to the level you judged.
+- **Rejects (FRESH)** → append a row to `ru_friendly_rejects.tsv`:
+  `name`, `reason` (`too_globalized` / `wrong_market` / `other`),
+  `note`, `date`. Tab-separated.
+
+Never write a `DUP` to either file. Never edit existing rows — append only.
+
+### 6. Outreach drafts (new US-viable only)
+
+For each new target with US-viability HIGH or "exception", produce:
+
+- the best contact (founder or Head of Product, with a source for the name);
+- a short outreach draft in the same style as the existing top-3 drafts
+  (see `profiles/<id>/outbound-strategy.md` if present). Neutral, specific
+  to the company's US client wedge — not a generic "I'm looking for work".
+
+**You draft; the user sends.** Do not auto-send anything.
+
+### 7. Update the rotation log + report
+
+Append a dated entry to `profiles/<id>/.relokant-state/sources_log.md`:
+which sources you swept, how many candidates seen, how many new targets /
+rejects / dupes. Then report to the user in chat:
+
+> Swept N candidates from <sources>. K new sweet-zone (→ targets), M
+> rejected (→ rejects), D dupes filtered. New US-viable: <names>.
+
+---
+
+## Cadence
+
+Run manually every 2–4 weeks. If you later want it automated, you can
+layer `/schedule` on top of this skill (a routine that invokes
+`/relokant-sweep`) — the skill mechanics don't change. Auto-cron is not
+part of RFC 061.
+
+---
+
+## Hard rules
+
+- **Append only.** Never rewrite or delete existing TSV rows.
+- **Dedup on code.** Always run names through `sweep_dedup.js` before
+  appending — do not rely on remembering what's already there.
+- **Drafts only for outreach.** The user sends messages by hand.
+- **No engine changes.** If a sweep needs the scan engine / a new
+  discovery adapter, stop and open an RFC — that's out of scope here.
+- **PII stays in profiles/.** These TSVs are gitignored personal data;
+  never echo a real contact's details into a committed file.


### PR DESCRIPTION
## What

Implements **BL-200** per **[RFC 061](rfc/061-relokant-sourcing-process.md)**: a repeatable sourcing process for the "relokant sweet-zone" channel — CIS-rooted companies whose product+engineering team is still Russian-speaking, selling into US/EU, mid-size, not globalized (gold standard Virto Commerce, anti-pattern Miro).

## Mechanism (RFC-chosen)

Standalone **manual-launch** Claude skill `/relokant-sweep`. Not cron, not an engine CLI command — the sweep is LLM-driven web research + judgement, which doesn't fit the deterministic `engine/` discovery pattern (BL-200 keeps the scan engine out of scope). `/schedule` can be layered on top later without changing mechanics.

## Changes

- `skills/relokant-sweep/SKILL.md` — documented one-run workflow: load ledgers → rotate sources → classify (four-part sweet-zone + soft US-viability) → dedup → append → draft founder outreach → log.
- `scripts/relokant/sweep_dedup.js` (+ test) — **dedup on code, not on the model**. Pure name-normalize (lowercase, strip Latin diacritics, drop punctuation while **keeping Cyrillic** for the CIS domain, peel legal suffixes) + partition candidates into fresh/dup against both per-profile ledgers, so a run never re-researches a known company.
- `rfc/061-relokant-sourcing-process.md` — design + chosen mechanism.
- `README.md` — channel description + inventory + how to run.

## Out of scope (per RFC)

Auto-send outreach (drafts only), engine/discovery changes, auto-cron.

## Personal data

The per-profile ledgers (`ru_friendly_targets.tsv`, `ru_friendly_rejects.tsv`) and the rotation-state log are gitignored personal data and stay local — not in this PR.

## Tests

`12/12` on the dedup helper, incl. Cyrillic + legal-suffix + within-batch dedup cases. One unrelated pre-existing failure in `engine/cli.test.js:164` (a regex `/at .+\.js/` matches `.json` in the worktree path) is untouched by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)