### PR TITLE
feat(engine): BL-208 / RFC 063 — `add` command for manual job entry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,8 +134,15 @@ section is just the things to keep in your head while editing code.
 - **`sync` is pull-only since 2026-05-04.** Notion → TSV reconcile
   only. The push phase, the Stage 16 `push_manifest.json` gate, and
   the Inbox callout updater were all removed in commit `4f85ed2`.
-  New Notion pages are created exclusively by `prepare`'s commit
-  phase. Do not re-add a push path without an RFC.
+  Do not re-add a push path to `sync` without an RFC.
+- **One writer for Notion job pages.** All job-page creation goes
+  through `engine/core/notion_job_page.js` → `pushJobPage` (dedup by
+  `key`, Company relation, `createJobPage`). It has exactly two
+  callers: `prepare --phase commit` (scan-discovered rows) and `add`
+  (manual entry — referrals, newsletters, recruiter email; RFC 063).
+  Nothing else in `engine/` may call `createJobPage` directly. A new
+  caller needs an RFC. (`scripts/push_prepare_results_to_notion.js` is
+  a known legacy one-off that predates the rule.)
 - **Pure helpers, isolated side effects.** `core/*` and most of
   `scripts/stage18/*` are pure functions over in-memory objects. The
   filesystem, network, and `process.exit` live in `commands/*` and

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ node engine/cli.js <command> --profile <id> [flags]
 | Command | Purpose |
 |---|---|
 | `scan` | Poll all configured ATS adapters; append new jobs to `data/jobs.tsv`. |
+| `add` | Enter one job by hand — for vacancies arriving outside the scan (referrals, newsletters, recruiter email). Creates the Notion page + TSV row in one run, deduped. Dry-run by default; `--apply` writes. (RFC 063) |
 | `validate` | Re-apply filter rules to the existing pool (catches retroactively-blocked jobs). |
 | `prepare` | Two-phase: pre (assign archetype + draft cover letter) → commit (write artifacts). |
 | `sync` | Push/pull against per-profile Notion DBs. Defaults to dry-run; `--apply` writes. |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -129,6 +129,18 @@ status). Idempotent — rows that already have a URL are skipped. Does not
 break pull-only: it creates no pages and touches no operator-owned field,
 only the engine-owned URL.
 
+**`add`**. Manual job entry (RFC 063) for vacancies that arrive outside the
+ATS scan: referrals, newsletters, recruiter email, applying straight on a
+company site. Writes the Notion page and the TSV row in one run. It is **not**
+a second Notion writer — page creation goes through `core/notion_job_page.js`
+→ `pushJobPage`, the same helper `prepare --phase commit` uses, making the
+invariant "all job-page creation goes through `pushJobPage`; `prepare` and
+`add` are its only callers". Manual rows skip `Inbox` (that status means
+"discovered, not yet evaluated by `prepare`", which a hand-entered row never
+is) and carry an operator-asserted `--status`. Ordering is Notion first then
+TSV — the inverse of `prepare`'s batch behaviour — so a Notion failure writes
+nothing rather than leaving a row with an empty `notion_page_id`.
+
 **`companies-upsert`**. Pushes relokant-sweep sweet-zone targets
 (`profiles/<id>/ru_friendly_targets.tsv`) into the per-profile Notion
 Companies DB (BL-202 / RFC 062). Reuses the same Notion path the pipeline

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -80,6 +80,70 @@ Common errors:
 - `warn: no adapter for source "<name>"` — entry in companies.tsv references an unregistered adapter.
 - `warn: auto-sync failed` — non-fatal; usually missing `<ID>_NOTION_TOKEN` in env.
 
