### PR TITLE
feat(relokant): BL-202 / RFC 062 — auto-upsert sweep companies into Notion

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ node engine/cli.js <command> --profile <id> [flags]
 | `answer` | Generate or reuse application answers and push back to Notion Q&A DB. |
 | `retro-tailor` | Re-tailor Strong rows currently in `To Apply` whose resume predates the RFC-044 tailoring loop. |
 | `backfill-outreach-url` | One-shot: fill the LinkedIn people-search URL for existing `To Apply` / `Applied` rows that predate the RFC-059 outreach feature. Dry-run by default; `--apply` writes TSV + Notion. Idempotent. |
+| `companies-upsert` | Push relokant-sweep sweet-zone targets into the Notion Companies DB, two-way deduped (domain + name vs Notion / `data/companies.tsv` / relokant ledgers). Back-fills empty fields only; never writes `Tier`. Dry-run by default; `--apply` writes. (RFC 062) |
 
 `node engine/cli.js --help` prints the same list with full flag docs.
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -55,6 +55,8 @@ Three invariants follow:
 | `jobs_tsv.js` | Shared `data/jobs.tsv` reader/writer. | `commands/scan.js`, dedup |
 | `companies.js` | `data/companies.tsv` reader/writer. | `commands/scan.js`, `company_resolver.js` |
 | `company_resolver.js` | Lookup-or-create company in the per-profile Notion Companies DB; in-memory cache. | `commands/sync.js` (push) |
+| `company_keys.js` | Shared company-identity keys for dedup: `normalizeName` (Cyrillic-safe, legal-suffix peeling) + `normalizeDomain`. | `companies_upsert.js`, `scripts/relokant/sweep_dedup.js` |
+| `companies_upsert.js` | Pure create/fill/skip planner for pushing relokant-sweep targets into the Notion Companies DB (two-way dedup, fill-gaps, never writes `Tier`). [RFC 062](../../rfc/062-companies-notion-upsert.md). | `commands/companies_upsert.js` |
 | `notion_sync.js` | Hybrid Notion client wrapper. Direct API for fast ops (`updatePageStatus`, `addPageComment`, `createJobPage`), batch queue for bulk push. SDK v5 compliant — uses `dataSources.query` and skips empty values. | `commands/sync.js`, `commands/check.js`, `commands/prepare.js` |
 | `fit_prompt.js` | Assembles the per-profile fit-evaluation prompt. | `commands/prepare.js` |
 | `jd_cache.js` | JD fetch + cache for Greenhouse, Lever, Workday (JSON), iCIMS (HTML scrape), Taleo (HTML scrape, JSON-LD-preferred). Other sources surface `unsupported`. | `commands/prepare.js`, `jd_extract.js` |
@@ -126,6 +128,23 @@ the Notion `LinkedIn Search` field via a targeted single-field
 status). Idempotent — rows that already have a URL are skipped. Does not
 break pull-only: it creates no pages and touches no operator-owned field,
 only the engine-owned URL.
+
+**`companies-upsert`**. Pushes relokant-sweep sweet-zone targets
+(`profiles/<id>/ru_friendly_targets.tsv`) into the per-profile Notion
+Companies DB (BL-202 / RFC 062). Reuses the same Notion path the pipeline
+already uses for the Companies DB (`pages.create` with
+`parent: { database_id }`, data source via `resolveDataSourceId`), but
+adds two-way dedup and back-fill. Dedup is on code via `company_keys.js`
+(domain primary, name fallback) against three sources — existing Notion
+pages, `data/companies.tsv`, and the relokant ledgers — so a company the
+pipeline already created is never duplicated. The create/fill/skip
+decision is the pure planner in `core/companies_upsert.js`; the command is
+the side-effect shell. Existing pages are back-filled on empty mapped
+fields only (Website, Careers URL, Why Interested, Notes, Outbound Status);
+`Tier` is never written. Dry-run by default; `--apply` commits. Preserves
+the Notion-write invariant ([RFC 022](../../rfc/022-prepare-commit-atomic-notion.md)):
+the relokant-sweep skill never writes Notion directly, it invokes this
+command.
 
 ## 3. Discovery adapters
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -25,6 +25,7 @@ Commands:
 | `indeed-prep` | Print Indeed scan playbook for a browser MCP. Phase 1 of the Indeed ingest flow. |
 | `reclassify` | Re-run the email classifier across historical `OTHER` entries in `processed_messages.json` (30-day window). Dry-run by default. |
 | `retro-tailor` | Re-tailor Strong rows already in `To Apply` whose resume predates the RFC-044 tailoring loop. Recon by default; `--apply --results-file` commits. |
+| `companies-upsert` | Push relokant-sweep sweet-zone targets into the Notion Companies DB, two-way deduped (domain + name vs Notion / `data/companies.tsv` / relokant ledgers). Back-fills empty fields only; never writes `Tier`. Dry-run by default; `--apply` commits. (RFC 062) |
 
 The dispatcher also runs deterministic pre-command hooks (BL-151 / RFC 054). Today both `scan` and `prepare` auto-trigger `sync --apply` before their main work runs, so downstream filters / cap counters / fit-eval read fresh Notion state. The sync command itself also archives engine-tailored CV/CL files for rows whose status moved past `To Apply` (Applied / Interview / Offer / Rejected / Closed / No Response). The pre-hook is suppressed by `--no-sync`; `scan --dry-run` also suppresses it for parity with the prior dry-run-never-mutates behaviour.
 

--- a/engine/cli.js
+++ b/engine/cli.js
@@ -24,6 +24,7 @@ const KNOWN_COMMANDS = [
   "reclassify",
   "retro-tailor",
   "backfill-outreach-url",
+  "companies-upsert",
 ];
 
 const PARSE_OPTIONS = {
@@ -96,6 +97,14 @@ Commands:
              --apply computes the URL, writes it to TSV, and pushes it to the
              Notion "LinkedIn Search" field via a targeted page update.
              Idempotent — a second run is a no-op. See RFC 059 / BL-186.
+  companies-upsert
+             Push relokant-sweep sweet-zone targets (ru_friendly_targets.tsv)
+             into the per-profile Notion Companies DB, two-way deduped (by
+             domain + name against existing Notion pages, data/companies.tsv,
+             and the relokant ledgers). Existing pages are back-filled on empty
+             fields only; Tier is never written. Dry-run by default (prints
+             "N to create, M to fill, K skip"); --apply commits. See RFC 062 /
+             BL-202.
 
 Flags:
   --profile <id>       Profile id (required for all commands). Lowercase, alphanum + - _.
@@ -220,6 +229,7 @@ function defaultCommands() {
     reclassify: require("./commands/reclassify.js"),
     "retro-tailor": require("./commands/retro_tailor.js"),
     "backfill-outreach-url": require("./commands/backfill_outreach_url.js"),
+    "companies-upsert": require("./commands/companies_upsert.js"),
   };
 }
 

