### PR TITLE
feat(interview-coach): Rule 5 — calibrate spoken English against Reword mastered set

### DIFF
--- a/skills/interview-coach/SKILL.md
+++ b/skills/interview-coach/SKILL.md
@@ -30,7 +30,7 @@ When the doc below says "read `coaching_state.md`" → read `profiles/<id>/inter
 
 When instructions compete for attention, follow this priority order:
 
-1. **Conventions of behavior**: `references/conventions.md` defines three rules that constrain Claude's own behavior across every command — ESL formatting of spoken English, no fabricated commercial profiles, direct admission of mistakes. **Read this file before generating any prep brief, practice script, mock session, anchor file, hype output, or storybank update.** These rules override anything else in this skill if they conflict.
+1. **Conventions of behavior**: `references/conventions.md` defines the rules that constrain Claude's own behavior across every command — ESL formatting of spoken English, Russian narrative stays Russian, no fabricated commercial profiles, direct admission of mistakes, factual hygiene, and vocabulary calibration of spoken English against the candidate's Reword mastered set (Rule 5). **Read this file before generating any prep brief, practice script, mock session, anchor file, hype output, or storybank update.** These rules override anything else in this skill if they conflict.
 2. **Session state**: Load and update `coaching_state.md` if available. Everything else builds on continuity.
 3. **Triage before template**: Branch coaching based on what the data reveals. Never run the same assembly line for every candidate.
 4. **Evidence enforcement**: Don't make claims you can't back. Silence is better than confident-sounding guesses. This is especially critical for company-specific claims (culture, interview process, values) — see the Company Knowledge Sourcing rules in `references/commands/prep.md`.

--- a/skills/interview-coach/references/conventions.md
+++ b/skills/interview-coach/references/conventions.md
@@ -394,6 +394,84 @@ mashed into one sentence (rule 4 violated).
 
 ---
 
+## 5. Vocabulary calibration — spoken English from the candidate's Reword mastered set
+
+**Rule.** Before emitting any English the candidate will **read aloud**
+(prep brief 🗣️ blocks, konspekt spoken answers, `practice` / `mock`
+lines, the EN column of a `Story Details` STAR table, `hype` anchors),
+calibrate the word choice against the candidate's **Reword mastered
+vocabulary**. Two tiers, never silent:
+
+- **A — auto-replace.** A word is *not* in the mastered set **and** it is
+  genuinely advanced / rare / idiomatic **and** a natural synonym that
+  **is** in the mastered set preserves the meaning → replace it and log
+  `old → new` with a one-word reason. (Pilot examples: `tolerate → accept`,
+  `make a dent → have impact`.)
+- **B — watch-list, text untouched.** Any *content* word left in the
+  answer that is not in the mastered set and was not auto-replaced → list
+  it under the answer. Do **not** change the answer. The candidate reads
+  the list and decides: knows it → ignore; shaky → drills it.
+
+Then hand the block-B words to the **`reword-vocab` skill** to build a
+drill deck (see "How to apply" step 4). Learned words re-enter `mastered`
+on the next export, so they stop surfacing — the loop closes.
+
+**Why.** 2026-07-08 pilot (Sam Tang / Capital One konspekt): the
+candidate reads his answers fluently, but a handful of advanced words
+occasionally surface that he'd rather swap or drill. "Absent from
+mastered" alone is **not** a flag — his baseline English is fluent and
+many common words (`flagship`, `breakthrough`) aren't in the deck yet are
+obviously known. Over-replacing dumbs his answers down, which is worse
+than leaving a known word. So replacement is **rare and light-touch**
+(the pilot swapped 2 words in a 35 KB konspekt); the watch-list is the
+default catch-all, and nothing not-in-mastered passes silently.
+
+**How to apply.**
+
+1. **Refresh the snapshot first (every time — data must be current).**
+   Read `profiles/<id>/interview-coach-state/vocab_config.json`. If it is
+   absent, this profile has no Reword source → **skip calibration
+   entirely, no note**. If present, run from the repo root:
+   `python3 skills/interview-coach/references/vocab_snapshot.py --backup <reword_backup_path> --out <snapshot_path>`
+   (both values from the config). The script re-reads the live 305 MB
+   backup and rewrites the small `<snapshot_path>` mastered list, so an
+   updated Reword export is picked up automatically. If the script exits
+   non-zero (backup missing — e.g. Drive not synced, cloud session),
+   **skip calibration and the deck**, and add one line to the output:
+   *"Reword backup unavailable — answers not vocab-calibrated this run."*
+2. **Load the mastered list** from `<snapshot_path>` (skip `#` meta
+   lines; each remaining line is one lowercased word/phrase). Note the
+   `# backup_exported:` date — if the output surfaces vocabulary
+   provenance, cite that date so the candidate knows how fresh it is.
+3. **Apply the two tiers (A / B above).** Match case-insensitively;
+   lemmatize loosely (a mastered `share` covers `sharing`, `shares`).
+   **Never touch, flag, or deck:** the candidate's own domain jargon
+   (funnel, conversion, monetization, retention, guardrail, proxy metric,
+   north-star, cohort, MCP, CPA, affiliate, aggregator, …), proper nouns,
+   numbers, or the mastered words themselves. **When unsure whether to
+   auto-replace → downgrade to the watch-list.** Never force-swap a word
+   that might be known, and never silently drop a not-mastered word.
+4. **Build the drill deck from block B.** When the watch-list is
+   non-empty, pass those words to the `reword-vocab` skill. It dedups them
+   against the *full* Reword backup (mastered **and** learning) and prior
+   CSVs in the canonical output dir, enriches (IPA + RU + examples), and
+   writes a dated deck `<YYYY-MM-DD>-<company-or-topic>-interview.csv`.
+   Report one line: *"N words → deck `<path>`, import to Reword."* Do this
+   **automatically** whenever block B is non-empty; skip only if the
+   candidate says "no deck" / "без дека" for that run. One deck per
+   konspekt, slug from the company/role.
+5. **Output shape.** Under the spoken answers, two compact blocks — 🔄
+   *Replaced* (A: what → what, why) and 👀 *Check* (B: in the answer, not
+   in Reword mastered) — plus the one-line deck report. Omit a block if
+   it's empty.
+
+**Interaction with Rule 1.** Calibration operates on *word choice* after
+Rule 1 has set the format. A mastered-set synonym must still obey Rule 1:
+in 🗣️ anchor phrases spell words out (no symbols); numbers as symbols
+where Rule 1 requires. Word swaps never override the ESL format.
+
+---
+
 ## How these rules surface
 
 These rules are loaded at the top of every command's instruction set:
@@ -401,9 +479,12 @@ These rules are loaded at the top of every command's instruction set:
 - `prep`: Rule 1 (🗣️ format — Russian summary + English anchor phrases)
   and Rule 2 (no fabrication) gate the output. Rule 1b (Russian narrative
   stays Russian) gates the prose. Rule 4 (factual hygiene) gates every
-  candidate-history fact narrated in the brief. Rule 3 governs how to
-  handle a fabrication or conflation caught mid-session.
+  candidate-history fact narrated in the brief. Rule 5 (vocabulary
+  calibration) gates the spoken-English word choice in every 🗣️ block.
+  Rule 3 governs how to handle a fabrication or conflation caught
+  mid-session.
 - `practice`, `mock`: Rule 1 gates every line the candidate will speak.
+  Rule 5 calibrates those spoken lines against the Reword mastered set.
   Rule 4 gates how candidate history is described in the setup text.
 - `analyze`, `debrief`, `feedback`: Rule 2 governs how to label cases
   pulled from the storybank. Rule 4 governs how to narrate candidate
@@ -411,8 +492,10 @@ These rules are loaded at the top of every command's instruction set:
   attribution turns out wrong.
 - `stories`: Rule 2 governs the `Commercial Profile` field — ask, don't
   guess. Rule 4 governs multi-direction cases — surface both directions
-  in `Story Details`, do not collapse.
-- `hype`: Rule 1 governs the anchor lines and the opening line.
+  in `Story Details`, do not collapse. Rule 5 calibrates the English
+  column of any `Story Details` STAR table the candidate will speak.
+- `hype`: Rule 1 governs the anchor lines and the opening line. Rule 5
+  calibrates their word choice.
 
 When in doubt, this file wins. The cost of breaking one of these rules
 is higher than the cost of being slightly slower or less polished.