+### add
+
+Synopsis: `node engine/cli.js add --profile <id> --company <name> --title <title> --status <status> [--apply] [flags]`
+
+Enters **one** job into the pipeline by hand — for vacancies that arrive outside the ATS scan: referrals, newsletters, recruiter email, applying straight on a company site. Creates the Notion page and the `applications.tsv` row in a single run, replacing the one-off scripts previously written per entry. See [RFC 063](../../rfc/063-manual-job-entry.md).
+
+Manual rows deliberately skip `Inbox`. That status means "discovered, not yet evaluated by `prepare`" ([RFC 014](../../rfc/014-status-split-new-vs-toapply.md)), which a hand-entered row never is — the operator supplies the status because they already know it. `--status Inbox` is rejected.
+
+Page creation goes through the same shared helper `prepare --phase commit` uses (`core/notion_job_page.pushJobPage`), so `add` is a second **caller**, not a second writer. The invariant is: all Notion job-page creation goes through `pushJobPage`; `prepare --phase commit` and `add` are its only callers.
+
+Ordering is Notion first, TSV second — the inverse of `prepare`'s batch behaviour ([RFC 022](../../rfc/022-prepare-commit-atomic-notion.md)). `add` handles one row interactively, so a Notion failure writes nothing rather than leaving a row with an empty `notion_page_id`, which is not a valid state. `pushJobPage`'s dedup-by-key guard makes a retry safe.
+
+Flags:
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--profile <id>` | string | — | Required. |
+| `--company <name>` | string | — | Required. Resolved against the Notion Companies DB; the page is created if absent. |
+| `--title <title>` | string | — | Required. Stored verbatim; normalized only for duplicate comparison. |
+| `--status <status>` | string | — | Required, no default. One of `To Apply`, `Applied`, `Interview`, `Offer`, `Rejected`, `No Response`, `Closed`, `Archived`. `Inbox` is rejected (TSV-only, RFC 014). |
+| `--salary <range>` | string | — | `MIN` or `MIN-MAX`, whole dollars (`140000-185000`). Rendered as `$140-185K ($165K mid)`. |
+| `--locations <list>` | string | — | Comma-separated (`Remote,United States`). |
+| `--url <url>` | string | — | Job posting URL. |
+| `--fit <score>` | string | — | One of `Strong`, `Medium`, `Weak`. Manual rows are not fit-evaluated; left empty when absent. |
+| `--notes <text>` | string | — | Free text; lands in `fit_rationale` and the Notion `Notes` field. |
+| `--applied-date <date>` | string | — | `YYYY-MM-DD`. |
+| `--resume-ver <name>` | string | — | Resume archetype used for the application. |
+| `--tier <S\|A\|B\|C>` | string | — | Writes `company_tiers["<company>"]` into `profile.json`. Never guessed when absent. |
+| `--force` | boolean | false | Add despite detected duplicates. |
+| `--apply` | boolean | false | Create the page and write the row. Without it, `add` is a dry-run. |
+
+Duplicate detection runs before any write, in two layers: exact key, and same company + same normalized title on any non-archived row (catches the same posting re-entered on a different day, where the date-suffixed keys differ). Archived rows are ignored — re-adding a long-archived job is legitimate.
+
+Outputs and side effects:
+
+- Creates one page in the Notion Jobs Pipeline DB; creates the Company page if it does not exist.
+- Appends one row to `profiles/<id>/applications.tsv` with `source: Manual` and key `manual:<company>_<title>_<YYYY-MM-DD>`.
+- Backs up the TSV to `applications.tsv.pre-add-<company>-<date>` before writing.
+- With `--tier`: writes `company_tiers` into `profiles/<id>/profile.json`.
+- Prints the Notion page URL.
+
+Example:
+
+```bash
+# dry-run first (default)
+node engine/cli.js add --profile <id> \
+  --company "LawnStarter" \
+  --title "Senior Product Manager, Pricing & Monetization" \
+  --status Interview \
+  --salary 140000-185000 \
+  --locations "Remote,United States"
+
+# then write
+node engine/cli.js add --profile <id> ... --apply
+```
+
+Common errors:
+
+- `--status is required (one of: ...)` — no default exists; the status must be asserted.
+- `status Inbox is TSV-only (RFC 014) ...` — use a real pipeline status.
+- `refusing: N existing row(s) look like this job` — duplicate guard; inspect the printed rows, pass `--force` only if genuinely distinct.
+- `error: Notion push failed — ...` — nothing was written; fix and re-run.
+- `missing <ID>_NOTION_TOKEN in env` — add it to `.env`.
+
 ### validate
 
 Synopsis: `node engine/cli.js validate --profile <id> [--dry-run] [--apply] [--dedup]`

--- a/engine/cli.js
+++ b/engine/cli.js
@@ -15,6 +15,7 @@ const { parseArgs } = require("util");
 
 const KNOWN_COMMANDS = [
   "scan",
+  "add",
   "validate",
   "sync",
   "prepare",
@@ -51,6 +52,18 @@ const PARSE_OPTIONS = {
     dedup: { type: "boolean", default: false },
     notion: { type: "boolean", default: false },
     limit: { type: "string" },
+    // `add` (RFC 063). `company` is shared with `answer` above.
+    title: { type: "string" },
+    status: { type: "string" },
+    salary: { type: "string" },
+    locations: { type: "string" },
+    url: { type: "string" },
+    tier: { type: "string" },
+    fit: { type: "string" },
+    notes: { type: "string" },
+    "applied-date": { type: "string" },
+    "resume-ver": { type: "string" },
+    force: { type: "boolean", default: false },
   },
   allowPositionals: true,
   strict: true,
@@ -66,6 +79,10 @@ Commands:
   scan       Discover new jobs across configured ATS adapters, append them
              to the shared pool + per-profile applications. Auto-syncs with
              Notion BEFORE running (BL-151 / RFC 054). Pass --no-sync to skip.
+  add        Enter one job by hand — for vacancies that arrive outside the
+             ATS scan (referrals, newsletters, recruiter email, direct site
+             applications). Creates the Notion page and the TSV row in one
+             run. Default: dry-run. See RFC 063.
   validate   Pre-flight: URL liveness, company cap, TSV hygiene.
   sync       Reconcile per-profile applications with Notion + archive used
              tailored CV/CL artifacts for rows past To Apply (BL-151).
@@ -220,6 +237,7 @@ function defaultCommands() {
   // process. This keeps test startup fast when tests inject their own handlers.
   return {
     scan: require("./commands/scan.js"),
+    add: require("./commands/add.js"),
     validate: require("./commands/validate.js"),
     sync: require("./commands/sync.js"),
     prepare: require("./commands/prepare.js"),
@@ -291,6 +309,18 @@ async function runCli({ argv, env = process.env, stdout, stderr, commands } = {}
       dedup: Boolean(parsed.values.dedup),
       notion: Boolean(parsed.values.notion),
       limit: parsed.values.limit ? parseInt(parsed.values.limit, 10) : null,
+      // add (RFC 063) — `company` above is shared with answer.
+      title: parsed.values.title || "",
+      status: parsed.values.status || "",
+      salary: parsed.values.salary || "",
+      locations: parsed.values.locations || "",
+      url: parsed.values.url || "",
+      tier: parsed.values.tier || "",
+      fit: parsed.values.fit || "",
+      notes: parsed.values.notes || "",
+      appliedDate: parsed.values["applied-date"] || "",
+      resumeVer: parsed.values["resume-ver"] || "",
+      force: Boolean(parsed.values.force),
     },
     env,
     stdout: writeOut,

--- a/engine/cli.test.js
+++ b/engine/cli.test.js
@@ -199,6 +199,7 @@ test("runCli reports missing handler with a clear error", async () => {
 
 test("KNOWN_COMMANDS lists exactly the supported commands", () => {
   assert.deepEqual([...KNOWN_COMMANDS].sort(), [
+    "add",
     "answer",
     "backfill-outreach-url",
     "check",
@@ -211,6 +212,104 @@ test("KNOWN_COMMANDS lists exactly the supported commands", () => {
     "sync",
     "validate",
   ]);
+});
+
+// Regression (RFC 063): ctx.flags is an explicit whitelist, so registering a
+// flag in PARSE_OPTIONS is not enough — it must also be threaded into ctx.
+// The first live run of `add` hit exactly this: every flag parsed fine and
+// arrived at the command as undefined. Command-level tests build ctx by hand
+// and cannot catch it; this asserts the real cli.js wiring.
+test("add: every registered flag reaches the command through ctx.flags", async () => {
+  const s = makeStreams();
+  const add = spyCommand();
+  const code = await runCli({
+    argv: [
+      "add",
+      "--profile",
+      "jared",
+      "--company",
+      "LawnStarter",
+      "--title",
+      "Senior Product Manager, Pricing & Monetization",
+      "--status",
+      "Interview",
+      "--salary",
+      "140000-185000",
+      "--locations",
+      "Remote,United States",
+      "--url",
+      "https://example.com/job",
+      "--tier",
+      "B",
+      "--fit",
+      "Strong",
+      "--notes",
+      "craft match",
+      "--applied-date",
+      "2026-07-01",
+      "--resume-ver",
+      "GrowthExperimentation",
+      "--force",
+      "--apply",
+    ],
+    stdout: s.stdout,
+    stderr: s.stderr,
+    commands: { add },
+  });
+
+  assert.equal(code, 0);
+  assert.equal(add.calls.length, 1);
+  assert.deepEqual(
+    {
+      company: add.calls[0].flags.company,
+      title: add.calls[0].flags.title,
+      status: add.calls[0].flags.status,
+      salary: add.calls[0].flags.salary,
+      locations: add.calls[0].flags.locations,
+      url: add.calls[0].flags.url,
+      tier: add.calls[0].flags.tier,
+      fit: add.calls[0].flags.fit,
+      notes: add.calls[0].flags.notes,
+      appliedDate: add.calls[0].flags.appliedDate,
+      resumeVer: add.calls[0].flags.resumeVer,
+      force: add.calls[0].flags.force,
+      apply: add.calls[0].flags.apply,
+    },
+    {
+      company: "LawnStarter",
+      title: "Senior Product Manager, Pricing & Monetization",
+      status: "Interview",
+      salary: "140000-185000",
+      locations: "Remote,United States",
+      url: "https://example.com/job",
+      tier: "B",
+      fit: "Strong",
+      notes: "craft match",
+      appliedDate: "2026-07-01",
+      resumeVer: "GrowthExperimentation",
+      force: true,
+      apply: true,
+    }
+  );
+});
+
+test("add: omitted flags default to empty string / false, never undefined", async () => {
+  const s = makeStreams();
+  const add = spyCommand();
+  await runCli({
+    argv: ["add", "--profile", "jared", "--company", "X"],
+    stdout: s.stdout,
+    stderr: s.stderr,
+    commands: { add },
+  });
+
+  const f = add.calls[0].flags;
+  assert.equal(f.title, "");
+  assert.equal(f.status, "");
+  assert.equal(f.tier, "");
+  assert.equal(f.appliedDate, "");
+  assert.equal(f.force, false);
+  assert.equal(f.apply, false);
 });
 
 test("scan auto-triggers sync --apply BEFORE main work (pre-hook)", async () => {

--- a/engine/commands/add.js
+++ b/engine/commands/add.js
@@ -1,0 +1,275 @@
+// `add` command (RFC 063 / BL-208): enter one job into the pipeline by hand.
+//
+// For vacancies that arrive outside the ATS scan — referrals, newsletters,
+// recruiter email, applying straight on a company site. Replaces the one-off
+// scripts written for Virto Commerce, the Lenny's batch, and LawnStarter.
+//
+// This is NOT a second Notion writer. Page creation goes through the same
+// shared helper `prepare --phase commit` uses — core/notion_job_page.pushJobPage
+// — so the invariant is "all job-page creation goes through pushJobPage;
+// prepare and add are its only callers".
+//
+// Ordering (RFC 063 §4), inverted vs RFC 022's batch case: Notion first, TSV
+// second. One row, interactive, operator watching — so a Notion failure must
+// write nothing rather than leave a row with an empty notion_page_id, which is
+// not a valid state (only Inbox rows are legitimately Notion-less, RFC 014).
+//
+// Default is dry-run; --apply writes. Side effects live here; the row/payload
+// logic is the pure core in engine/core/manual_job.js.
+
+const fs = require("fs");
+const path = require("path");
+
+const profileLoader = require("../core/profile_loader.js");
+const notion = require("../core/notion_sync.js");
+const notionJobPage = require("../core/notion_job_page.js");
+const companyResolver = require("../core/company_resolver.js");
+const applicationsTsv = require("../core/applications_tsv.js");
+const { resolveProfilesDir } = require("../core/paths.js");
+const manualJob = require("../core/manual_job.js");
+
+// Printed to stderr on a validation error. The pure core throws messages that
+// name the offending flag; this gives the operator the full shape to fix it
+// against without leaving the terminal.
+const USAGE = `usage: node engine/cli.js add --profile <id> --company <name> --title <title> --status <status> [flags]
+
+required:
+  --company <name>       Company name. Resolved against the Notion Companies DB.
+  --title <title>        Job title, stored verbatim.
+  --status <status>      To Apply | Applied | Interview | Offer | Rejected | No Response | Closed | Archived
+                         (Inbox is TSV-only per RFC 014 and is rejected here)
+
+optional:
+  --salary <range>       "MIN" or "MIN-MAX", whole dollars (140000-185000).
+  --locations <list>     Comma-separated ("Remote,United States").
+  --url <url>            Job posting URL.
+  --fit <score>          Strong | Medium | Weak.
+  --notes <text>         Free text → fit_rationale + the Notion Notes field.
+  --applied-date <date>  YYYY-MM-DD.
+  --resume-ver <name>    Resume archetype used for the application.
+  --tier <S|A|B|C>       Writes company_tiers into profile.json.
+  --force                Add despite detected duplicates.
+  --apply                Create the page and write the row (default is dry-run).`;
+
+const DEFAULT_DEPS = {
+  loadProfile: profileLoader.loadProfile,
+  loadSecrets: profileLoader.loadSecrets,
+  makeClient: notion.makeClient,
+  resolveDataSourceId: notion.resolveDataSourceId,
+  makeCompanyResolver: companyResolver.makeCompanyResolver,
+  pushJobPage: notionJobPage.pushJobPage,
+  loadApps: applicationsTsv.load,
+  saveApps: applicationsTsv.save,
+  now: () => new Date().toISOString(),
+  readFileSync: fs.readFileSync,
+  writeFileSync: fs.writeFileSync,
+  copyFileSync: fs.copyFileSync,
+  existsSync: fs.existsSync,
+};
+
+// Back up the TSV next to itself, mirroring the repo's existing
+// `applications.tsv.pre-<what>-<date>` convention.
+function backupPath(tsvPath, slug, date) {
+  return `${tsvPath}.pre-add-${slug}-${date}`;
+}
+
+// Writing the tier into profile.json is a read-modify-write of a small JSON
+// file the loader owns elsewhere; we touch only the company_tiers map and
+// preserve formatting by re-serializing with 2-space indent (matches the file).
+function writeCompanyTier(deps, profilePath, companyName, tier) {
+  const raw = deps.readFileSync(profilePath, "utf8");
+  const json = JSON.parse(raw);
+  if (!json.company_tiers) json.company_tiers = {};
+  json.company_tiers[companyName] = tier;
+  deps.writeFileSync(profilePath, `${JSON.stringify(json, null, 2)}\n`, "utf8");
+}
+
+function renderPlan(row, fields, { tier, dryRun }) {
+  const lines = [];
+  const salary =
+    row.salary_min || row.salary_max
+      ? `${row.salary_min ?? "?"} - ${row.salary_max ?? "?"}`
+      : "(none)";
+  lines.push(`  key:        ${row.key}`);
+  lines.push(`  company:    ${row.companyName}${tier ? `  (tier ${tier} → profile.json)` : ""}`);
+  lines.push(`  title:      ${row.title}`);
+  lines.push(`  status:     ${row.status}`);
+  lines.push(`  locations:  ${row.locations.length ? row.locations.join(", ") : "(none)"}`);
+  lines.push(
+    `  salary:     ${salary}${fields.salaryExpectations ? `  → "${fields.salaryExpectations}"` : ""}`
+  );
+  lines.push(`  url:        ${row.url || "(none)"}`);
+  lines.push(`  fit:        ${row.fit_score || "(none)"}`);
+  lines.push(`  applied:    ${row.applied_date || "(none)"}`);
+  if (dryRun) lines.push("");
+  return lines;
+}
+
+function makeAddCommand(overrides = {}) {
+  const deps = { ...DEFAULT_DEPS, ...overrides };
+
+  return async function addCommand(ctx) {
+    const { profileId, flags, env, stdout, stderr } = ctx;
+    const apply = Boolean(flags.apply);
+    const profilesDir = resolveProfilesDir(ctx, env || process.env);
+
+    const profile = deps.loadProfile(profileId, { profilesDir });
+
+    const jobsDbId = profile.notion && profile.notion.jobs_pipeline_db_id;
+    const companiesDbId = profile.notion && profile.notion.companies_db_id;
+    const propertyMap = profile.notion && profile.notion.property_map;
+    if (!jobsDbId) {
+      stderr("error: profile.notion.jobs_pipeline_db_id is not configured");
+      return 1;
+    }
+    if (!companiesDbId) {
+      stderr("error: profile.notion.companies_db_id is not configured");
+      return 1;
+    }
+
+    // 1. Build + validate the row from flags (pure; throws with a usable message).
+    let row;
+    let tier;
+    try {
+      tier = manualJob.validateTier(flags.tier);
+      row = manualJob.buildManualRow(
+        {
+          company: flags.company,
+          title: flags.title,
+          status: flags.status,
+          salary: flags.salary,
+          locations: flags.locations,
+          url: flags.url,
+          fit: flags.fit,
+          notes: flags.notes,
+          appliedDate: flags.appliedDate,
+          resumeVer: flags.resumeVer,
+        },
+        deps.now()
+      );
+    } catch (err) {
+      stderr(`error: ${err.message}`);
+      stderr("");
+      stderr(USAGE);
+      return 2;
+    }
+
+    const fields = manualJob.buildJobFields(row);
+    const tsvPath = path.join(profile.paths.root, "applications.tsv");
+    const { apps } = deps.loadApps(tsvPath);
+
+    // 2. Duplicate guard — before any write, before touching Notion.
+    const dupes = manualJob.findDuplicates(apps, row);
+    if (dupes.length && !flags.force) {
+      stderr(`refusing: ${dupes.length} existing row(s) look like this job:`);
+      for (const d of dupes) {
+        stderr(`  - [${d.reason}] ${d.row.key}`);
+        stderr(`    ${d.row.companyName} — ${d.row.title}  (status=${d.row.status})`);
+      }
+      stderr("pass --force to add anyway");
+      return 1;
+    }
+    if (dupes.length && flags.force) {
+      stdout(`warning: --force set, adding despite ${dupes.length} similar row(s)`);
+    }
+
+    stdout(`${apply ? "adding" : "would add"} to ${profileId}:`);
+    for (const line of renderPlan(row, fields, { tier, dryRun: !apply })) stdout(line);
+
+    if (!apply) {
+      stdout("(dry-run — pass --apply to create the Notion page and write the TSV row)");
+      return 0;
+    }
+
+    // 3. Notion first. Any failure here writes nothing.
+    const secrets = deps.loadSecrets(profileId, env || process.env);
+    const token = secrets.NOTION_TOKEN || null;
+    if (!token) {
+      stderr(`error: missing ${profileLoader.secretEnvName(profileId, "NOTION_TOKEN")} in env`);
+      return 1;
+    }
+
+    let pageId;
+    let dedup = false;
+    try {
+      const client = deps.makeClient(token);
+      const companiesDataSourceId = await deps.resolveDataSourceId(client, companiesDbId);
+      const resolver = deps.makeCompanyResolver({
+        client,
+        companiesDbId,
+        companiesDataSourceId,
+        companyTiers: profile.company_tiers || {},
+        log: (msg) => stdout(`  resolver: ${msg}`),
+      });
+
+      const res = await deps.pushJobPage({
+        client,
+        jobsDbId,
+        propertyMap,
+        companyResolver: resolver,
+        jobFields: fields,
+      });
+      pageId = res.pageId;
+      dedup = Boolean(res.dedup);
+    } catch (err) {
+      stderr(`error: Notion push failed — ${err.message}`);
+      stderr(
+        "TSV not modified. Fix the cause and re-run; the page dedup guard makes a retry safe."
+      );
+      return 1;
+    }
+
+    if (dedup) {
+      stdout(`  note: page already existed for this key — reusing ${pageId}, no duplicate created`);
+    } else {
+      stdout(`  created page ${pageId}`);
+    }
+
+    // 4. TSV second, with a backup.
+    row.notion_page_id = pageId;
+    row.updatedAt = deps.now();
+    try {
+      if (deps.existsSync(tsvPath)) {
+        const bak = backupPath(
+          tsvPath,
+          manualJob.slugify(row.companyName),
+          row.createdAt.slice(0, 10)
+        );
+        deps.copyFileSync(tsvPath, bak);
+        stdout(`  backup: ${path.basename(bak)}`);
+      }
+      apps.push(row);
+      deps.saveApps(tsvPath, apps);
+      stdout(`  TSV row written (${apps.length} rows total)`);
+    } catch (err) {
+      stderr(
+        `error: TSV write failed after the Notion page was created (${pageId}) — ${err.message}`
+      );
+      stderr("the page exists; re-running will reuse it rather than duplicate.");
+      return 1;
+    }
+
+    // 5. Tier, last — a profile.json failure must not fail the whole add.
+    if (tier) {
+      try {
+        writeCompanyTier(
+          deps,
+          path.join(profile.paths.root, "profile.json"),
+          row.companyName,
+          tier
+        );
+        stdout(`  profile.json: company_tiers["${row.companyName}"] = "${tier}"`);
+      } catch (err) {
+        stderr(`warning: could not write tier to profile.json — ${err.message}`);
+        stderr(`the row and page are fine; set company_tiers["${row.companyName}"] by hand.`);
+      }
+    }
+
+    stdout(`\nhttps://www.notion.so/${String(pageId).replace(/-/g, "")}`);
+    return 0;
+  };
+}
+
+module.exports = makeAddCommand();
+module.exports.makeAddCommand = makeAddCommand;
+module.exports.backupPath = backupPath;

