### PR TITLE
docs(job-pipeline): recruiter-sourced role → act only through the recruiter

### DIFF
--- a/skills/job-pipeline/SKILL.md
+++ b/skills/job-pipeline/SKILL.md
@@ -815,6 +815,17 @@ Summarize:
 
 These rules apply whenever Claude generates content or makes pipeline decisions. They reference per-profile config — do not hardcode profile-specific values here.
 
+### Recruiter-sourced role — act ONLY through the recruiter
+
+When a role reaches us via a **recruiter inbound** (LinkedIn DM, email — not our own scan / auto-apply pipeline), the recruiter's advocacy (pushing the candidate through to the client) is the only edge that role carries. So:
+
+- Engage / tailor a resume for a recruiter-sourced role **only if BOTH**: (1) the vacancy is genuinely interesting, AND (2) we stay in the recruiter's process.
+- If we **decline or burn the recruiter** (they misrepresented the role, withheld the company, inflated requirements, or otherwise aren't worth going through) → **do NOT then apply to that same role directly cold.** Kill the recruiter → kill the role.
+- **Why:** a cold direct application to a recruiter-sourced role loses the recruiter's push, rarely converts, and just burns the candidate's time + tokens. Cold applications are already covered by the candidate's separate auto-apply pipeline — don't duplicate that by hand here.
+- This does not touch the candidate's own cold outbound / auto-apply channel, which stays as-is.
+
+(Reference case: Taxwell / recruiter "Amjad" called a public full-time Workday role a confidential contract, inflated 5–7yrs → 7+, withheld the company; we declined → we also do not apply directly.)
+
 ### Level Filter
 
 Single source of truth: `profiles/<id>/filter_rules.json` → `title_blocklist.patterns` and `location_blocklist.patterns`. Applied as **case-insensitive substring matches** against the full title string. Never hardcode level checks inline — add/remove patterns in `filter_rules.json` only.


### PR DESCRIPTION
## What

Adds a Global Guard Rail to the job-pipeline skill: a recruiter-inbound role is worth engaging / tailoring for **only if** it is genuinely interesting **and** we stay in the recruiter's process. If we decline or burn the recruiter, we do **not** then apply to that same role directly cold.

## Why

A cold direct application to a recruiter-sourced role loses the recruiter's advocacy (the only edge that channel carries), rarely converts, and just burns the candidate's time + tokens — cold applications are already handled by the separate auto-apply pipeline.

Reference case: recruiter misrepresented a public full-time Workday role (Taxwell) as a confidential contract, inflated the years requirement, and withheld the company. We declined → no direct apply.

Mirrored into the recruiter-inbound memory rule (the channel that fires when a recruiter message is pasted into chat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)