### PR TITLE
fix(relokant): BL-207 — companies-upsert self-dedup bug (creates always 0)

### DIFF
--- a/engine/commands/companies_upsert.js
+++ b/engine/commands/companies_upsert.js
@@ -158,10 +158,12 @@ function makeCompaniesUpsertCommand(overrides = {}) {
       return 0;
     }
 
-    const ledgerNames = [
-      ...deps.readNamesColumn(targetsPath),
-      ...deps.readNamesColumn(rejectsPath),
-    ];
+    // Dedup ledger = REJECTS only. The targets ledger is the candidate source
+    // (`rows` above); including it here would make every candidate match itself
+    // and get skipped as "known-non-notion", so `creates` could never be > 0.
+    // Idempotency across runs comes from the Notion read below: a target pushed
+    // in a prior run already has a page and is caught there.
+    const ledgerNames = [...deps.readNamesColumn(rejectsPath)];
     const tsvNames = deps.readNamesColumn(companiesTsvPath);
 
     // Notion read: the authoritative existing-pages source. Without a token we

--- a/engine/commands/companies_upsert.test.js
+++ b/engine/commands/companies_upsert.test.js
@@ -94,6 +94,27 @@ test("--apply: creates a Notion page for the new company", async () => {
   assert.ok(!rec.creates[0].properties.Tier);
 });
 
+test("regression: target present in its own ledger still creates (no self-skip)", async () => {
+  // The command reads the targets ledger both as candidate rows AND (previously)
+  // as a dedup source. Simulate the real file: readNamesColumn returns the
+  // target's own name from ru_friendly_targets.tsv. Under the old self-
+  // referential dedup this produced 0 creates; the fix must still create it.
+  const rec = { creates: [], updates: [] };
+  const client = fakeClient(rec);
+  const cmd = makeCompaniesUpsertCommand(
+    baseDeps({
+      __client: client,
+      makeClient: () => client,
+      readNamesColumn: (p) => (String(p).includes("ru_friendly_targets") ? ["New Co"] : []),
+    })
+  );
+  const { ctx, out } = makeCtx({ flags: { apply: true } });
+  const code = await cmd(ctx);
+  assert.strictEqual(code, 0);
+  assert.strictEqual(rec.creates.length, 1);
+  assert.ok(out.some((l) => l.includes("1 to create")));
+});
+
 test("--apply: existing page with empty fields gets a fill, not a create", async () => {
   const rec = { creates: [], updates: [] };
   const client = fakeClient(rec);

--- a/engine/core/companies_upsert.js
+++ b/engine/core/companies_upsert.js
@@ -76,7 +76,9 @@ function candidateKeys(row) {
 //
 //   notionPages: [{ pageId, name, website, values: { <field>: <string> } }]
 //   tsvNames:    [ "Acme", ... ]   (data/companies.tsv — name column only)
-//   ledgerNames: [ "Acme", ... ]   (relokant targets + rejects)
+//   ledgerNames: [ "Acme", ... ]   (relokant REJECTS only — never the targets
+//                                    ledger, which is the candidate source and
+//                                    would self-match every row into a skip)
 function buildKnownIndex({ notionPages = [], tsvNames = [], ledgerNames = [] } = {}) {
   const byName = new Map();
   const byDomain = new Map();


### PR DESCRIPTION
## What

`companies-upsert` (RFC 062 / BL-202) could never create a Notion page. It
built its dedup known-set from **both** the targets ledger (the candidate
source) and the rejects ledger, so every candidate row self-matched a
`{inNotion:false}` presence marker in `planUpsert` → skipped as
`known-non-notion` → `creates` always 0.

## Fix

- Dedup ledger = **rejects only**. The targets ledger is the candidate
  source, not a dedup source.
- Cross-run idempotency is preserved by the Notion read (a target pushed in
  a prior run already has a page and is caught there).
- Regression test feeds the target's own name back through `readNamesColumn`
  — the production path the old `() => []` stub never exercised. Fails on the
  old code (0 creates), passes on the fix.

## Verification

- `node --test engine/**/companies_upsert.test.js` → 21/21 green.
- Live run unblocked **BL-203**: `companies-upsert --apply` created **33**
  sweet-zone pages (errors 0); re-run dry-run → `0 to create, 46 already
  there` (idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)