--- a/skills/interview-coach/references/vocab_snapshot.py
+++ b/skills/interview-coach/references/vocab_snapshot.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Extract the candidate's MASTERED English words from a Reword backup.
+
+Reword is a spaced-repetition app; its backup is a SQLite DB whose WORD
+table carries SuperMemo SM-2 state per word. This script distills that
+into a small plain-text snapshot the interview-coach skill loads to
+calibrate spoken-English answers (see SKILL.md "Vocabulary calibration").
+
+PII-free by construction: the backup path is an argument, never hardcoded.
+The 305 MB DB is read column-projected (never SELECT *), so this is fast
+and light. Re-run before every konspekt/story generation so the snapshot
+always reflects the latest export.
+
+Status encoding (reverse-engineered, verified against real data):
+  Q_REC = grade of the last answer, 0..4
+  S_REC = SR box / stage, 0..6
+  MASTERED = marked-known (Q_REC >= 3 AND S_REC == 0)
+             OR drilled to a high box (S_REC >= 4)
+  LEARNING = mid boxes (S_REC in 1..3)        [reported in meta only]
+  UNSTUDIED = no signal (Q_REC == 0 AND S_REC == 0)  -> NOT "unknown"
+
+Exit codes: 0 ok, 2 backup missing/unreadable, 3 schema mismatch.
+"""
+
+import argparse
+import datetime
+import os
+import sqlite3
+import sys
+
+
+def _die(code, msg):
+    sys.stderr.write("vocab_snapshot: " + msg + "\n")
+    sys.exit(code)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Reword backup -> mastered-words snapshot")
+    ap.add_argument("--backup", required=True, help="path to reword_en.backup (SQLite)")
+    ap.add_argument("--out", required=True, help="path to write the snapshot .txt")
+    args = ap.parse_args()
+
+    if not os.path.isfile(args.backup):
+        _die(2, "backup not found: " + args.backup)
+
+    try:
+        # read-only, do not create if missing
+        db = sqlite3.connect("file:%s?mode=ro" % args.backup, uri=True)
+    except sqlite3.Error as e:
+        _die(2, "cannot open backup: " + str(e))
+
+    cur = db.cursor()
+    cols = {r[1].upper() for r in cur.execute("PRAGMA table_info(WORD)")}
+    if not {"WORD", "Q_REC", "S_REC"} <= cols:
+        _die(3, "WORD table missing expected columns (WORD, Q_REC, S_REC)")
+
+    mastered = set()
+    learning = 0
+    unstudied = 0
+    total = 0
+    for word, q, s in cur.execute("SELECT WORD, Q_REC, S_REC FROM WORD"):
+        total += 1
+        if not word:
+            continue
+        q = q or 0
+        s = s or 0
+        if (q >= 3 and s == 0) or (s >= 4):
+            mastered.add(word.strip().lower())
+        elif 1 <= s <= 3:
+            learning += 1
+        elif q == 0 and s == 0:
+            unstudied += 1
+    db.close()
+
+    src_mtime = datetime.datetime.fromtimestamp(os.path.getmtime(args.backup))
+    now = datetime.datetime.now()
+    words = sorted(mastered)
+
+    out_dir = os.path.dirname(os.path.abspath(args.out))
+    if out_dir and not os.path.isdir(out_dir):
+        os.makedirs(out_dir, exist_ok=True)
+
+    with open(args.out, "w", encoding="utf-8") as f:
+        f.write("# reword mastered-words snapshot\n")
+        f.write("# source: %s\n" % os.path.basename(args.backup))
+        f.write("# backup_exported: %s\n" % src_mtime.strftime("%Y-%m-%d %H:%M"))
+        f.write("# generated: %s\n" % now.strftime("%Y-%m-%d %H:%M"))
+        f.write("# counts: total=%d mastered=%d learning=%d unstudied=%d\n"
+                % (total, len(words), learning, unstudied))
+        f.write("# one lowercased word/phrase per line below\n")
+        for w in words:
+            f.write(w + "\n")
+
+    # machine-readable one-liner for the skill / logs
+    sys.stdout.write(
+        "OK mastered=%d learning=%d unstudied=%d total=%d backup_exported=%s out=%s\n"
+        % (len(words), learning, unstudied, total,
+           src_mtime.strftime("%Y-%m-%d"), args.out)
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What
New conventions Rule 5: before emitting any English the candidate reads aloud (prep 🗣️ blocks, konspekt answers, practice/mock lines, Story Details EN column, hype), calibrate word choice against his **Reword mastered vocabulary**.

- **A / auto-replace** — word not in mastered + genuinely advanced/idiomatic + a natural mastered-set synonym preserves meaning → swap + log (🔄 block).
- **B / watch-list** — any other not-mastered content word → surfaced under the answer, text untouched (👀 block), then fed to the `reword-vocab` skill to build a dated drill deck. Learned words re-enter mastered → stop surfacing. Loop closes.

Light-touch by design (pilot swapped 2 words in a 35 KB konspekt): over-replacing dumbs answers down; watch-list is the default catch-all.

## How
- `references/vocab_snapshot.py` — reads the Reword SQLite backup (column-projected, read-only), distills MASTERED words `((Q_REC>=3 AND S_REC=0) OR S_REC>=4)` into a small snapshot. Re-run every generation → picks up new exports. PII-free (backup path is an arg); exit 2 on missing backup.
- Per-profile `vocab_config.json` (gitignored) holds backup + snapshot paths. Absent → calibration skipped silently. Backup unavailable → skipped + one-line notice.
- `conventions.md` Rule 5 + "How these rules surface" wiring; `SKILL.md` pointer updated.

## Test
- Script smoke test on the real 305 MB backup: mastered=4991, edge-case (missing backup → exit 2) ✓. Sanity: pilot swaps (`tolerate`, `dent`) correctly absent from mastered; jargon/known words correctly not flagged.
- `node skills/interview-coach/SKILL.test.js` → 3/3 pass.
- `prettier --check` on changed markdown → clean.

Tier M. Design + approval captured conversationally (образ результата flow), no engine changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)