--- a/engine/commands/add.test.js
+++ b/engine/commands/add.test.js
@@ -1,0 +1,336 @@
+const test = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const { makeAddCommand, backupPath } = require("./add.js");
+const applicationsTsv = require("../core/applications_tsv.js");
+
+const NOW = "2026-07-16T12:00:00.000Z";
+const PAGE_ID = "39fd3a02-26ca-81d7-8f7a-c9ebab8f9565";
+
+function makeTmpProfile(rows = []) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "add-test-"));
+  const tsvPath = path.join(root, "applications.tsv");
+  applicationsTsv.save(tsvPath, rows);
+  fs.writeFileSync(
+    path.join(root, "profile.json"),
+    `${JSON.stringify({ id: "t", company_tiers: { Existing: "A" } }, null, 2)}\n`,
+    "utf8"
+  );
+  return { root, tsvPath };
+}
+
+const PROFILE = (root) => ({
+  id: "t",
+  paths: { root },
+  company_tiers: {},
+  notion: {
+    jobs_pipeline_db_id: "jobs-db",
+    companies_db_id: "companies-db",
+    property_map: { key: { field: "Key", type: "rich_text" } },
+  },
+});
+
+// Collects stdout/stderr and records what the fakes were asked to do.
+function harness(overrides = {}, rows = []) {
+  const { root, tsvPath } = makeTmpProfile(rows);
+  const out = [];
+  const err = [];
+  const calls = { pushJobPage: [], resolveDataSourceId: 0, makeClient: 0 };
+
+  const deps = {
+    loadProfile: () => PROFILE(root),
+    loadSecrets: () => ({ NOTION_TOKEN: "secret_test" }),
+    makeClient: () => {
+      calls.makeClient++;
+      return { fake: true };
+    },
+    resolveDataSourceId: async () => {
+      calls.resolveDataSourceId++;
+      return "companies-ds";
+    },
+    makeCompanyResolver: () => ({ resolve: async () => "company-page-id" }),
+    pushJobPage: async (args) => {
+      calls.pushJobPage.push(args);
+      return { pageId: PAGE_ID, dedup: false };
+    },
+    now: () => NOW,
+    ...overrides,
+  };
+
+  const cmd = makeAddCommand(deps);
+  const ctx = (flags) => ({
+    profileId: "t",
+    flags,
+    env: {},
+    stdout: (m) => out.push(String(m)),
+    stderr: (m) => err.push(String(m)),
+  });
+
+  return { cmd, ctx, out, err, calls, root, tsvPath };
+}
+
+const BASE_FLAGS = {
+  company: "LawnStarter",
+  title: "Senior Product Manager, Pricing & Monetization",
+  status: "Interview",
+  salary: "140000-185000",
+  locations: "Remote,United States",
+};
+
+function readRows(tsvPath) {
+  return applicationsTsv.load(tsvPath).apps;
+}
+
+// ---------- dry-run ----------
+
+test("dry-run is the default: no client, no TSV write", async () => {
+  const h = harness();
+  const before = fs.readFileSync(h.tsvPath, "utf8");
+
+  const code = await h.cmd(h.ctx({ ...BASE_FLAGS }));
+
+  assert.equal(code, 0);
+  assert.equal(h.calls.makeClient, 0, "no Notion client in dry-run");
+  assert.equal(h.calls.pushJobPage.length, 0, "no page push in dry-run");
+  assert.equal(fs.readFileSync(h.tsvPath, "utf8"), before, "TSV untouched");
+  assert.match(h.out.join("\n"), /would add/);
+  assert.match(h.out.join("\n"), /dry-run/);
+});
+
+test("dry-run renders the planned row", async () => {
+  const h = harness();
+  await h.cmd(h.ctx({ ...BASE_FLAGS }));
+  const text = h.out.join("\n");
+  assert.match(text, /manual:lawnstarter_senior-product-manager-pricing-monetization_2026-07-16/);
+  assert.match(text, /status:\s+Interview/);
+  assert.match(text, /\$140-185K \(\$165K mid\)/);
+});
+
+// ---------- happy path ----------
+
+test("--apply creates the page and persists notion_page_id", async () => {
+  const h = harness();
+
+  const code = await h.cmd(h.ctx({ ...BASE_FLAGS, apply: true }));
+
+  assert.equal(code, 0);
+  assert.equal(h.calls.pushJobPage.length, 1);
+
+  const rows = readRows(h.tsvPath);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].companyName, "LawnStarter");
+  assert.equal(rows[0].status, "Interview");
+  assert.equal(rows[0].notion_page_id, PAGE_ID);
+  assert.equal(rows[0].source, "Manual");
+  assert.equal(rows[0].salary_min, 140000);
+  assert.match(h.out.join("\n"), new RegExp(PAGE_ID));
+});
+
+test("--apply passes the shared helper a payload carrying companyName and key", async () => {
+  const h = harness();
+  await h.cmd(h.ctx({ ...BASE_FLAGS, apply: true }));
+
+  const args = h.calls.pushJobPage[0];
+  assert.equal(args.jobsDbId, "jobs-db");
+  assert.equal(args.jobFields.companyName, "LawnStarter");
+  assert.equal(
+    args.jobFields.key,
+    "manual:lawnstarter_senior-product-manager-pricing-monetization_2026-07-16"
+  );
+  assert.equal(args.jobFields.status, "Interview");
+  assert.equal(typeof args.companyResolver.resolve, "function");
+});
+
+test("--apply backs the TSV up before writing", async () => {
+  const h = harness();
+  await h.cmd(h.ctx({ ...BASE_FLAGS, apply: true }));
+
+  const bak = backupPath(h.tsvPath, "lawnstarter", "2026-07-16");
+  assert.ok(fs.existsSync(bak), "backup file exists");
+  assert.equal(applicationsTsv.load(bak).apps.length, 0, "backup holds the pre-write state");
+});
+
+// ---------- failure ordering (RFC 063 §4) ----------
+
+test("Notion failure leaves the TSV byte-identical and exits non-zero", async () => {
+  const h = harness({
+    pushJobPage: async () => {
+      throw new Error("notion is down");
+    },
+  });
+  const before = fs.readFileSync(h.tsvPath, "utf8");
+
+  const code = await h.cmd(h.ctx({ ...BASE_FLAGS, apply: true }));
+
+  assert.equal(code, 1);
+  assert.equal(fs.readFileSync(h.tsvPath, "utf8"), before, "TSV byte-identical");
+  assert.match(h.err.join("\n"), /Notion push failed/);
+  assert.match(h.err.join("\n"), /TSV not modified/);
+});
+
+test("missing token fails before any Notion call and writes nothing", async () => {
+  const h = harness({ loadSecrets: () => ({}) });
+  const before = fs.readFileSync(h.tsvPath, "utf8");
+
+  const code = await h.cmd(h.ctx({ ...BASE_FLAGS, apply: true }));
+
+  assert.equal(code, 1);
+  assert.equal(h.calls.makeClient, 0);
+  assert.equal(fs.readFileSync(h.tsvPath, "utf8"), before);
+  assert.match(h.err.join("\n"), /NOTION_TOKEN/);
+});
+
+test("dedup hit reuses the existing page rather than creating a second", async () => {
+  const h = harness({
+    pushJobPage: async () => ({ pageId: "existing-page", dedup: true }),
+  });
+
+  const code = await h.cmd(h.ctx({ ...BASE_FLAGS, apply: true }));
+
+  assert.equal(code, 0);
+  const rows = readRows(h.tsvPath);
+  assert.equal(rows[0].notion_page_id, "existing-page");
+  assert.match(h.out.join("\n"), /already existed/);
+});
+
+// ---------- validation ----------
+
+test("missing --status is rejected with exit 2, before any I/O", async () => {
+  const h = harness();
+  const code = await h.cmd(h.ctx({ company: "X", title: "Y", apply: true }));
+  assert.equal(code, 2);
+  assert.equal(h.calls.makeClient, 0);
+  assert.match(h.err.join("\n"), /--status is required/);
+});
+
+test("--status Inbox is rejected by name", async () => {
+  const h = harness();
+  const code = await h.cmd(h.ctx({ ...BASE_FLAGS, status: "Inbox", apply: true }));
+  assert.equal(code, 2);
+  assert.match(h.err.join("\n"), /TSV-only/);
+});
+
+test("bad --salary is rejected", async () => {
+  const h = harness();
+  const code = await h.cmd(h.ctx({ ...BASE_FLAGS, salary: "$140k", apply: true }));
+  assert.equal(code, 2);
+  assert.match(h.err.join("\n"), /whole dollars/);
+});
+
+test("bad --tier is rejected", async () => {
+  const h = harness();
+  const code = await h.cmd(h.ctx({ ...BASE_FLAGS, tier: "Z", apply: true }));
+  assert.equal(code, 2);
+  assert.match(h.err.join("\n"), /--tier/);
+});
+
+// ---------- duplicates ----------
+
+test("a duplicate row is refused before touching Notion", async () => {
+  const existing = {
+    key: "manual:lawnstarter_pm-pricing_2026-07-01",
+    source: "Manual",
+    jobId: "x",
+    companyName: "LawnStarter",
+    title: "Senior Product Manager, Pricing & Monetization",
+    url: "",
+    locations: [],
+    status: "Applied",
+    notion_page_id: "p",
+    resume_ver: "",
+    cl_key: "",
+    salary_min: null,
+    salary_max: null,
+    cl_path: "",
+    createdAt: NOW,
+    updatedAt: NOW,
+    fit_score: "",
+    fit_rationale: "",
+    fit_evaluated_at: "",
+    skip_reason: "",
+    company_people_search_url: "",
+    outreach_type: "",
+    contact_name: "",
+    contact_linkedin: "",
+    hm_outreach_status: "To do",
+    hm_outreach_date: "",
+    applied_date: "",
+  };
+  const h = harness({}, [existing]);
+
+  const code = await h.cmd(h.ctx({ ...BASE_FLAGS, apply: true }));
+
+  assert.equal(code, 1);
+  assert.equal(h.calls.makeClient, 0, "duplicate guard runs before Notion");
+  assert.equal(readRows(h.tsvPath).length, 1, "no row added");
+  assert.match(h.err.join("\n"), /refusing/);
+  assert.match(h.err.join("\n"), /same company \+ title/);
+});
+
+test("--force overrides the duplicate guard", async () => {
+  const existing = {
+    key: "manual:lawnstarter_pm-pricing_2026-07-01",
+    source: "Manual",
+    jobId: "x",
+    companyName: "LawnStarter",
+    title: "Senior Product Manager, Pricing & Monetization",
+    url: "",
+    locations: [],
+    status: "Applied",
+    notion_page_id: "p",
+    resume_ver: "",
+    cl_key: "",
+    salary_min: null,
+    salary_max: null,
+    cl_path: "",
+    createdAt: NOW,
+    updatedAt: NOW,
+    fit_score: "",
+    fit_rationale: "",
+    fit_evaluated_at: "",
+    skip_reason: "",
+    company_people_search_url: "",
+    outreach_type: "",
+    contact_name: "",
+    contact_linkedin: "",
+    hm_outreach_status: "To do",
+    hm_outreach_date: "",
+    applied_date: "",
+  };
+  const h = harness({}, [existing]);
+
+  const code = await h.cmd(h.ctx({ ...BASE_FLAGS, apply: true, force: true }));
+
+  assert.equal(code, 0);
+  assert.equal(readRows(h.tsvPath).length, 2);
+  assert.match(h.out.join("\n"), /--force set/);
+});
+
+// ---------- tier ----------
+
+test("--tier writes company_tiers into profile.json without dropping existing entries", async () => {
+  const h = harness();
+  const code = await h.cmd(h.ctx({ ...BASE_FLAGS, apply: true, tier: "B" }));
+
+  assert.equal(code, 0);
+  const json = JSON.parse(fs.readFileSync(path.join(h.root, "profile.json"), "utf8"));
+  assert.equal(json.company_tiers.LawnStarter, "B");
+  assert.equal(json.company_tiers.Existing, "A", "pre-existing tiers preserved");
+});
+
+test("a profile.json failure warns but does not fail the add", async () => {
+  const h = harness({
+    writeFileSync: () => {
+      throw new Error("read-only fs");
+    },
+  });
+
+  const code = await h.cmd(h.ctx({ ...BASE_FLAGS, apply: true, tier: "B" }));
+
+  assert.equal(code, 0, "row and page are fine — tier is best-effort");
+  assert.equal(readRows(h.tsvPath)[0].notion_page_id, PAGE_ID);
+  assert.match(h.err.join("\n"), /could not write tier/);
+});