--- a/engine/cli.test.js
+++ b/engine/cli.test.js
@@ -202,6 +202,7 @@ test("KNOWN_COMMANDS lists exactly the supported commands", () => {
     "answer",
     "backfill-outreach-url",
     "check",
+    "companies-upsert",
     "indeed-prep",
     "prepare",
     "reclassify",

--- a/engine/commands/companies_upsert.js
+++ b/engine/commands/companies_upsert.js
@@ -1,0 +1,251 @@
+// `companies-upsert` command (RFC 062): push relokant-sweep sweet-zone targets
+// into the per-profile Notion Companies DB, two-way deduped, fill-gaps.
+//
+// Reuses the same Notion path the job pipeline already uses to populate the
+// Companies DB (lookup-or-create by name, `pages.create` with
+// `parent: { database_id }`, data_source resolved via notion_sync). The
+// difference vs company_resolver: relokant rows carry extra fields, dedup is by
+// domain AND name, and existing pages are back-filled (empty fields only).
+//
+// Default mode is dry-run (prints the plan). `--apply` writes to Notion.
+//
+// Side effects live here; the create/fill/skip decision is the pure core in
+// engine/core/companies_upsert.js.
+
+const fs = require("fs");
+const path = require("path");
+
+const profileLoader = require("../core/profile_loader.js");
+const { secretEnvName } = profileLoader;
+const notion = require("../core/notion_sync.js");
+const { resolveProfilesDir } = require("../core/paths.js");
+const { planUpsert, buildKnownIndex } = require("../core/companies_upsert.js");
+
+// ---- TSV readers (single I/O point; injectable for tests) ----
+
+// Parse the 10-column relokant targets TSV into row objects keyed by header.
+function readTargetsRows(targetsPath) {
+  if (!targetsPath || !fs.existsSync(targetsPath)) return [];
+  const text = fs.readFileSync(targetsPath, "utf8");
+  const lines = text.split(/\r?\n/).filter((l) => l.length > 0);
+  if (lines.length <= 1) return [];
+  const header = lines[0].split("\t");
+  return lines.slice(1).map((line) => {
+    const cells = line.split("\t");
+    const row = {};
+    header.forEach((h, i) => {
+      row[h] = (cells[i] || "").trim();
+    });
+    return row;
+  });
+}
+
+// Read the first (name) column of a TSV, skipping the header. Missing file -> [].
+function readNamesColumn(filePath) {
+  if (!filePath || !fs.existsSync(filePath)) return [];
+  const text = fs.readFileSync(filePath, "utf8");
+  const lines = text.split(/\r?\n/).filter((l) => l.length > 0);
+  if (lines.length <= 1) return [];
+  return lines.slice(1).map((line) => line.split("\t")[0]);
+}
+
+// ---- Notion property extraction / construction ----
+
+// Read a Notion property's text value. Probed by shape in priority order; the
+// Companies schema guarantees one shape per field (a field is title OR url OR
+// rich_text OR select), so the order never masks a real value.
+function extractText(prop) {
+  if (!prop) return "";
+  if (Array.isArray(prop.title)) return prop.title.map((t) => t.plain_text || "").join("");
+  if (Array.isArray(prop.rich_text)) return prop.rich_text.map((t) => t.plain_text || "").join("");
+  if (prop.url) return prop.url;
+  if (prop.select && prop.select.name) return prop.select.name;
+  return "";
+}
+
+// Turn a Notion page into the shape buildKnownIndex expects.
+function pageToKnown(page) {
+  const props = page.properties || {};
+  const values = {};
+  for (const field of ["Website", "Careers URL", "Why Interested", "Notes", "Outbound Status"]) {
+    values[field] = extractText(props[field]);
+  }
+  return {
+    pageId: page.id,
+    name: extractText(props.Name),
+    website: extractText(props.Website),
+    values,
+  };
+}
+
+function toNotionProp({ type, value }) {
+  switch (type) {
+    case "title":
+      return { title: [{ text: { content: String(value) } }] };
+    case "rich_text":
+      return { rich_text: [{ text: { content: String(value) } }] };
+    case "url":
+      return { url: String(value) };
+    case "select":
+      return { select: { name: String(value) } };
+    default:
+      return { rich_text: [{ text: { content: String(value) } }] };
+  }
+}
+
+function propsToNotion(propList) {
+  const out = {};
+  for (const p of propList) out[p.field] = toNotionProp(p);
+  return out;
+}
+
+// Default Notion reader: page through the Companies data source.
+async function fetchCompaniesPages(client, dataSourceId) {
+  const pages = [];
+  let cursor;
+  do {
+    const params = { data_source_id: dataSourceId, page_size: 100 };
+    if (cursor) params.start_cursor = cursor;
+    const resp = await client.dataSources.query(params);
+    for (const page of resp.results || []) pages.push(page);
+    cursor = resp.has_more ? resp.next_cursor : undefined;
+  } while (cursor);
+  return pages;
+}
+
+const DEFAULT_DEPS = {
+  loadProfile: profileLoader.loadProfile,
+  loadSecrets: profileLoader.loadSecrets,
+  makeClient: notion.makeClient,
+  resolveDataSourceId: notion.resolveDataSourceId,
+  readTargetsRows,
+  readNamesColumn,
+  fetchCompaniesPages,
+};
+
+function makeCompaniesUpsertCommand(overrides = {}) {
+  const deps = { ...DEFAULT_DEPS, ...overrides };
+
+  return async function companiesUpsertCommand(ctx) {
+    const { profileId, flags, env, stdout, stderr } = ctx;
+    const apply = Boolean(flags.apply);
+    const profilesDir = resolveProfilesDir(ctx, env || process.env);
+    // Resolve the shared companies.tsv the SAME way scan.js does (the writer of
+    // that file): ctx.dataDir override, else <cwd>/data. Using the paths.js
+    // AI_JOB_SEARCHER_DATA_DIR resolver here would diverge from where scan
+    // actually writes the pool.
+    const dataDir = ctx.dataDir || path.resolve(process.cwd(), "data");
+
+    const profile = deps.loadProfile(profileId, { profilesDir });
+    const secrets = deps.loadSecrets(profileId, env || process.env);
+    const token = secrets.NOTION_TOKEN || null;
+    const companiesDbId = profile.notion && profile.notion.companies_db_id;
+
+    if (!companiesDbId) {
+      stderr("error: profile.notion.companies_db_id is not configured");
+      return 1;
+    }
+
+    // Candidate rows = relokant targets ledger.
+    const root = profile.paths.root;
+    const targetsPath = path.join(root, "ru_friendly_targets.tsv");
+    const rejectsPath = path.join(root, "ru_friendly_rejects.tsv");
+    const companiesTsvPath = path.join(dataDir, "companies.tsv");
+
+    const rows = deps.readTargetsRows(targetsPath);
+    if (!rows.length) {
+      stdout("no relokant targets found — nothing to upsert.");
+      return 0;
+    }
+
+    const ledgerNames = [
+      ...deps.readNamesColumn(targetsPath),
+      ...deps.readNamesColumn(rejectsPath),
+    ];
+    const tsvNames = deps.readNamesColumn(companiesTsvPath);
+
+    // Notion read: the authoritative existing-pages source. Without a token we
+    // cannot read Notion — degrade to tsv/ledger-only dedup and warn.
+    let notionPages = [];
+    let client = null;
+    if (token) {
+      try {
+        client = deps.makeClient(token);
+        const dataSourceId = await deps.resolveDataSourceId(client, companiesDbId);
+        const pages = await deps.fetchCompaniesPages(client, dataSourceId);
+        notionPages = pages.map(pageToKnown);
+      } catch (err) {
+        stderr(`error: failed to read Notion Companies DB: ${err.message}`);
+        return 1;
+      }
+    } else {
+      stderr(
+        `warn: missing ${secretEnvName(profileId, "NOTION_TOKEN")} — Notion state unknown; ` +
+          `plan computed against data/companies.tsv + relokant ledgers only.`
+      );
+    }
+
+    const known = buildKnownIndex({ notionPages, tsvNames, ledgerNames });
+    const { creates, fills, skips } = planUpsert({ rows, known });
+
+    stdout(
+      `plan: ${creates.length} to create, ${fills.length} to fill, ${skips.length} already there (skip)`
+    );
+    for (const c of creates) stdout(`  create: ${c.name}`);
+    for (const f of fills) {
+      stdout(`  fill:   ${f.name} (${f.props.map((p) => p.field).join(", ")})`);
+    }
+
+    if (!apply) {
+      stdout("dry-run — no changes written. Re-run with --apply to commit.");
+      return 0;
+    }
+    if (!token) {
+      stderr(
+        `warn: ${secretEnvName(profileId, "NOTION_TOKEN")} missing — --apply is a no-op. ` +
+          `Add the token to .env and re-run.`
+      );
+      return 1;
+    }
+
+    let created = 0;
+    let filled = 0;
+    let errors = 0;
+    for (const c of creates) {
+      try {
+        await client.pages.create({
+          parent: { database_id: companiesDbId },
+          properties: propsToNotion(c.props),
+        });
+        created++;
+        stdout(`  created: ${c.name}`);
+      } catch (err) {
+        errors++;
+        stderr(`  error creating ${c.name}: ${err.message}`);
+      }
+    }
+    for (const f of fills) {
+      try {
+        await client.pages.update({
+          page_id: f.pageId,
+          properties: propsToNotion(f.props),
+        });
+        filled++;
+        stdout(`  filled: ${f.name}`);
+      } catch (err) {
+        errors++;
+        stderr(`  error filling ${f.name}: ${err.message}`);
+      }
+    }
+
+    stdout(`done: created ${created}, filled ${filled}, errors ${errors}.`);
+    return errors > 0 ? 1 : 0;
+  };
+}
+
+module.exports = makeCompaniesUpsertCommand();
+module.exports.makeCompaniesUpsertCommand = makeCompaniesUpsertCommand;
+module.exports.readTargetsRows = readTargetsRows;
+module.exports.readNamesColumn = readNamesColumn;
+module.exports.pageToKnown = pageToKnown;
+module.exports.propsToNotion = propsToNotion;

--- a/engine/commands/companies_upsert.test.js
+++ b/engine/commands/companies_upsert.test.js
@@ -1,0 +1,159 @@
+const test = require("node:test");
+const assert = require("node:assert");
+
+const { makeCompaniesUpsertCommand } = require("./companies_upsert.js");
+
+function targetRow(over = {}) {
+  return {
+    name: "New Co",
+    website: "newco.com",
+    ru_signal: "RU founder (Yerevan)",
+    market: "US SaaS",
+    us_viability: "HIGH",
+    channel: "outreach",
+    ats: "",
+    contact: "Jane Doe (CEO)",
+    open_roles_url: "https://newco.com/careers",
+    notes: "early stage",
+    ...over,
+  };
+}
+
+function makeCtx(over = {}) {
+  const out = [];
+  const err = [];
+  return {
+    ctx: {
+      profileId: "jared",
+      flags: { apply: false },
+      env: {},
+      profilesDir: "/fake/profiles",
+      stdout: (s) => out.push(s),
+      stderr: (s) => err.push(s),
+      ...over,
+    },
+    out,
+    err,
+  };
+}
+
+function fakeClient(recorder) {
+  return {
+    pages: {
+      create: async (args) => {
+        recorder.creates.push(args);
+        return { id: `created-${recorder.creates.length}` };
+      },
+      update: async (args) => {
+        recorder.updates.push(args);
+        return { id: args.page_id };
+      },
+    },
+  };
+}
+
+function baseDeps(overrides = {}) {
+  return {
+    loadProfile: () => ({
+      paths: { root: "/fake/profiles/jared" },
+      notion: { companies_db_id: "db-123" },
+    }),
+    loadSecrets: () => ({ NOTION_TOKEN: "secret-token" }),
+    makeClient: () => overrides.__client,
+    resolveDataSourceId: async () => "ds-123",
+    readTargetsRows: () => [targetRow()],
+    readNamesColumn: () => [],
+    fetchCompaniesPages: async () => [],
+    ...overrides,
+  };
+}
+
+test("dry-run: plans a create, writes nothing", async () => {
+  const rec = { creates: [], updates: [] };
+  const client = fakeClient(rec);
+  const cmd = makeCompaniesUpsertCommand(baseDeps({ __client: client, makeClient: () => client }));
+  const { ctx, out } = makeCtx({ flags: { apply: false } });
+  const code = await cmd(ctx);
+  assert.strictEqual(code, 0);
+  assert.strictEqual(rec.creates.length, 0);
+  assert.ok(out.some((l) => l.includes("1 to create")));
+  assert.ok(out.some((l) => l.includes("dry-run")));
+});
+
+test("--apply: creates a Notion page for the new company", async () => {
+  const rec = { creates: [], updates: [] };
+  const client = fakeClient(rec);
+  const cmd = makeCompaniesUpsertCommand(baseDeps({ __client: client, makeClient: () => client }));
+  const { ctx } = makeCtx({ flags: { apply: true } });
+  const code = await cmd(ctx);
+  assert.strictEqual(code, 0);
+  assert.strictEqual(rec.creates.length, 1);
+  assert.deepStrictEqual(rec.creates[0].parent, { database_id: "db-123" });
+  assert.ok(rec.creates[0].properties.Name);
+  assert.ok(rec.creates[0].properties.Website);
+  assert.ok(!rec.creates[0].properties.Tier);
+});
+
+test("--apply: existing page with empty fields gets a fill, not a create", async () => {
+  const rec = { creates: [], updates: [] };
+  const client = fakeClient(rec);
+  const cmd = makeCompaniesUpsertCommand(
+    baseDeps({
+      __client: client,
+      makeClient: () => client,
+      fetchCompaniesPages: async () => [
+        {
+          id: "page-existing",
+          properties: {
+            Name: { title: [{ plain_text: "New Co" }] },
+            Website: { url: "https://newco.com" },
+            Notes: { rich_text: [] },
+            "Why Interested": { rich_text: [{ plain_text: "kept" }] },
+            "Careers URL": { url: "" },
+            "Outbound Status": { select: { name: "Contacted" } },
+          },
+        },
+      ],
+    })
+  );
+  const { ctx } = makeCtx({ flags: { apply: true } });
+  const code = await cmd(ctx);
+  assert.strictEqual(code, 0);
+  assert.strictEqual(rec.creates.length, 0);
+  assert.strictEqual(rec.updates.length, 1);
+  assert.strictEqual(rec.updates[0].page_id, "page-existing");
+  // only the empty fields (Notes, Careers URL) get patched
+  const patched = Object.keys(rec.updates[0].properties).sort();
+  assert.deepStrictEqual(patched, ["Careers URL", "Notes"]);
+});
+
+test("missing token: --apply is a no-op with exit 1", async () => {
+  const rec = { creates: [], updates: [] };
+  const client = fakeClient(rec);
+  const cmd = makeCompaniesUpsertCommand(
+    baseDeps({ __client: client, makeClient: () => client, loadSecrets: () => ({}) })
+  );
+  const { ctx, err } = makeCtx({ flags: { apply: true } });
+  const code = await cmd(ctx);
+  assert.strictEqual(code, 1);
+  assert.strictEqual(rec.creates.length, 0);
+  assert.ok(err.some((l) => l.includes("NOTION_TOKEN")));
+});
+
+test("missing companies_db_id -> error exit 1", async () => {
+  const cmd = makeCompaniesUpsertCommand(
+    baseDeps({ loadProfile: () => ({ paths: { root: "/x" }, notion: {} }) })
+  );
+  const { ctx, err } = makeCtx({});
+  const code = await cmd(ctx);
+  assert.strictEqual(code, 1);
+  assert.ok(err.some((l) => l.includes("companies_db_id")));
+});
+
+test("no targets -> clean exit 0", async () => {
+  const cmd = makeCompaniesUpsertCommand(baseDeps({ readTargetsRows: () => [] }));
+  const { ctx, out } = makeCtx({});
+  const code = await cmd(ctx);
+  assert.strictEqual(code, 0);
+  assert.ok(out.some((l) => l.includes("no relokant targets")));
+});

--- a/engine/core/companies_upsert.js
+++ b/engine/core/companies_upsert.js
@@ -1,0 +1,182 @@
+// RFC 062 — relokant-sweep → Notion Companies upsert (pure core).
+//
+// Given parsed relokant target rows and a known-set built from the three
+// sources that feed the Companies DB (existing Notion pages, data/companies.tsv,
+// the relokant ledgers), decide for each candidate whether to CREATE a new
+// Notion page, FILL empty fields on an existing page, or SKIP it.
+//
+// Pure: no Notion client, no fs, no network. The command shell does the I/O,
+// hands this module plain in-memory data, and turns the returned field
+// descriptors into Notion property objects.
+//
+// Dedup is on code (two keys): a candidate matches an existing company if
+// EITHER its normalized domain OR its normalized name is already known.
+// Fill-gaps: on an existing Notion page, only empty mapped fields are written;
+// a non-empty value is never overwritten and nothing is deleted. `Tier` is
+// never written (it is the operator's pipeline judgement).
+
+const { normalizeName, normalizeDomain } = require("./company_keys.js");
+
+// Build the full website URL stored in the `Website` property from the TSV
+// `website` column ("lokalise.com" -> "https://lokalise.com"; an already-
+// schemed value is kept as-is).
+function websiteUrl(website) {
+  const s = (website || "").trim();
+  if (!s) return "";
+  return /^[a-z][a-z0-9+.-]*:\/\//i.test(s) ? s : `https://${s}`;
+}
+
+function whyInterested(row) {
+  // Strip a trailing period so the formatter's own "." doesn't double up
+  // ("US SaaS." -> "US SaaS" -> "US SaaS.").
+  const ru = (row.ru_signal || "").trim().replace(/\.+$/, "");
+  const market = (row.market || "").trim().replace(/\.+$/, "");
+  if (!ru && !market) return "";
+  const parts = [];
+  if (ru) parts.push(`CIS-edge: ${ru}.`);
+  if (market) parts.push(`${market}.`);
+  return parts.join(" ").trim();
+}
+
+function notesText(row) {
+  const bits = ["Relokant sweet-zone (US-HQ)."];
+  if ((row.contact || "").trim()) bits.push(`Contact: ${row.contact.trim()}.`);
+  if ((row.us_viability || "").trim()) bits.push(`US-viability: ${row.us_viability.trim()}.`);
+  if ((row.ats || "").trim()) bits.push(`ATS: ${row.ats.trim()}.`);
+  if ((row.notes || "").trim()) bits.push(row.notes.trim());
+  return bits.join(" ").trim();
+}
+
+// Declarative field map. `role`:
+//   "key"  — the title; create-only, never filled (it IS the dedup key).
+//   "fill" — written on create AND back-filled on an existing page if empty.
+const FIELD_SPECS = [
+  { field: "Name", type: "title", role: "key", from: (r) => (r.name || "").trim() },
+  { field: "Website", type: "url", role: "fill", from: (r) => websiteUrl(r.website) },
+  { field: "Careers URL", type: "url", role: "fill", from: (r) => (r.open_roles_url || "").trim() },
+  { field: "Why Interested", type: "rich_text", role: "fill", from: (r) => whyInterested(r) },
+  { field: "Notes", type: "rich_text", role: "fill", from: (r) => notesText(r) },
+  { field: "Outbound Status", type: "select", role: "fill", from: () => "Not started" },
+];
+
+function isEmpty(v) {
+  return v === undefined || v === null || String(v).trim() === "";
+}
+
+function candidateKeys(row) {
+  return {
+    nameKey: normalizeName(row.name || ""),
+    domainKey: normalizeDomain(row.website || ""),
+  };
+}
+
+// Build the known-set index from the three sources. Notion entries carry the
+// page id + current property values (for fill-gaps); tsv/ledger entries only
+// mark presence. Notion entries win when a key appears in more than one source.
+//
+//   notionPages: [{ pageId, name, website, values: { <field>: <string> } }]
+//   tsvNames:    [ "Acme", ... ]   (data/companies.tsv — name column only)
+//   ledgerNames: [ "Acme", ... ]   (relokant targets + rejects)
+function buildKnownIndex({ notionPages = [], tsvNames = [], ledgerNames = [] } = {}) {
+  const byName = new Map();
+  const byDomain = new Map();
+
+  const addPresence = (name) => {
+    const key = normalizeName(name);
+    if (key && !byName.has(key)) byName.set(key, { inNotion: false });
+  };
+  // Non-Notion sources first so a later Notion entry overwrites the bare
+  // presence marker with a real page id.
+  for (const n of tsvNames) addPresence(n);
+  for (const n of ledgerNames) addPresence(n);
+
+  for (const p of notionPages) {
+    const entry = { inNotion: true, pageId: p.pageId, values: p.values || {} };
+    const nameKey = normalizeName(p.name || "");
+    const domainKey = normalizeDomain(p.website || "");
+    if (nameKey) byName.set(nameKey, entry);
+    if (domainKey) byDomain.set(domainKey, entry);
+  }
+  return { byName, byDomain };
+}
+
+// Field descriptors for a brand-new page: every spec whose value is non-empty
+// (Name always present — a row without a name is rejected upstream).
+function createProps(row) {
+  const props = [];
+  for (const spec of FIELD_SPECS) {
+    const value = spec.from(row);
+    if (!isEmpty(value)) props.push({ field: spec.field, type: spec.type, value });
+  }
+  return props;
+}
+
+// Field descriptors to back-fill on an existing page: a "fill"-role spec whose
+// current page value is empty AND whose new value is non-empty.
+function fillProps(row, pageValues) {
+  const props = [];
+  for (const spec of FIELD_SPECS) {
+    if (spec.role !== "fill") continue;
+    if (!isEmpty(pageValues[spec.field])) continue; // never overwrite
+    const value = spec.from(row);
+    if (isEmpty(value)) continue; // nothing to add
+    props.push({ field: spec.field, type: spec.type, value });
+  }
+  return props;
+}
+
+// Partition candidate rows into { creates, fills, skips }.
+function planUpsert({ rows = [], known = { byName: new Map(), byDomain: new Map() } } = {}) {
+  const creates = [];
+  const fills = [];
+  const skips = [];
+  const seenNames = new Set();
+  const seenDomains = new Set();
+
+  for (const row of rows) {
+    const name = (row.name || "").trim();
+    const { nameKey, domainKey } = candidateKeys(row);
+    if (!nameKey) {
+      skips.push({ name, reason: "no-name" });
+      continue;
+    }
+    // In-batch collapse: same company listed twice within one run.
+    if (seenNames.has(nameKey) || (domainKey && seenDomains.has(domainKey))) {
+      skips.push({ name, reason: "in-batch-dup" });
+      continue;
+    }
+    seenNames.add(nameKey);
+    if (domainKey) seenDomains.add(domainKey);
+
+    const match = (domainKey && known.byDomain.get(domainKey)) || known.byName.get(nameKey) || null;
+
+    if (match && match.inNotion) {
+      const props = fillProps(row, match.values || {});
+      if (props.length) {
+        fills.push({ name, pageId: match.pageId, props });
+      } else {
+        skips.push({ name, reason: "already-complete" });
+      }
+    } else if (match) {
+      // Known via data/companies.tsv or the ledgers but no Notion page yet —
+      // treat as known and do NOT create a duplicate (two-way dedup).
+      skips.push({ name, reason: "known-non-notion" });
+    } else {
+      creates.push({ name, nameKey, domainKey, props: createProps(row) });
+    }
+  }
+
+  return { creates, fills, skips };
+}
+
+module.exports = {
+  planUpsert,
+  buildKnownIndex,
+  createProps,
+  fillProps,
+  candidateKeys,
+  websiteUrl,
+  whyInterested,
+  notesText,
+  FIELD_SPECS,
+};

--- a/engine/core/companies_upsert.test.js
+++ b/engine/core/companies_upsert.test.js
@@ -1,0 +1,187 @@
+const test = require("node:test");
+const assert = require("node:assert");
+
+const { planUpsert, buildKnownIndex, createProps, FIELD_SPECS } = require("./companies_upsert.js");
+
+function row(over = {}) {
+  return {
+    name: "New Co",
+    website: "newco.com",
+    ru_signal: "RU founder (Yerevan)",
+    market: "US SaaS",
+    us_viability: "HIGH",
+    channel: "outreach",
+    ats: "greenhouse:newco",
+    contact: "Jane Doe (CEO)",
+    open_roles_url: "https://newco.com/careers",
+    notes: "early stage",
+    ...over,
+  };
+}
+
+test("create: unknown company -> full props, Name + fill fields present", () => {
+  const known = buildKnownIndex({});
+  const plan = planUpsert({ rows: [row()], known });
+  assert.strictEqual(plan.creates.length, 1);
+  assert.strictEqual(plan.fills.length, 0);
+  assert.strictEqual(plan.skips.length, 0);
+  const fields = plan.creates[0].props.map((p) => p.field);
+  assert.ok(fields.includes("Name"));
+  assert.ok(fields.includes("Website"));
+  assert.ok(fields.includes("Why Interested"));
+  assert.ok(fields.includes("Notes"));
+  assert.ok(fields.includes("Outbound Status"));
+});
+
+test("Tier is never written on create", () => {
+  assert.ok(!FIELD_SPECS.some((s) => s.field === "Tier"));
+  const plan = planUpsert({ rows: [row()], known: buildKnownIndex({}) });
+  assert.ok(!plan.creates[0].props.some((p) => p.field === "Tier"));
+});
+
+test("Website value gets https:// prefix; bare domain normalized for dedup", () => {
+  const plan = planUpsert({ rows: [row({ website: "newco.com" })], known: buildKnownIndex({}) });
+  const website = plan.creates[0].props.find((p) => p.field === "Website");
+  assert.strictEqual(website.value, "https://newco.com");
+});
+
+test("dedup by domain: existing Notion page with same domain -> not created", () => {
+  const known = buildKnownIndex({
+    notionPages: [
+      {
+        pageId: "p1",
+        name: "Totally Different Name",
+        website: "https://www.newco.com/jobs",
+        values: {
+          Website: "https://newco.com",
+          Notes: "x",
+          "Why Interested": "y",
+          "Careers URL": "z",
+          "Outbound Status": "Not started",
+        },
+      },
+    ],
+  });
+  const plan = planUpsert({ rows: [row()], known });
+  assert.strictEqual(plan.creates.length, 0);
+  // all fields already present -> skip, not fill
+  assert.strictEqual(plan.skips.length, 1);
+  assert.strictEqual(plan.skips[0].reason, "already-complete");
+});
+
+test("dedup by name when no website on candidate", () => {
+  const known = buildKnownIndex({
+    notionPages: [{ pageId: "p2", name: "New Co", website: "", values: {} }],
+  });
+  const plan = planUpsert({ rows: [row({ website: "" })], known });
+  assert.strictEqual(plan.creates.length, 0);
+  assert.strictEqual(plan.fills.length, 1);
+  assert.strictEqual(plan.fills[0].pageId, "p2");
+});
+
+test("fill-gaps: only empty page fields are written, non-empty kept", () => {
+  const known = buildKnownIndex({
+    notionPages: [
+      {
+        pageId: "p3",
+        name: "New Co",
+        website: "newco.com",
+        values: {
+          Website: "https://newco.com", // non-empty -> keep
+          Notes: "", // empty -> fill
+          "Why Interested": "existing reason", // non-empty -> keep
+          "Careers URL": "", // empty -> fill
+          "Outbound Status": "Contacted", // non-empty -> keep
+        },
+      },
+    ],
+  });
+  const plan = planUpsert({ rows: [row()], known });
+  assert.strictEqual(plan.fills.length, 1);
+  const filled = plan.fills[0].props.map((p) => p.field).sort();
+  assert.deepStrictEqual(filled, ["Careers URL", "Notes"]);
+});
+
+test("known via data/companies.tsv but not in Notion -> skip, no create", () => {
+  const known = buildKnownIndex({ tsvNames: ["New Co"] });
+  const plan = planUpsert({ rows: [row()], known });
+  assert.strictEqual(plan.creates.length, 0);
+  assert.strictEqual(plan.skips.length, 1);
+  assert.strictEqual(plan.skips[0].reason, "known-non-notion");
+});
+
+test("known via relokant ledger but not in Notion -> skip", () => {
+  const known = buildKnownIndex({ ledgerNames: ["New Co"] });
+  const plan = planUpsert({ rows: [row()], known });
+  assert.strictEqual(plan.skips[0].reason, "known-non-notion");
+});
+
+test("in-batch dedup: same company twice -> one create, one skip", () => {
+  const plan = planUpsert({ rows: [row(), row()], known: buildKnownIndex({}) });
+  assert.strictEqual(plan.creates.length, 1);
+  assert.strictEqual(plan.skips.length, 1);
+  assert.strictEqual(plan.skips[0].reason, "in-batch-dup");
+});
+
+test("in-batch dedup catches same domain under different name", () => {
+  const rows = [row({ name: "New Co" }), row({ name: "Newco Inc", website: "www.newco.com" })];
+  const plan = planUpsert({ rows, known: buildKnownIndex({}) });
+  assert.strictEqual(plan.creates.length, 1);
+  assert.strictEqual(plan.skips[0].reason, "in-batch-dup");
+});
+
+test("row with no name -> skip no-name", () => {
+  const plan = planUpsert({ rows: [row({ name: "" })], known: buildKnownIndex({}) });
+  assert.strictEqual(plan.skips[0].reason, "no-name");
+  assert.strictEqual(plan.creates.length, 0);
+});
+
+test("buildKnownIndex: a Notion page upgrades a bare tsv/ledger marker (gets fill, not skip)", () => {
+  // Same company present in both data/companies.tsv (presence only) AND Notion
+  // with an empty field. The Notion entry must win so we back-fill, not treat
+  // it as a non-Notion known and skip it.
+  const known = buildKnownIndex({
+    tsvNames: ["New Co"],
+    notionPages: [{ pageId: "pX", name: "New Co", website: "", values: { Notes: "" } }],
+  });
+  const plan = planUpsert({ rows: [row({ website: "" })], known });
+  assert.strictEqual(plan.skips.length, 0);
+  assert.strictEqual(plan.fills.length, 1);
+  assert.strictEqual(plan.fills[0].pageId, "pX");
+});
+
+test("planUpsert: domain match wins over an unrelated name-key entry", () => {
+  // byDomain points at page D (complete); byName would point at page N. The
+  // domain hit must be chosen -> already-complete skip, not a fill on N.
+  const known = {
+    byDomain: new Map([
+      [
+        "newco.com",
+        {
+          inNotion: true,
+          pageId: "D",
+          values: {
+            Website: "https://newco.com",
+            Notes: "x",
+            "Why Interested": "y",
+            "Careers URL": "z",
+            "Outbound Status": "Not started",
+          },
+        },
+      ],
+    ]),
+    byName: new Map([["new co", { inNotion: true, pageId: "N", values: {} }]]),
+  };
+  const plan = planUpsert({ rows: [row()], known });
+  assert.strictEqual(plan.skips.length, 1);
+  assert.strictEqual(plan.skips[0].reason, "already-complete");
+  assert.strictEqual(plan.fills.length, 0);
+});
+
+test("createProps omits empty optional fields", () => {
+  const props = createProps(row({ open_roles_url: "", ru_signal: "", market: "" }));
+  const fields = props.map((p) => p.field);
+  assert.ok(!fields.includes("Careers URL"));
+  assert.ok(!fields.includes("Why Interested"));
+  assert.ok(fields.includes("Name"));
+});

--- a/engine/core/company_keys.js
+++ b/engine/core/company_keys.js
@@ -1,0 +1,74 @@
+// Shared company-identity keys for dedup across the pipeline.
+//
+// Two normalized keys turn a company into a comparison token:
+//   - normalizeName(raw)   — Cyrillic-safe name key (diacritics, punctuation,
+//                            legal-suffix peeling). Originally lived in
+//                            scripts/relokant/sweep_dedup.js; moved here so the
+//                            relokant sweep dedup and the Notion upsert share
+//                            ONE implementation (RFC 062).
+//   - normalizeDomain(raw) — website key (scheme / www / path stripped).
+//
+// Pure functions over strings. No I/O, no network.
+
+// Legal-entity suffixes stripped before comparison so "Virto Commerce, Inc."
+// matches "Virto Commerce". Applied as a trailing-token set.
+const LEGAL_SUFFIXES = new Set([
+  "inc",
+  "llc",
+  "ltd",
+  "limited",
+  "gmbh",
+  "corp",
+  "co",
+  "company",
+  "plc",
+  "ag",
+  "sa",
+  "bv",
+  "oy",
+  "ab",
+]);
+
+// Normalize a company name to a comparison key:
+//   - strip diacritics (José -> jose)
+//   - lowercase
+//   - drop punctuation (keep Unicode letters/digits + spaces)
+//   - collapse whitespace
+//   - drop trailing legal-entity suffix tokens
+function normalizeName(raw) {
+  if (typeof raw !== "string") return "";
+  let s = raw.normalize("NFKD").replace(/[̀-ͯ]/g, ""); // strip Latin diacritics
+  s = s.toLowerCase();
+  // Drop punctuation but KEEP Unicode letters/digits — many CIS company
+  // names are Cyrillic; stripping to ASCII would normalize "Яндекс" to ""
+  // and the dedup would then mislabel a genuinely new company as a dup.
+  s = s.replace(/[^\p{L}\p{N}\s]/gu, " "); // punctuation -> space
+  s = s.replace(/\s+/g, " ").trim();
+  if (!s) return "";
+  let tokens = s.split(" ");
+  // Peel trailing legal suffixes (e.g. "... inc", "... co ltd").
+  while (tokens.length > 1 && LEGAL_SUFFIXES.has(tokens[tokens.length - 1])) {
+    tokens.pop();
+  }
+  return tokens.join(" ");
+}
+
+// Normalize a website / URL to a domain comparison key:
+//   - lowercase
+//   - strip scheme (http://, https://)
+//   - strip a single leading "www."
+//   - drop everything from the first path / query / port separator
+//   - drop a trailing dot
+// "https://www.Lokalise.com/careers" and "lokalise.com" both -> "lokalise.com".
+function normalizeDomain(raw) {
+  if (typeof raw !== "string") return "";
+  let s = raw.trim().toLowerCase();
+  if (!s) return "";
+  s = s.replace(/^[a-z][a-z0-9+.-]*:\/\//, ""); // strip scheme
+  s = s.replace(/^www\./, ""); // strip leading www.
+  s = s.split(/[/?#:]/)[0]; // drop path / query / fragment / port
+  s = s.replace(/\.+$/, ""); // drop trailing dot(s)
+  return s.trim();
+}
+
+module.exports = { normalizeName, normalizeDomain, LEGAL_SUFFIXES };

--- a/engine/core/company_keys.test.js
+++ b/engine/core/company_keys.test.js
@@ -1,0 +1,31 @@
+const test = require("node:test");
+const assert = require("node:assert");
+
+const { normalizeName, normalizeDomain } = require("./company_keys.js");
+
+test("normalizeName: Cyrillic preserved, legal suffix peeled, casing folded", () => {
+  assert.strictEqual(normalizeName("Яндекс"), "яндекс");
+  assert.strictEqual(normalizeName("Virto Commerce, Inc."), "virto commerce");
+  assert.strictEqual(normalizeName("KRISP"), "krisp");
+});
+
+test("normalizeDomain strips scheme, www, path, query, port", () => {
+  assert.strictEqual(normalizeDomain("https://www.Lokalise.com/careers"), "lokalise.com");
+  assert.strictEqual(normalizeDomain("lokalise.com"), "lokalise.com");
+  assert.strictEqual(normalizeDomain("http://ntropy.com"), "ntropy.com");
+  assert.strictEqual(normalizeDomain("https://example.com:8080/x?y=1"), "example.com");
+  assert.strictEqual(normalizeDomain("www.example.com."), "example.com");
+});
+
+test("normalizeDomain: schemed and bare forms collide", () => {
+  assert.strictEqual(
+    normalizeDomain("https://www.improvado.io/about"),
+    normalizeDomain("improvado.io")
+  );
+});
+
+test("normalizeDomain: empty / non-string -> empty key", () => {
+  assert.strictEqual(normalizeDomain(""), "");
+  assert.strictEqual(normalizeDomain(null), "");
+  assert.strictEqual(normalizeDomain(undefined), "");
+});

--- a/rfc/062-companies-notion-upsert.md
+++ b/rfc/062-companies-notion-upsert.md
@@ -1,0 +1,122 @@
+# RFC 062 — relokant-sweep → Notion Companies upsert
+
+- **Status:** Accepted (approved 2026-06-25, implemented)
+- **Tier:** M
+- **Refs:** BL-202, BL-200, RFC 061 (relokant sweep), RFC 022 (Notion-write
+  invariant)
+- **Date:** 2026-06-25
+
+## What changes for the user
+
+Today relokant-sweep finds new sweet-zone companies and writes them only to
+`ru_friendly_targets.tsv`; getting them into the Notion Companies DB is
+manual (just done by hand for Lokalise / Ntropy). After this change the sweep
+**also pushes the new companies into the Notion Companies DB by itself**, and
+never creates a duplicate of a company that's already there.
+
+One new command, same `--dry-run` default / `--apply` convention as `sync`:
+
+```
+node engine/cli.js companies-upsert --profile jared           # prints the plan
+node engine/cli.js companies-upsert --profile jared --apply   # writes to Notion
+```
+
+`--dry-run` prints e.g. `3 to create, 1 to fill, 9 already there (skip)`.
+The relokant-sweep skill calls `--apply` as its last step; nothing else in
+the pipeline changes.
+
+## Approach — reuse the existing company path, don't build a parallel one
+
+The Companies DB is already populated by the job pipeline through
+`engine/core/company_resolver.js` (lookup-or-create by name). We extend that
+same path rather than inventing a second writer:
+
+- **Lookup / create / data-source resolution**: same as `company_resolver`
+  (`dataSources.query` by title, `pages.create` with
+  `parent: { database_id }`, data_source via
+  `notion_sync.resolveDataSourceId`).
+- **Extra over the resolver**: relokant targets carry more than a name, so we
+  (a) write the extra fields below, (b) dedup by **domain as well as name**,
+  (c) on an existing page, **fill only empty fields** (never overwrite).
+
+### Dedup key
+
+- Primary = normalized domain (lowercase, strip `https?://`, `www.`, path,
+  trailing slash).
+- Fallback (no website) = `normalizeName` — the Cyrillic-safe one already in
+  `scripts/relokant/sweep_dedup.js`.
+- A candidate matches an existing company if **either** key is already known.
+
+Known-set = existing Notion pages (`Name` + `Website`) ∪ `data/companies.tsv`
+∪ the relokant ledgers. So a company the pipeline already created from a
+vacancy is recognized and not duplicated ("two-way" dedup).
+
+### Fields written on create (fill-gaps on existing)
+
+| Notion field | Source (from the TSV row) |
+|---|---|
+| `Name` (title) | `name` — the dedup key, create-only |
+| `Website` (url) | `https://` + `website` |
+| `Careers URL` (url) | `open_roles_url` |
+| `Why Interested` (text) | `CIS-edge: <ru_signal>. <market>.` |
+| `Notes` (text) | `Relokant sweet-zone (US-HQ). Contact: <contact>. US-viability: <us_viability>. ATS: <ats>. <notes>` |
+| `Outbound Status` (select) | `Not started` |
+
+`Tier` is **never** written (it's the user's pipeline judgement; relokant
+data carries no tier — same stance as `company_resolver`, which only sets
+Tier from an explicit profile map).
+
+On an existing page: create missing pages in full; for a page that exists,
+patch only the **empty** mapped fields, never overwrite a non-empty value,
+never delete.
+
+## Code shape (implementation detail — not approval-gated)
+
+- A small tested helper builds the per-row field payload and the
+  create-vs-fill-vs-skip decision from in-memory data (no I/O) — same
+  pure-helper convention as the rest of `core/`.
+- The side-effectful command reads the three sources, builds the Notion
+  client via `loadSecrets("jared")`, and runs `pages.create` / `pages.update`.
+- `normalizeName` (+ new `normalizeDomain`) move to a shared
+  `engine/core/company_keys.js`; `sweep_dedup.js` re-exports from there so its
+  CLI/tests don't change.
+
+## Non-goals
+
+- No outreach send (drafts stay manual, RFC 061).
+- No scan-engine / discovery-adapter changes.
+- No Notion → tsv push; `sync` stays pull-only.
+- No `Tier` writes.
+
+## Edge cases
+
+- Already in Notion, all mapped fields filled → skip, no write.
+- Already in Notion, some empty → patch only the empty ones.
+- Same company twice in one batch → collapse via in-batch seen-set.
+- No website → name-key dedup only.
+- Missing `JARED_NOTION_TOKEN` → `--apply` warns and no-ops; `--dry-run`
+  still prints the plan.
+- `data/companies.tsv` absent → treated as empty (no throw).
+
+## Notion-write invariant (RFC 022)
+
+All page writes stay in **engine** code. The relokant-sweep skill does not
+call Notion directly — after appending to the TSV it invokes
+`companies-upsert --apply`. Daily routine adds the same step.
+
+## Testing
+
+- Helper unit tests: create vs fill vs skip; domain-vs-name key hit; in-batch
+  dedup; empty-field detection; Tier never written.
+- Key-normalization tests (domain + name) incl. Cyrillic / legal suffixes.
+- Command test with a faked Notion client (records create/update; no network).
+- Smoke: `--dry-run` prints a plan and writes nothing.
+
+## Rollout
+
+1. Land `company_keys.js` + the helper + command + tests.
+2. Wire the `--apply` step into `skills/relokant-sweep/SKILL.md` and the daily
+   routine.
+3. First automated run is a no-op dedup over the current ledger (Lokalise /
+   Ntropy already in Notion) — proves the path doesn't duplicate.
+4. Update README + `docs/architecture` inventory (DoD).

--- a/scripts/relokant/sweep_dedup.js
+++ b/scripts/relokant/sweep_dedup.js
@@ -19,48 +19,10 @@
 const fs = require("fs");
 const path = require("path");
 
-// Legal-entity suffixes stripped before comparison so "Virto Commerce, Inc."
-// matches "Virto Commerce". Order-independent; applied as a trailing-token set.
-const LEGAL_SUFFIXES = new Set([
-  "inc",
-  "llc",
-  "ltd",
-  "limited",
-  "gmbh",
-  "corp",
-  "co",
-  "company",
-  "plc",
-  "ag",
-  "sa",
-  "bv",
-  "oy",
-  "ab",
-]);
-
-// Normalize a company name to a comparison key:
-//   - strip diacritics (José -> jose)
-//   - lowercase
-//   - drop punctuation (keep alnum + spaces)
-//   - collapse whitespace
-//   - drop trailing legal-entity suffix tokens
-function normalizeName(raw) {
-  if (typeof raw !== "string") return "";
-  let s = raw.normalize("NFKD").replace(/[̀-ͯ]/g, ""); // strip Latin diacritics
-  s = s.toLowerCase();
-  // Drop punctuation but KEEP Unicode letters/digits — many CIS company
-  // names are Cyrillic; stripping to ASCII would normalize "Яндекс" to ""
-  // and the helper would then mislabel a genuinely new company as a dup.
-  s = s.replace(/[^\p{L}\p{N}\s]/gu, " "); // punctuation -> space
-  s = s.replace(/\s+/g, " ").trim();
-  if (!s) return "";
-  let tokens = s.split(" ");
-  // Peel trailing legal suffixes (e.g. "... inc", "... co ltd").
-  while (tokens.length > 1 && LEGAL_SUFFIXES.has(tokens[tokens.length - 1])) {
-    tokens.pop();
-  }
-  return tokens.join(" ");
-}
+// normalizeName + LEGAL_SUFFIXES moved to engine/core/company_keys.js so the
+// relokant sweep and the Notion upsert (RFC 062) share ONE implementation.
+// Re-exported below to keep this module's public API unchanged.
+const { normalizeName, LEGAL_SUFFIXES } = require("../../engine/core/company_keys.js");
 
 // Partition candidate names into fresh (unknown) and dupes (already known).
 // `knownNames` is a Set of *normalized* names. Preserves the original casing

--- a/skills/relokant-sweep/SKILL.md
+++ b/skills/relokant-sweep/SKILL.md
@@ -21,9 +21,12 @@ cheap stage (candidate review) before any outreach.
 1. New sweet-zone companies appended to `profiles/<id>/ru_friendly_targets.tsv`.
 2. Rejected companies appended to `profiles/<id>/ru_friendly_rejects.tsv`
    with a reason (memory of the sweep — next run won't re-research them).
-3. An outreach draft for each **new US-viable** target (contact +
+3. The new sweet-zone companies pushed into the per-profile **Notion
+   Companies DB**, two-way deduped (no duplicates of companies already there
+   from the job pipeline / `data/companies.tsv`).
+4. An outreach draft for each **new US-viable** target (contact +
    message). **Drafts only — the user sends them by hand.**
-4. A short run report + an updated source-rotation log.
+5. A short run report + an updated source-rotation log.
 
 ---
 
@@ -139,7 +142,29 @@ rejects. Only `FRESH` names proceed.
 
 Never write a `DUP` to either file. Never edit existing rows — append only.
 
-### 6. Outreach drafts (new US-viable only)
+### 6. Push the new companies into Notion
+
+After appending, sync the targets ledger into the per-profile Notion
+Companies DB — deterministically, on code, not by hand:
+
+```
+node engine/cli.js companies-upsert --profile <id>           # preview the plan
+node engine/cli.js companies-upsert --profile <id> --apply   # write to Notion
+```
+
+The command is two-way deduped: it matches each target by domain **and**
+name against existing Notion pages, `data/companies.tsv`, and both relokant
+ledgers, so a company the job pipeline already created is never duplicated.
+A page that already exists is back-filled on **empty fields only** (Website,
+Careers URL, Why Interested, Notes, Outbound Status) — nothing is
+overwritten and `Tier` is never touched. `--dry-run` (default) prints
+`N to create, M to fill, K skip`; run `--apply` once the preview looks right.
+
+Do **not** create Notion pages by hand or via the Notion MCP from this skill
+— page writes live in the engine (RFC 022). This step is the only sanctioned
+path. See RFC 062 / BL-202.
+
+### 7. Outreach drafts (new US-viable only)
 
 For each new target with US-viability HIGH or "exception", produce:
 
@@ -150,7 +175,7 @@ For each new target with US-viability HIGH or "exception", produce:
 
 **You draft; the user sends.** Do not auto-send anything.
 
-### 7. Update the rotation log + report
+### 8. Update the rotation log + report
 
 Append a dated entry to `profiles/<id>/.relokant-state/sources_log.md`:
 which sources you swept, how many candidates seen, how many new targets /
@@ -175,6 +200,9 @@ part of RFC 061.
 - **Append only.** Never rewrite or delete existing TSV rows.
 - **Dedup on code.** Always run names through `sweep_dedup.js` before
   appending — do not rely on remembering what's already there.
+- **Notion writes go through the engine.** Push companies to Notion only via
+  `companies-upsert` (step 6) — never create pages by hand or via the Notion
+  MCP from this skill (RFC 022).
 - **Drafts only for outreach.** The user sends messages by hand.
 - **No engine changes.** If a sweep needs the scan engine / a new
   discovery adapter, stop and open an RFC — that's out of scope here.


### PR DESCRIPTION
## What

relokant-sweep now uploads its found sweet-zone companies into the per-profile **Notion Companies DB** automatically, two-way deduped — instead of by hand.

New command:

```
node engine/cli.js companies-upsert --profile jared           # plan: N create, M fill, K skip
node engine/cli.js companies-upsert --profile jared --apply   # write
```

## Approach (RFC 062)

Reuses the **existing** Notion path the job pipeline already uses for the Companies DB (`pages.create` with `parent: { database_id }`, data source via `resolveDataSourceId`) rather than building a parallel writer. Adds three things on top:

- **Two-way dedup on code** — `engine/core/company_keys.js` (`normalizeName` moved here from `scripts/relokant/sweep_dedup.js`, which now re-exports + new `normalizeDomain`). A candidate matches if **domain OR name** is already known across Notion ∪ `data/companies.tsv` ∪ relokant ledgers, so a company the pipeline already created is never duplicated.
- **Fill-gaps** — existing pages get empty mapped fields back-filled only (Website, Careers URL, Why Interested, Notes, Outbound Status); non-empty values are never overwritten; `Tier` is never written.
- **Pure planner / side-effect split** — create/fill/skip decision is pure (`engine/core/companies_upsert.js`); Notion I/O is the command shell.

Preserves the Notion-write invariant (RFC 022): the skill invokes the CLI, never Notion directly.

## Wiring + docs

- `skills/relokant-sweep/SKILL.md` step 6 + hard rule; daily routine `relokant-sweep-jared` step 6 (local, not in repo).
- README command table, `docs/architecture/overview.md` (core inventory + command section), `docs/reference/cli.md`.

## Tests

`company_keys.test.js`, `companies_upsert.test.js` (core: create/fill/skip, domain-vs-name precedence, in-batch dedup, fill-gaps, Tier-never-written, known-non-notion skip), `commands/companies_upsert.test.js` (faked Notion client). Full suite green (2169).

## Live dry-run (read-only)

Against jared's real Notion: `0 to create, 1 to fill (Virto Commerce — empty Website/Why Interested/Notes), 12 skip` — all 13 targets already present, proving dedup + a genuine gap-fill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)