--- a/engine/core/manual_job.js
+++ b/engine/core/manual_job.js
@@ -1,0 +1,259 @@
+// engine/core/manual_job.js
+//
+// Pure helpers for `add` — manual job entry (RFC 063 / BL-208).
+//
+// Vacancies that arrive outside the ATS scan (referrals, newsletters,
+// recruiter email, direct site applications) are entered by hand. These
+// helpers build the TSV row and the Notion payload; no filesystem, no
+// network, no env. The command (engine/commands/add.js) owns side effects.
+//
+// Manual rows deliberately skip `Inbox`: that status means "discovered, not
+// yet evaluated by prepare" (RFC 014), which a hand-entered row never is —
+// the operator asserts its status because they already know it.
+
+const { EXPECTED_STATUS_OPTIONS } = require("./notion_status_options.js");
+const { formatSalaryDisplay } = require("./notion_job_page.js");
+
+// Seniority prefixes are stripped for duplicate *comparison* only — never
+// from the stored title. "Senior PM, Pricing" and "PM, Pricing" at the same
+// company are almost certainly the same posting re-entered.
+const SENIORITY_PREFIXES = ["senior", "sr", "staff", "lead", "principal", "junior", "jr"];
+
+// ---------- Slugs and keys ----------
+
+function slugify(value) {
+  return String(value || "")
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+// `manual:<company>_<title>_<YYYY-MM-DD>`. The date suffix keeps two genuinely
+// different postings at the same company distinguishable; near-duplicate entry
+// on a different day is caught by findDuplicates, not by the key.
+function makeManualKey({ company, title, date }) {
+  const c = slugify(company);
+  const t = slugify(title);
+  if (!c) throw new Error("company is required");
+  if (!t) throw new Error("title is required");
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(String(date || ""))) {
+    throw new Error(`date must be YYYY-MM-DD, got: ${date}`);
+  }
+  return `manual:${c}_${t}_${date}`;
+}
+
+// ---------- Input parsing / validation ----------
+
+// "140000-185000" → {min, max}; "140000" → {min, max: null}; "" → both null.
+function parseSalaryRange(input) {
+  const raw = String(input || "").trim();
+  if (!raw) return { min: null, max: null };
+  const m = raw.match(/^(\d+)(?:\s*-\s*(\d+))?$/);
+  if (!m) {
+    throw new Error(`--salary must be "MIN" or "MIN-MAX" in whole dollars, got: ${input}`);
+  }
+  const min = Number(m[1]);
+  const max = m[2] === undefined ? null : Number(m[2]);
+  if (max !== null && max < min) {
+    throw new Error(`--salary max (${max}) is below min (${min})`);
+  }
+  return { min, max };
+}
+
+// `Inbox` is rejected explicitly: it is TSV-only by RFC 014 and would fail
+// Notion validation anyway. The error names the reason rather than just
+// listing valid values.
+function validateStatus(status) {
+  const s = String(status || "").trim();
+  if (!s) throw new Error(`--status is required (one of: ${EXPECTED_STATUS_OPTIONS.join(", ")})`);
+  if (s === "Inbox") {
+    throw new Error(
+      "status Inbox is TSV-only (RFC 014) and never reaches Notion; a manual row asserts a real status"
+    );
+  }
+  if (!EXPECTED_STATUS_OPTIONS.includes(s)) {
+    throw new Error(`unknown status: ${s} (one of: ${EXPECTED_STATUS_OPTIONS.join(", ")})`);
+  }
+  return s;
+}
+
+function validateDate(value, flag) {
+  const v = String(value || "").trim();
+  if (!v) return "";
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(v)) throw new Error(`${flag} must be YYYY-MM-DD, got: ${value}`);
+  return v;
+}
+
+const VALID_TIERS = ["S", "A", "B", "C"];
+
+function validateTier(value) {
+  const v = String(value || "").trim();
+  if (!v) return "";
+  if (!VALID_TIERS.includes(v)) throw new Error(`--tier must be one of: ${VALID_TIERS.join(", ")}`);
+  return v;
+}
+
+const VALID_FIT = ["Strong", "Medium", "Weak"];
+
+function validateFit(value) {
+  const v = String(value || "").trim();
+  if (!v) return "";
+  if (!VALID_FIT.includes(v)) throw new Error(`--fit must be one of: ${VALID_FIT.join(", ")}`);
+  return v;
+}
+
+// "Remote,United States" → ["Remote", "United States"]
+function parseLocations(input) {
+  return String(input || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+// ---------- Row assembly ----------
+
+// Builds the flat TSV row (v7, 27 columns). `notion_page_id` is left empty —
+// the command fills it after pushJobPage succeeds, and writes nothing if it
+// doesn't (RFC 063 §4).
+function buildManualRow(input, nowIso) {
+  const now = nowIso || new Date().toISOString();
+  const date = now.slice(0, 10);
+  const company = String(input.company || "").trim();
+  const title = String(input.title || "").trim();
+  if (!company) throw new Error("--company is required");
+  if (!title) throw new Error("--title is required");
+
+  const status = validateStatus(input.status);
+  const { min, max } = parseSalaryRange(input.salary);
+  const fit = validateFit(input.fit);
+  const key = makeManualKey({ company, title, date });
+
+  return {
+    key,
+    source: "Manual",
+    jobId: key.slice("manual:".length),
+    companyName: company,
+    title,
+    url: String(input.url || "").trim(),
+    locations: parseLocations(input.locations),
+    status,
+    notion_page_id: "",
+    resume_ver: String(input.resumeVer || "").trim(),
+    cl_key: "",
+    salary_min: min,
+    salary_max: max,
+    cl_path: "",
+    createdAt: now,
+    updatedAt: now,
+    fit_score: fit,
+    fit_rationale: String(input.notes || "").trim(),
+    fit_evaluated_at: fit ? now : "",
+    skip_reason: "",
+    company_people_search_url: "",
+    outreach_type: "",
+    contact_name: "",
+    contact_linkedin: "",
+    hm_outreach_status: "To do",
+    hm_outreach_date: "",
+    applied_date: validateDate(input.appliedDate, "--applied-date"),
+  };
+}
+
+// Maps a TSV row onto the flat payload pushJobPage consumes. companyName is
+// passed through deliberately — pushJobPage resolves it into the relation and
+// strips it before buildProperties sees it.
+function buildJobFields(row) {
+  return {
+    title: row.title,
+    companyName: row.companyName,
+    source: row.source,
+    jobId: row.jobId,
+    url: row.url,
+    status: row.status,
+    key: row.key,
+    fitScore: row.fit_score,
+    dateAdded: row.createdAt.slice(0, 10),
+    city: Array.isArray(row.locations) ? row.locations.join(", ") : "",
+    state: "Any",
+    notes: row.fit_rationale,
+    salaryExpectations: formatSalaryDisplay(row.salary_min, row.salary_max),
+    salaryMin: row.salary_min,
+    salaryMax: row.salary_max,
+    coverLetter: row.cl_key,
+    resumeVersion: row.resume_ver,
+  };
+}
+
+// ---------- Duplicate detection ----------
+
+// Title-specific normalization, deliberately NOT sweep_dedup.normalizeName —
+// that one is built for company names (legal suffixes, Cyrillic) and coupling
+// the two dedup domains would make both harder to reason about.
+function normalizeTitle(title) {
+  let t = String(title || "")
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9\s]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  for (const p of SENIORITY_PREFIXES) {
+    if (t.startsWith(p + " ")) {
+      t = t.slice(p.length + 1);
+      break;
+    }
+  }
+  return t;
+}
+
+function normalizeCompany(name) {
+  return String(name || "")
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "")
+    .trim();
+}
+
+// Returns rows that look like the same posting. Two layers:
+//   - exact key match (same company + title + same day)
+//   - same company + same normalized title, on any non-archived row
+// Archived rows are ignored: re-adding a job that was archived long ago is a
+// legitimate action, not a duplicate.
+function findDuplicates(apps, row) {
+  const key = row.key;
+  const company = normalizeCompany(row.companyName);
+  const title = normalizeTitle(row.title);
+  const out = [];
+  for (const a of apps || []) {
+    if (a.key === key) {
+      out.push({ row: a, reason: "exact key" });
+      continue;
+    }
+    if (a.status === "Archived") continue;
+    if (normalizeCompany(a.companyName) === company && normalizeTitle(a.title) === title) {
+      out.push({ row: a, reason: `same company + title (status=${a.status})` });
+    }
+  }
+  return out;
+}
+
+module.exports = {
+  slugify,
+  makeManualKey,
+  parseSalaryRange,
+  validateStatus,
+  validateDate,
+  validateTier,
+  validateFit,
+  parseLocations,
+  buildManualRow,
+  buildJobFields,
+  normalizeTitle,
+  normalizeCompany,
+  findDuplicates,
+  VALID_TIERS,
+  VALID_FIT,
+};

--- a/engine/core/manual_job.test.js
+++ b/engine/core/manual_job.test.js
@@ -1,0 +1,290 @@
+const test = require("node:test");
+const assert = require("node:assert");
+
+const {
+  slugify,
+  makeManualKey,
+  parseSalaryRange,
+  validateStatus,
+  validateDate,
+  validateTier,
+  validateFit,
+  parseLocations,
+  buildManualRow,
+  buildJobFields,
+  normalizeTitle,
+  normalizeCompany,
+  findDuplicates,
+} = require("./manual_job.js");
+
+const { HEADER } = require("./applications_tsv.js");
+
+const NOW = "2026-07-16T12:00:00.000Z";
+
+function baseInput(over = {}) {
+  return {
+    company: "LawnStarter",
+    title: "Senior Product Manager, Pricing & Monetization",
+    status: "Interview",
+    ...over,
+  };
+}
+
+// ---------- slugify / makeManualKey ----------
+
+test("slugify: lowercases, strips punctuation, collapses separators", () => {
+  assert.equal(
+    slugify("Senior Product Manager, Pricing & Monetization"),
+    "senior-product-manager-pricing-monetization"
+  );
+  assert.equal(slugify("  Spaces  "), "spaces");
+  assert.equal(slugify("A/B Testing"), "a-b-testing");
+});
+
+test("slugify: strips diacritics rather than dropping the letter", () => {
+  assert.equal(slugify("Café München"), "cafe-munchen");
+});
+
+test("makeManualKey: manual:<company>_<title>_<date>", () => {
+  assert.equal(
+    makeManualKey({ company: "LawnStarter", title: "Senior PM", date: "2026-07-16" }),
+    "manual:lawnstarter_senior-pm_2026-07-16"
+  );
+});
+
+test("makeManualKey: rejects a bad date and empty parts", () => {
+  assert.throws(
+    () => makeManualKey({ company: "X", title: "Y", date: "16-07-2026" }),
+    /YYYY-MM-DD/
+  );
+  assert.throws(
+    () => makeManualKey({ company: "", title: "Y", date: "2026-07-16" }),
+    /company is required/
+  );
+  assert.throws(
+    () => makeManualKey({ company: "X", title: "", date: "2026-07-16" }),
+    /title is required/
+  );
+});
+
+// ---------- parseSalaryRange ----------
+
+test("parseSalaryRange: range, single bound, empty", () => {
+  assert.deepEqual(parseSalaryRange("140000-185000"), { min: 140000, max: 185000 });
+  assert.deepEqual(parseSalaryRange("140000 - 185000"), { min: 140000, max: 185000 });
+  assert.deepEqual(parseSalaryRange("150000"), { min: 150000, max: null });
+  assert.deepEqual(parseSalaryRange(""), { min: null, max: null });
+  assert.deepEqual(parseSalaryRange(undefined), { min: null, max: null });
+});
+
+test("parseSalaryRange: rejects garbage and inverted ranges", () => {
+  assert.throws(() => parseSalaryRange("$140k-185k"), /whole dollars/);
+  assert.throws(() => parseSalaryRange("140000-"), /whole dollars/);
+  assert.throws(() => parseSalaryRange("185000-140000"), /below min/);
+});
+
+// ---------- validateStatus ----------
+
+test("validateStatus: accepts the Notion status set", () => {
+  for (const s of [
+    "To Apply",
+    "Applied",
+    "Interview",
+    "Offer",
+    "Rejected",
+    "No Response",
+    "Closed",
+    "Archived",
+  ]) {
+    assert.equal(validateStatus(s), s);
+  }
+});
+
+test("validateStatus: rejects Inbox by name, citing RFC 014", () => {
+  assert.throws(() => validateStatus("Inbox"), /TSV-only/);
+});
+
+test("validateStatus: rejects unknown and empty", () => {
+  assert.throws(() => validateStatus("Submitted"), /unknown status/);
+  assert.throws(() => validateStatus(""), /required/);
+});
+
+// ---------- small validators ----------
+
+test("validateDate: passes YYYY-MM-DD, empty is allowed, garbage throws", () => {
+  assert.equal(validateDate("2026-07-16", "--applied-date"), "2026-07-16");
+  assert.equal(validateDate("", "--applied-date"), "");
+  assert.throws(
+    () => validateDate("16/07/2026", "--applied-date"),
+    /--applied-date must be YYYY-MM-DD/
+  );
+});
+
+test("validateTier / validateFit: known values, empty allowed, junk throws", () => {
+  assert.equal(validateTier("B"), "B");
+  assert.equal(validateTier(""), "");
+  assert.throws(() => validateTier("Z"), /--tier/);
+  assert.equal(validateFit("Strong"), "Strong");
+  assert.equal(validateFit(""), "");
+  assert.throws(() => validateFit("Great"), /--fit/);
+});
+
+test("parseLocations: splits, trims, drops empties", () => {
+  assert.deepEqual(parseLocations("Remote,United States"), ["Remote", "United States"]);
+  assert.deepEqual(parseLocations(" Remote , , US "), ["Remote", "US"]);
+  assert.deepEqual(parseLocations(""), []);
+});
+
+// ---------- buildManualRow ----------
+
+test("buildManualRow: row carries exactly the TSV v7 columns", () => {
+  const row = buildManualRow(baseInput(), NOW);
+  assert.deepEqual(Object.keys(row).sort(), [...HEADER].sort());
+});
+
+test("buildManualRow: source Manual, empty notion_page_id, key from company+title+date", () => {
+  const row = buildManualRow(baseInput(), NOW);
+  assert.equal(row.source, "Manual");
+  assert.equal(row.notion_page_id, "");
+  assert.equal(
+    row.key,
+    "manual:lawnstarter_senior-product-manager-pricing-monetization_2026-07-16"
+  );
+  assert.equal(row.jobId, "lawnstarter_senior-product-manager-pricing-monetization_2026-07-16");
+  assert.equal(row.status, "Interview");
+  assert.equal(row.hm_outreach_status, "To do");
+});
+
+test("buildManualRow: salary and locations parsed; applied_date passed through", () => {
+  const row = buildManualRow(
+    baseInput({
+      salary: "140000-185000",
+      locations: "Remote,United States",
+      appliedDate: "2026-07-01",
+    }),
+    NOW
+  );
+  assert.equal(row.salary_min, 140000);
+  assert.equal(row.salary_max, 185000);
+  assert.deepEqual(row.locations, ["Remote", "United States"]);
+  assert.equal(row.applied_date, "2026-07-01");
+});
+
+test("buildManualRow: fit_evaluated_at set only when a fit is given", () => {
+  assert.equal(buildManualRow(baseInput(), NOW).fit_evaluated_at, "");
+  assert.equal(buildManualRow(baseInput({ fit: "Strong" }), NOW).fit_evaluated_at, NOW);
+});
+
+test("buildManualRow: propagates validation errors", () => {
+  assert.throws(() => buildManualRow(baseInput({ status: "Inbox" }), NOW), /TSV-only/);
+  assert.throws(() => buildManualRow(baseInput({ company: "" }), NOW), /--company is required/);
+  assert.throws(() => buildManualRow(baseInput({ title: "  " }), NOW), /--title is required/);
+});
+
+// ---------- buildJobFields ----------
+
+test("buildJobFields: keeps companyName for the resolver, formats salary via the shared helper", () => {
+  const row = buildManualRow(
+    baseInput({ salary: "140000-185000", locations: "Remote,United States" }),
+    NOW
+  );
+  const fields = buildJobFields(row);
+  assert.equal(fields.companyName, "LawnStarter");
+  assert.equal(fields.key, row.key);
+  assert.equal(fields.status, "Interview");
+  assert.equal(fields.city, "Remote, United States");
+  assert.equal(fields.state, "Any");
+  assert.equal(fields.dateAdded, "2026-07-16");
+  assert.equal(fields.salaryExpectations, "$140-185K ($165K mid)");
+  assert.equal(fields.salaryMin, 140000);
+});
+
+test("buildJobFields: no salary → empty display string (buildProperties drops it)", () => {
+  const fields = buildJobFields(buildManualRow(baseInput(), NOW));
+  assert.equal(fields.salaryExpectations, "");
+});
+
+// ---------- normalization ----------
+
+test("normalizeTitle: strips one seniority prefix, punctuation, extra space", () => {
+  assert.equal(
+    normalizeTitle("Senior Product Manager, Pricing & Monetization"),
+    "product manager pricing monetization"
+  );
+  assert.equal(normalizeTitle("Sr.  Product   Manager"), "product manager");
+  assert.equal(normalizeTitle("Product Manager"), "product manager");
+});
+
+test("normalizeTitle: only a leading prefix is stripped, not a mid-title word", () => {
+  assert.equal(normalizeTitle("Product Manager, Senior Living"), "product manager senior living");
+});
+
+test("normalizeCompany: case and punctuation insensitive", () => {
+  assert.equal(normalizeCompany("LawnStarter"), normalizeCompany("lawn starter"));
+  assert.equal(normalizeCompany("Capital One (WD)"), "capitalonewd");
+});
+
+// ---------- findDuplicates ----------
+
+const EXISTING = [
+  {
+    key: "manual:lawnstarter_senior-pm_2026-07-16",
+    companyName: "LawnStarter",
+    title: "Senior PM",
+    status: "Interview",
+  },
+  { key: "greenhouse:gh:1", companyName: "Acme", title: "Product Manager", status: "To Apply" },
+  { key: "greenhouse:gh:2", companyName: "LawnStarter", title: "Data Analyst", status: "Applied" },
+  { key: "greenhouse:gh:3", companyName: "Oldco", title: "Product Manager", status: "Archived" },
+];
+
+test("findDuplicates: exact key match is reported", () => {
+  const row = {
+    key: "manual:lawnstarter_senior-pm_2026-07-16",
+    companyName: "LawnStarter",
+    title: "Senior PM",
+  };
+  const dupes = findDuplicates(EXISTING, row);
+  assert.equal(dupes.length, 1);
+  assert.equal(dupes[0].reason, "exact key");
+});
+
+test("findDuplicates: same company + title on a different day is caught despite a different key", () => {
+  const row = {
+    key: "manual:lawnstarter_senior-pm_2026-07-20",
+    companyName: "LawnStarter",
+    title: "PM",
+  };
+  const dupes = findDuplicates(EXISTING, row);
+  assert.equal(dupes.length, 1);
+  assert.match(dupes[0].reason, /same company \+ title/);
+  assert.match(dupes[0].reason, /status=Interview/);
+});
+
+test("findDuplicates: a genuinely different title at the same company is not a duplicate", () => {
+  const row = {
+    key: "manual:lawnstarter_x_2026-07-20",
+    companyName: "LawnStarter",
+    title: "Engineering Manager",
+  };
+  assert.deepEqual(findDuplicates(EXISTING, row), []);
+});
+
+test("findDuplicates: same title at a different company is not a duplicate", () => {
+  const row = {
+    key: "manual:other_pm_2026-07-20",
+    companyName: "Other Co",
+    title: "Product Manager",
+  };
+  assert.deepEqual(findDuplicates(EXISTING, row), []);
+});
+
+test("findDuplicates: archived rows are ignored — re-adding an old job is legitimate", () => {
+  const row = { key: "manual:oldco_pm_2026-07-20", companyName: "Oldco", title: "Product Manager" };
+  assert.deepEqual(findDuplicates(EXISTING, row), []);
+});
+
+test("findDuplicates: empty pool is safe", () => {
+  assert.deepEqual(findDuplicates([], { key: "k", companyName: "C", title: "T" }), []);
+  assert.deepEqual(findDuplicates(undefined, { key: "k", companyName: "C", title: "T" }), []);
+});

--- a/rfc/063-manual-job-entry.md
+++ b/rfc/063-manual-job-entry.md
@@ -1,0 +1,233 @@
+---
+id: RFC-063
+title: Manual job entry — `add` command as a second caller of pushJobPage
+status: accepted
+tier: M
+created: 2026-07-16
+tags: [engine, cli, notion, manual-entry, tsv]
+---
+
+# RFC 063 — Manual job entry: `add` as a second caller of `pushJobPage`
+
+- **Status:** Accepted (approved 2026-07-16, implemented)
+- **Tier:** M (new command + CLI registration + tests + docs; no schema change)
+- **Refs:** BL-208, RFC 014 (Inbox is TSV-only), RFC 022 (atomic per-row Notion push)
+- **Date:** 2026-07-16
+
+## 1. What changes for the user
+
+Vacancies that arrive outside the ATS scan — referrals, Lenny's Newsletter,
+recruiter emails, applying straight on a company site — currently need a
+one-off script each time. Three such entries in two months (Virto Commerce,
+the Lenny's batch, LawnStarter). After this change there is one command:
+
+```
+node engine/cli.js add --profile jared \
+  --company "LawnStarter" \
+  --title "Senior Product Manager, Pricing & Monetization" \
+  --status Interview \
+  --salary 140000-185000 \
+  --locations "Remote,United States" \
+  --url https://...
+```
+
+- **Dry-run by default** (same convention as `sync` / `companies-upsert`).
+  Prints the TSV row to be written, the company resolution
+  (`found` / `will create`), and the Notion fields. `--apply` writes.
+- **TSV backup** before write: `applications.tsv.pre-add-<slug>-<date>`.
+- **Key generated**: `manual:<company-slug>_<title-slug>_<YYYY-MM-DD>`.
+- **Duplicates refused** before any write, with the existing row printed.
+- **Notion page link** printed on success.
+
+## 2. The invariant question, and why this is not a second writer
+
+`CLAUDE.md` and RFC 014 / 022 state that new Notion job pages are created
+**exclusively by `prepare --phase commit`**, and that a push path must not be
+re-added without an RFC. BL-208 framed three options; the user picked
+**option 3 — one shared helper, two entry points**.
+
+The finding that makes this cheap: **the shared helper already exists.**
+`engine/core/notion_job_page.js` → `pushJobPage()` already owns the whole
+page-creation path — lazy `data_source_id` resolution, dedup-by-`key` against
+the Jobs DB, Company relation resolution, `createJobPage`. It is dependency-
+injected and does no filesystem or env access. `prepare` is simply its first
+caller (`engine/commands/prepare.js:829`).
+
+So `add` does **not** introduce a new writer. It becomes the **second caller
+of the same helper**. The invariant is restated, and gets stronger:
+
+> **Old:** only `prepare --phase commit` creates Notion job pages.
+> **New:** all Notion job-page creation goes through
+> `notion_job_page.pushJobPage`. `prepare --phase commit` and `add` are its
+> only callers. Nothing else calls `createJobPage` directly.
+
+This is a tighter invariant than the old one: it is enforceable by grep
+(`createJobPage` must appear only in `notion_sync.js` and `notion_job_page.js`),
+whereas "only prepare" was enforceable only by convention. `sync` stays
+pull-only — untouched.
+
+**Known exception:** `scripts/push_prepare_results_to_notion.js` calls
+`createJobPage` directly, bypassing `pushJobPage` and therefore its
+dedup-by-key guard. It is a one-off from the Lenny's batch, on no automated
+path. It stays (§10.4), so the invariant is enforced within `engine/`.
+
+## 3. Why manual rows skip `Inbox`
+
+RFC 014: fresh `scan` rows are `Inbox`, meaning "discovered, not yet
+evaluated — URL liveness, fitScore, resume archetype, CL all still absent",
+and `Inbox` rows by definition have `notion_page_id == ""` and never reach
+Notion. The `Inbox → To Apply` transition and page creation happen atomically
+inside `prepare --phase commit`.
+
+A manual row is categorically not that. The operator is entering it precisely
+*because* they already know what it is — typically "I already applied" or "I
+have an interview". Its status is asserted by the human, not derived by
+`prepare`. Running it through `prepare` (filter, URL-check, JD-fetch,
+salary-calc, fit-eval, resume + CL generation) would be expensive machinery
+producing artifacts nobody wants for a row that is already past that stage.
+
+So: `add` writes the operator-supplied status directly and creates the page in
+the same run. `--status` accepts the Notion status set
+(`To Apply / Applied / Interview / Offer / Rejected / Closed / No Response /
+Archived`) and is validated against it — never `Inbox`, which is TSV-only by
+RFC 014 and would fail Notion validation anyway.
+
+**Default:** `--status` is **required**, no default. The three real cases so
+far were `Interview`, `Applied`, `Applied` — there is no safe default, and
+guessing wrong writes a wrong card into the pipeline.
+
+## 4. Failure ordering — Notion first, then TSV
+
+RFC 022 chose, for the batch case: a per-row Notion failure leaves the row
+`Inbox` silently, the batch continues, the next run retries. That is right for
+a 20-row unattended batch.
+
+`add` is the opposite situation — one row, interactive, operator watching. It
+inverts the choice:
+
+1. Resolve company → create page via `pushJobPage`.
+2. Only on success: back up TSV, append row with `notion_page_id`, save.
+3. On any Notion error: **write nothing**, exit non-zero, print the error.
+
+Rationale: a TSV row with an empty `notion_page_id` and status `Interview` is
+not a valid state in this design — it is neither an `Inbox` row (which is
+legitimately Notion-less) nor a synced row. `sync` would later see it as a
+discrepancy. Better to write nothing and let the operator re-run.
+
+`pushJobPage`'s dedup-by-key guard makes the re-run safe: if the page was in
+fact created before the crash, the retry finds it by key and returns
+`{dedup: true}` instead of creating a second one.
+
+## 5. Duplicate detection
+
+Two layers, both before any write:
+
+- **Exact key** — `manual:<company-slug>_<title-slug>_<date>` already in TSV
+  → refuse, print the existing row.
+- **Same company + similar title** — any non-archived row with the same
+  normalized company name and a title match → refuse, print the candidates,
+  require `--force` to proceed. Catches the real case: same job entered twice
+  on different days, so the date-suffixed keys differ.
+
+Title normalization is a title-specific matcher local to `manual_job.js`, not
+`sweep_dedup.normalizeName` — see §10.3.
+
+`pushJobPage`'s own dedup-by-key against the Jobs DB stays as the last line of
+defence for the crash-window case.
+
+## 6. Shape
+
+- `engine/commands/add.js` — the command: arg parsing, dry-run rendering, TSV
+  backup, orchestration. Side effects live here.
+- `engine/core/manual_job.js` — pure helpers, no I/O:
+  - `slugify(name)` / `makeManualKey({company, title, date})`
+  - `parseSalaryRange("140000-185000")` → `{min, max}`
+  - `validateStatus(s)` against the Notion status set
+  - `buildManualRow(input)` → the flat TSV row object (v7, 27 columns)
+  - `buildJobFields(row)` → the flat payload `pushJobPage` consumes
+  - `findDuplicates(apps, row)` → the candidate list for §5
+- `engine/cli.js` — register `add` in `KNOWN_COMMANDS`.
+
+Reused as-is, no changes: `applications_tsv` (`load` / `save`),
+`company_resolver.makeCompanyResolver`, `notion_job_page.pushJobPage`,
+`notion_sync.makeClient` / `resolveDataSourceId`, `profile_loader`
+(`loadProfile` / `loadSecrets` — the token is read at runtime, never inline).
+
+Salary display: use `notion_job_page.formatSalaryDisplay`, which yields
+`$140-185K ($165K mid)`. (The LawnStarter one-off hand-wrote
+`"$140-185K base (posted)"` — inconsistent; the helper wins.)
+
+## 7. Tests
+
+Node's built-in runner, no network:
+
+- `manual_job.test.js` — slug/key generation, salary parsing (valid, single-
+  bound, garbage), status validation (rejects `Inbox` and unknown values),
+  row shape matches TSV v7 header, duplicate detection (exact key; same
+  company + similar title; no false positive on a genuinely different title).
+- `add.test.js` — arg parse; dry-run writes nothing and calls no client;
+  happy path with a fake client + fake resolver creates the row and persists
+  `notion_page_id`; **Notion throws → TSV byte-identical**; `pushJobPage`
+  returns `{dedup: true}` → row written with the existing page id, no second
+  page.
+
+## 8. Definition of Done
+
+- [x] `add` creates row + page in one run; dry-run default; `--apply` writes.
+- [x] Re-run with the same arguments → refused, no duplicate.
+- [x] Notion failure → TSV unchanged, non-zero exit.
+- [x] Within `engine/`, `createJobPage` is called only from `notion_sync.js` /
+      `notion_job_page.js`. (`scripts/push_prepare_results_to_notion.js` is a
+      known legacy exception — see §10.4.)
+- [x] `npm test` green; new tests hit no network.
+- [x] `docs/reference/cli.md` + `CLAUDE.md` + `docs/architecture/` updated; `CLAUDE.md`
+      invariant text updated to the §2 wording.
+- [x] BL-208 closed with `closed:` date.
+
+## 9. NOT in scope
+
+- Fit-eval for manual rows. `--fit` is passed by hand or left empty.
+- Resume / CL generation.
+- Batch import (CSV, Lenny's-style lists). One row first.
+- Retro-filling `applied_date` / `resume_ver` on existing manual rows.
+- Any change to `sync` (stays pull-only) or to `prepare`'s behaviour.
+
+## 9a. Implementation note — the bug the unit tests could not see
+
+`engine/cli.js` builds `ctx.flags` as an **explicit whitelist**, not a
+pass-through of `parseArgs` values. Registering a flag in `PARSE_OPTIONS` is
+therefore only half the wiring; it must also be threaded into the `ctx.flags`
+literal. The first implementation missed this, so every new flag parsed
+correctly and arrived at the command as `undefined` — `add --title X` failed
+with `--title is required`.
+
+`add.test.js` could not catch it: command tests construct `ctx` by hand, which
+mocks away the exact layer that was broken. The first live run caught it
+immediately. Regression coverage now lives in `cli.test.js` (`add: every
+registered flag reaches the command through ctx.flags`), asserting through the
+real `runCli` with a spy command. Any future command adding flags is covered by
+the same shape.
+
+## 10. Resolved
+
+1. **`--tier S|A|B|C`** — accepted, optional. When passed, `add` writes it into
+   `profile.json` → `company_tiers` (the salary matrix reads tiers from there,
+   so an untiered company silently loses its comp read). When absent, the
+   company page is still created and the tier stays unset — `add` never guesses
+   a tier.
+2. **`--applied-date YYYY-MM-DD`** — accepted, optional. Manual rows are usually
+   "already applied" and the TSV column exists; capturing it is free. Left empty
+   when not passed. (The LawnStarter row's empty `applied_date` can be filled
+   later by hand — out of scope, per §9.)
+3. **Title normalization for §5** — a small title-specific matcher inside
+   `manual_job.js`: lowercase, strip punctuation, collapse whitespace, drop
+   seniority prefixes (`senior`, `sr`, `staff`, `lead`, `principal`) for the
+   comparison only. Not reusing `sweep_dedup.normalizeName` — it is built for
+   company names (legal suffixes, Cyrillic) and stretching it onto job titles
+   would couple two unrelated dedup domains.
+4. **`scripts/push_prepare_results_to_notion.js`** — **kept as-is.** Deleting a
+   script is the operator's call, not a technical one, and there is no standing
+   approval for it. Consequence: the §8 invariant grep is scoped to `engine/`
+   rather than the whole repo. The script stays a known legacy one-off that
+   bypasses `pushJobPage`'s dedup; it is not on any automated path. If it should
+   go, that is a separate one-line ask.


### PR DESCRIPTION
## What changes for the user

Jobs arriving outside the ATS scan — referrals, Lenny's Newsletter, recruiter email, applying straight on a company site — needed a one-off script each time. Three in two months (Virto Commerce, the Lenny's batch, LawnStarter). Now:

```bash
node engine/cli.js add --profile jared \
  --company "LawnStarter" \
  --title "Senior Product Manager, Pricing & Monetization" \
  --status Interview --salary 140000-185000
```

Dry-run by default; `--apply` writes. Backs up the TSV, generates the key, refuses duplicates, prints the Notion page URL.

## Not a second Notion writer

The shared helper already existed. `core/notion_job_page.pushJobPage` owns page creation (data-source resolution, dedup-by-key, company relation, `createJobPage`); `prepare` was simply its first caller. `add` becomes the second, so the invariant **tightens**:

| | |
|---|---|
| Old | only `prepare --phase commit` creates job pages — convention-enforced |
| New | all creation goes through `pushJobPage`; `prepare` and `add` are its only callers — grep-enforceable within `engine/` |

## Decisions worth a look

- **Manual rows skip `Inbox`.** That status means "discovered, not yet evaluated by `prepare`" (RFC 014); a hand-entered row never is.
- **`--status` required, no default.** The three real cases were `Interview`, `Applied`, `Applied` — guessing writes a wrong card into the pipeline.
- **Notion first, TSV second** — the inverse of RFC 022's batch choice. One row, interactive: a Notion failure writes nothing rather than leaving a row with an empty `notion_page_id`, which is not a valid state.
- **`scripts/push_prepare_results_to_notion.js` kept**, not deleted — deleting a script is the operator's call. It stays a known legacy exception, so the invariant grep is scoped to `engine/`.

## The bug the unit tests couldn't see

`ctx.flags` in `cli.js` is an explicit whitelist — registering a flag in `PARSE_OPTIONS` is only half the wiring. The first implementation missed the threading and every flag arrived `undefined`. Command tests build `ctx` by hand, mocking away the exact broken layer; the first live run caught it. Regression now asserts through the real `runCli`.

## Verification

- `npm test` — 2216 pass, 0 fail, no network.
- `prettier --check .` clean; cli-args gate exit 2 (heuristic warn, same as existing `prepare --phase` / `answer --phase`).
- Live against the `jared` profile: duplicate guard catches the hand-added LawnStarter row via layer 2 (keys differ, company+title match); dry-run writes nothing.

Docs: `docs/reference/cli.md` (full flag table), `docs/architecture/overview.md`, `README.md`, `CLAUDE.md` invariant.

Refs: BL-208, [RFC 063](rfc/063-manual-job-entry.md), RFC 014, RFC 022.

🤖 Generated with [Claude Code](https://claude.com/claude-code)