### PR TITLE
docs(interview-coach): README — reflect mandatory 8-step prep research screen (RFC 064)

### DIFF
--- a/rfc/064-prep-company-research-stage.md
+++ b/rfc/064-prep-company-research-stage.md
@@ -1,0 +1,212 @@
+---
+id: RFC-064
+title: Prep company-research stage — mandatory 8-step screen inside the prep konspekt
+status: accepted
+tier: M
+created: 2026-07-23
+tags: [interview-coach, skill, prep, company-research, konspekt]
+---
+
+# RFC 064 — Prep company-research stage: mandatory 8-step screen inside the prep konspekt
+
+- **Status:** Accepted (approved 2026-07-23)
+- **Tier:** M (SKILL.md `prep` section + `references/commands/prep.md` rework + smoke test + VERSIONS.md bump; no engine, no new command, no schema migration)
+- **Skill:** `interview-coach` (vendored at `skills/interview-coach/`)
+- **Refs:** `profiles/jared/interview-coach-state/constraints.md` (rule 4 — JD triage defers to Notion), konspekt convention rule 1c/1d, job-pipeline `analyze` mode (post-response go/no-go — sibling, not this)
+- **Date:** 2026-07-23
+
+## 1. What changes for the user
+
+Today `prep [company]` produces a konspekt whose research front-matter
+(the 📖 sections) is light: "what is this call", "who is the interviewer",
+"what we don't know", "what they'll assess + gaps". The depth that made the
+LawnStarter screen strong — primary-source JD, anti-requirements,
+business-model read, verified-vs-unverified reputation, interviewer freshness,
+culture vocabulary, US comp mechanics — was produced **by hand**, not forced
+by the workflow. So it is inconsistent across companies.
+
+After this change, `prep` **always** opens with a systematic **8-step
+company + role research stage**. Those 8 steps *are* the 📖 sections of the
+konspekt — there is no separate `company-screen.md` file. The 🗣️ speech
+sections (positioning, two-column 🇷🇺/🇬🇧 anchors, concerns, questions,
+cheat-sheet) stay exactly as they are and now read from a much stronger
+research base.
+
+Concretely, when the user runs `prep [company]`:
+
+- The konspekt's front-matter is the 8-step screen (business model → role from
+  primary source → people → fit-map → risks/landmines → reputation
+  verified/unverified → culture vocab → comp mechanics).
+- Each research claim is tagged verified vs unverified, and unverified numbers
+  (competitor marketing, forum figures) are explicitly marked "don't state".
+- Anti-requirements (JD disqualifiers) are extracted, not just requirements —
+  so a story that would trip a disqualifier is flagged as a **landmine**.
+- All 8 steps always run at full depth, even for a 15-min coffee chat — the
+  research is what tells the candidate whether the call is worth taking. Only
+  the 🗣️ speech sections downstream scale to the round.
+- The file stays **living**: re-running `prep` for a later round with the same
+  company updates the same konspekt, and debriefs append (the Virto pattern).
+
+Nothing about the command surface changes: no new command, no new flag, no new
+file path. `research` (lightweight target-list triage) is untouched.
+
+## 2. Why now
+
+Interview screens are increasingly recorded and transcribed (Metaview on the
+LawnStarter screen; Capital One's Power Day panels). The notes go to the
+hiring team verbatim. Demonstrated understanding of the business — *why this
+role is the lever for their economics* — scores points that a generic "I'm a
+growth PM" answer does not. The candidate's cold applications now go out via
+an external auto-apply bot and job-pipeline `analyze` already handles the
+early go/no-go. By the time `prep` runs, the decision to invest is made and an
+interview is real — this is exactly where deep, systematic company research
+pays for itself, and exactly where it is currently left to chance.
+
+## 3. Design
+
+**No new command. No new artifact.** The 8-step screen is a mandatory stage at
+the front of the existing `prep` workflow, and its output is the 📖 portion of
+the existing prep konspekt in `interview-coach-state/`.
+
+This is an evolution of two things `prep.md` already has:
+
+- `### Structured Research Step` (prep.md:291) — expanded from a short prompt
+  into the 8-step protocol below.
+- `#### Company Knowledge Sourcing (Critical)` (prep.md:301) — the Tier 1/2/3
+  (verified / general / unknown) discipline, reused and made load-bearing for
+  every research claim.
+
+The konspekt Output Schema (prep.md:470+) is re-sectioned so its 📖
+front-matter carries all 8 steps; the 🗣️ sections are unchanged.
+
+## 4. Best-of synthesis (source of the 8 steps)
+
+The 8 steps are the union of what worked across three real screens. Each step
+adopts the strongest treatment observed:
+
+| Step | Best source | What the step adopts |
+|---|---|---|
+| 1. Pull JD from source | LawnStarter | Primary JD via ATS API (e.g. Workable `apply.workable.com/api/v2/...`), never a paraphrase; reconcile against the candidate's copy; **canon = candidate's copy**; record divergences (salary band) explicitly. + Capital One: stack context that reframes the role (Discover acquisition). |
+| 2. Requirements + **anti**-requirements | LawnStarter | Extract disqualifiers, not only requirements. On LawnStarter this removed a phantom gap (Python/ML explicitly *not* required) and flagged one story (S011, single-product pricing) as a **landmine**. |
+| 3. Business model | Virto + Capital One + LawnStarter | Product, customer, and **how they make money** (not "what they do"); why this role is the lever for their economics; plain-words framing + honest "why this genuinely interests you" hooks (Virto); "how to read it" (capital-efficient → margin, not growth-at-any-cost). |
+| 4. Reputation recheck | LawnStarter | verified (Trustpilot/BBB) vs unverified (competitor GreenPal's take-rate claims) kept **separate**; competitors filtered out of sources; confirm negatives are about *this* company, not dragged from an adjacent file. |
+| 5. People | Virto + LawnStarter + Capital One | Recruiter + hiring manager; incremental HM dossier built across sessions with a full career map → fit/gap (Virto); interviewer's product philosophy becomes the scoring rubric + **freshness check** on stale press releases (LawnStarter); calibrate the interviewer's *actual* power/scope (Capital One). Find the personal-resonance hook. |
+| 6. Fit map | LawnStarter + Capital One | Every JD requirement → a specific storybank story; **landmines marked explicitly** (stories not to lead with, given the anti-requirements). |
+| 7. Culture layer | LawnStarter (§7b) | Pull their exact lexicon (careers video, values, JD) → mirror the tone **without quoting verbatim**; tie each marker to a candidate story. |
+| 8. Comp / benefits | LawnStarter (§6) | US comp mechanics for the candidate: base net-of-tax, equity in a private company, PTO, 401k, healthcare; what is **missing** from the posting → ask. Hooks into the existing `salary` command. |
+| Cross-cutting | Capital One (§8) | Sensitive topics (e.g. the Honey affiliate scandal): hold in reserve, **surface only if the interviewer raises it**, note risk symmetry, never lead with it. |
+
+## 5. The 8 steps formalized (input → output)
+
+Each step names its input, its output into the konspekt, and its sourcing rule.
+
+1. **Pull JD from source.** In: JD URL / ATS id / candidate's pasted copy.
+   Out: canonical JD text in the konspekt role section. Rule: primary source
+   only; if JS-rendered, hit the ATS API; reconcile with the candidate's copy;
+   canon = candidate's copy; list divergences.
+2. **Requirements + anti-requirements.** In: canonical JD. Out: requirement
+   list + explicit disqualifier list. Rule: a disqualifier that matches a
+   candidate story marks that story as a landmine (feeds step 6).
+3. **Business model.** In: company site, filings, press. Out: product /
+   customer / revenue mechanic / why-this-role-is-the-lever + honest interest
+   hooks. Rule: "how they earn", not "what they do".
+4. **Reputation recheck.** In: Trustpilot / BBB / Glassdoor / forums. Out:
+   verified table + unverified list marked "don't state". Rule: separate
+   competitors from sources; confirm negatives are about this company.
+5. **People.** In: LinkedIn / TheOrg / interviews / press. Out: recruiter +
+   hiring-manager dossier, freshness-checked, with a resonance hook. Rule:
+   press releases can be stale — verify current seat; mark hypotheses as
+   hypotheses.
+6. **Fit map.** In: requirements (step 2) + storybank. Out: requirement →
+   story table with landmines marked. Rule: every claim points to a real story.
+7. **Culture layer.** In: careers video / values / JD language. Out: their
+   lexicon + tie-in to candidate stories. Rule: mirror, never quote verbatim.
+8. **Comp / benefits.** In: JD comp + market. Out: US-comp mechanics read +
+   what-to-ask list. Rule: net-to-net; equity liquidity realism; flag omissions.
+
+**No depth scaling — all 8 steps always run.** Even for a 15-minute coffee
+chat, the full screen runs, because the research itself is what tells the
+candidate whether the call is worth taking at all. There is no compressed
+tier: a short round gets the same 8-step research front-matter as an onsite;
+only the 🗣️ speech sections downstream scale to the round's length and format.
+This deliberately diverges from the tiered Research Depth Levels in
+`research.md` — `research` is triage, `prep` is commitment.
+
+## 6. How the konspekt schema changes
+
+The current Output Schema 📖 1–4 expand into the 8-step research front-matter;
+🗣️ 5–8 and the cheat-sheet are unchanged. Proposed section map (final
+numbering to confirm at review):
+
+| New 📖 section | Carries step | Was |
+|---|---|---|
+| 📖 A. Company in 60 seconds | 3 (business model) | new depth on old §1 |
+| 📖 B. Role from the primary source | 1 + 2 (JD + anti-reqs) | new |
+| 📖 C. People | 5 | old §2 (interviewer), deepened |
+| 📖 D. Fit map | 6 | old §4 (assess/gaps), restructured |
+| ⚠️ E. Risks & landmines | 2 (landmines) + honest gaps + what is NOT a gap | new |
+| 📖 F. Reputation + unverified | 4 | new |
+| 📖 G. Culture vocabulary | 7 | new |
+| 📖 H. Comp / benefits | 8 | ties to `salary` |
+| 🗣️ 5–8, 📖 9, 🗣️ 10 | — | unchanged (positioning, anchors, concerns, questions, plan, cheat-sheet) |
+
+The 🗣️ anchor tables keep konspekt rule 1c/1d verbatim: spoken lines are the
+`| 🇷🇺 Говоришь так | 🇬🇧 English |` two-column table, full text both sides.
+
+## 7. Files touched
+
+- `skills/interview-coach/SKILL.md` — `### prep` entry + State Update Triggers
+  note that prep now writes the 8-step screen; Command Registry line unchanged.
+- `skills/interview-coach/references/commands/prep.md` — expand
+  `### Structured Research Step`, make `#### Company Knowledge Sourcing` the
+  per-claim gate, re-section the Output Schema per §6, add depth-scaling note.
+- `skills/interview-coach/SKILL.test.js` — smoke assertions (see §9).
+- `skills/interview-coach/VERSIONS.md` — one-line entry on ship.
+
+No engine files. No `profiles/` writes from code (the konspekt is authored by
+the coach at runtime, as today).
+
+## 8. Boundaries with adjacent tools
+
+- **`research`** (interview-coach) — stays lightweight: target-list triage,
+  "should I even look". Not touched.
+- **`decode`** (interview-coach) — restricted by constraints.md rule 4:
+  single-vacancy structural breakdown only, no batch, no fit verdict that
+  contradicts Notion. The prep screen's step-1 primary-JD pull is a
+  single-vacancy read for an interview already in hand — within rule 4.
+- **job-pipeline `analyze`** — the earlier gate: post-response Go/Pass/
+  Conditional, "should I invest at all", chat-only, no writes. The prep screen
+  is downstream: the decision to invest is already made; this prepares the
+  interview. No overlap in purpose.
+- **constraints.md** — JD triage / dedup / fit scoring stay in the Notion
+  pipeline; this RFC adds no batch behaviour and no fit verdict surface.
+
+## 9. Testing
+
+Smoke test in `SKILL.test.js` (Node built-in runner, no framework), asserting
+the doc contract so drift is caught at review:
+
+- `prep.md` documents an 8-step research stage (the eight step names present).
+- `prep.md` still marks Company Knowledge Sourcing as verified/unverified
+  (Tier 1/2/3) and requires anti-requirement extraction.
+- The Output Schema still contains the 🗣️ two-column konspekt table (rule 1c)
+  and the 📖 research front-matter.
+- No separate `company-screen.md` path is introduced (guard against the
+  reverted design): the dossier lives in the konspekt.
+
+## 10. Non-goals
+
+- No new command, flag, or file artifact.
+- No batch company research or target-list scoring (that is `research`).
+- No fit verdict that competes with the Notion pipeline (constraints rule 4).
+- No change to the 🗣️ speech sections, anchor-table format, or rule 1c/1d.
+- No engine or `profiles/`-code changes.
+
+## 11. Resolved decisions (approved 2026-07-23)
+
+1. **Section placement:** the 8-step company research is one of the **first**
+   konspekt sections, before the 🗣️ Q&A. The §6 map (📖 A–H ahead of 🗣️ 5+)
+   stands.
+2. **No depth scaling:** all 8 steps always run at full depth, including for a
+   15-minute coffee chat — the research is what tells the candidate whether the
+   call is worth taking. Only the 🗣️ speech sections scale to the round.

--- a/skills/interview-coach/README.md
+++ b/skills/interview-coach/README.md
@@ -22,7 +22,7 @@ Say `kickoff`, share your resume, and you're being coached in under 2 minutes.
 
 **Role-fit assessment** — Structured evaluation of candidate-role fit across five dimensions (requirement coverage, seniority alignment, domain relevance, competency overlap, trajectory coherence). Distinguishes strong fits from investable stretches and long shots, so candidates focus their energy on roles where they're competitive. Over time, rejection patterns reveal targeting insights that no amount of practice can fix.
 
-**Enhanced company intelligence** — Three research depth levels (Quick Scan, Standard, Deep Dive) with a structured search protocol and claim verification. Every company-specific claim maps to a source tier (verified, general knowledge, or unknown). Prep briefs include targeted web research before applying company knowledge, with source attribution for every finding.
+**Enhanced company intelligence** — Three research depth levels (Quick Scan, Standard, Deep Dive) with a structured search protocol and claim verification. Every company-specific claim maps to a source tier (verified, general knowledge, or unknown). And every `prep` brief now **always opens with a mandatory 8-step company + role research screen** — JD from the primary source + anti-requirements, business model, people, fit map, risks and landmines, verified-vs-unverified reputation, culture vocabulary, and US comp mechanics. The screen runs at full depth even for a 15-minute call and forms the reference front-matter the speaking material is built on.
 
 **Interview lifecycle** — Company research, role-specific prep briefs with interviewer intelligence, same-day post-interview debrief, outcome tracking that correlates practice scores with real results, and post-offer negotiation coaching with exact scripts.
 
@@ -118,7 +118,7 @@ For both options, the coach will ask for your resume, target role, and timeline 
 |---|---|---|
 | `research [company]` | Company research + structured fit assessment (3 depth levels) | Company snapshot, culture signals, fit assessment, claim-verified findings |
 | `decode` | JD analysis + batch triage (3 depth levels, 6 lenses) | Confidence-labeled decoding, competency extraction, fit assessment, recruiter verification questions, batch comparison, teaching layer |
-| `prep [company]` | Build role-specific prep brief (format-aware, culture-aware, role-fit assessment) | Format guidance, culture read, role-fit assessment, interviewer intelligence, competencies, predicted Qs, story mapping |
+| `prep [company]` | Build role-specific prep brief — always opens with the mandatory 8-step company + role research screen | 8-step research front-matter (business model, primary-source JD + anti-requirements, people, fit map, risks/landmines, verified/unverified reputation, culture vocab, comp), then predicted Qs, story mapping, concerns, your questions, day-of cheat sheet |
 | `concerns` | Anticipate interviewer concerns | Concern-counter-evidence map |
 | `questions` | Generate interviewer questions | 5 tailored, non-generic questions |
 | `present` | Presentation round coaching (3 depth levels) | Narrative arc selection, content structuring, timing calibration, opening/closing optimization, Q&A preparation, constraint versions |

--- a/skills/interview-coach/SKILL.md
+++ b/skills/interview-coach/SKILL.md
@@ -408,7 +408,7 @@ Write to `coaching_state.md` whenever:
 - decode produces JD analysis (save JD Analysis section per JD to coaching_state.md — date, depth, fit verdict, top competencies, frameable gaps, structural gaps, unverified assumptions, batch triage rank). Multiple JD Analysis sections can exist. Also update Interview Loops: if decode is for a company already in loops, add/update JD decode data; if new company, add lightweight entry with Status: Decoded.
 - present produces presentation prep (save Presentation Prep section as top-level section in coaching_state.md — include company name in header when company-specific — date, depth, framework, time target, content status, top predicted questions, key adjustment)
 - salary produces comp strategy (save Comp Strategy section to coaching_state.md — date, depth, target range, range basis, research completeness, stage coached, jurisdiction notes, scripts provided, key principle)
-- prep starts a new company loop or updates interviewer intel, round formats, fit verdict, fit confidence, and structural gaps (add to Interview Loops)
+- prep starts a new company loop or updates interviewer intel, round formats, fit verdict, fit confidence, and structural gaps (add to Interview Loops). prep always opens with the mandatory 8-step company + role research screen — that screen *is* the konspekt's 📖 A–H front-matter (no separate research file), runs at full depth even for a 15-min call, and feeds the 🗣️ speech sections (RFC 064)
 - negotiate receives an offer (add to Outcome Log with Result: offer)
 - reflect archives the coaching state (add Status: Archived header)
 - Meta-check conversations (record candidate's response and any coaching adjustment to Meta-Check Log)
@@ -444,7 +444,7 @@ Execute commands immediately when detected. Before executing, **read the referen
 |---|---|
 | `kickoff` | Initialize coaching profile |
 | `research [company]` | Lightweight company research + fit assessment |
-| `prep [company]` | Company + role prep brief |
+| `prep [company]` | Company + role prep brief — opens with the mandatory 8-step research screen (📖 A–H) |
 | `analyze` | Transcript analysis and scoring |
 | `debrief` | Post-interview rapid capture (same day) |
 | `practice` | Practice drill menu and rounds |

--- a/skills/interview-coach/SKILL.test.js
+++ b/skills/interview-coach/SKILL.test.js
@@ -5,6 +5,8 @@ const fs = require("fs");
 const path = require("path");
 
 const SKILL_PATH = path.resolve(__dirname, "SKILL.md");
+const PREP_PATH = path.resolve(__dirname, "references/commands/prep.md");
+const CONVENTIONS_PATH = path.resolve(__dirname, "references/conventions.md");
 
 test("SKILL.md exists and starts with the required frontmatter", () => {
   assert.ok(fs.existsSync(SKILL_PATH), "SKILL.md missing");
@@ -25,5 +27,82 @@ test("SKILL.md pins coaching_state.md to profiles/<id>/interview-coach-state/", 
     text,
     /profiles\/<id>\/interview-coach-state\/coaching_state\.md/,
     "must document the profile-scoped path for coaching_state.md"
+  );
+});
+
+// RFC 064 — prep opens with a mandatory 8-step company + role research screen
+// whose output IS the konspekt 📖 A–H front-matter (no separate file). These
+// assertions lock the doc contract so a future edit can't silently drop a step,
+// re-introduce depth-scaling, or split the dossier into a parallel artifact.
+
+test("prep.md documents all 8 research-screen step titles (RFC 064)", () => {
+  const text = fs.readFileSync(PREP_PATH, "utf8");
+  for (const step of [
+    "Pull JD from the primary source",
+    "Requirements + anti-requirements",
+    "Business model",
+    "Reputation recheck",
+    "People",
+    "Fit map",
+    "Culture layer",
+    "Comp / benefits",
+  ]) {
+    assert.match(text, new RegExp(step.replace(/[+/]/g, "\\$&")), `missing step: ${step}`);
+  }
+});
+
+test("prep.md keeps Company Knowledge Sourcing as the per-claim verified/unverified gate (RFC 064)", () => {
+  const text = fs.readFileSync(PREP_PATH, "utf8");
+  assert.match(text, /Tier 1 — Verified/i, "Tier 1 verified must survive");
+  assert.match(text, /Tier 3 — Unknown/i, "Tier 3 unknown must survive");
+  // anti-requirement extraction is the load-bearing addition.
+  assert.match(text, /anti-requirements/i, "must require anti-requirement extraction");
+  // the tiering must be wired to the 8 steps, not left as an isolated aside.
+  assert.match(text, /per-claim gate for every one of the 8 research steps/i);
+});
+
+test("prep.md Output Schema carries the 📖 A–H front-matter AND the unchanged 🗣️ speech sections (RFC 064)", () => {
+  const text = fs.readFileSync(PREP_PATH, "utf8");
+  assert.match(text, /## 📖 A\. Компания за 60 секунд/, "front-matter A missing");
+  assert.match(text, /## ⚠️ E\. Риски и landmines/, "risks/landmines section missing");
+  assert.match(text, /## 📖 H\. Комп и бенефиты/, "comp section missing");
+  // Sections stay numbered 5–10 so the §9-plan and §10-cheat-sheet anchor
+  // links (which point at §5–§8 and at §9/§10 themselves) don't break.
+  assert.match(text, /## 🗣️ 5\. Твоё позиционирование/, "speech §5 must be unchanged");
+  assert.match(text, /## 🗣️ 6\. Вероятные вопросы и истории/, "speech §6 must be unchanged");
+  assert.match(text, /## 📖 9\. План на оставшиеся часы/, "plan §9 must be unchanged");
+  assert.match(text, /## 🗣️ 10\. Day-of cheat sheet/, "cheat-sheet §10 must be unchanged");
+});
+
+test("prep.md forbids depth-scaling — all 8 steps always run at full depth (RFC 064)", () => {
+  const text = fs.readFileSync(PREP_PATH, "utf8");
+  assert.match(
+    text,
+    /All 8 steps always\s*\n?\s*run at full depth/i,
+    "must state all 8 steps always run at full depth"
+  );
+});
+
+test("no separate company-screen.md artifact is introduced — dossier lives in the konspekt (RFC 064)", () => {
+  const prep = fs.readFileSync(PREP_PATH, "utf8");
+  const skill = fs.readFileSync(SKILL_PATH, "utf8");
+  assert.doesNotMatch(
+    prep,
+    /company-screen\.md/,
+    "prep.md must not reference a separate dossier file"
+  );
+  assert.doesNotMatch(
+    skill,
+    /company-screen\.md/,
+    "SKILL.md must not reference a separate dossier file"
+  );
+});
+
+test("conventions.md rule 1c two-column konspekt table is untouched (RFC 064 non-goal)", () => {
+  const text = fs.readFileSync(CONVENTIONS_PATH, "utf8");
+  assert.match(
+    text,
+    /\| 🇷🇺 Говоришь так \| 🇬🇧 English \|/,
+    "rule 1c two-column table must survive"
   );
 });

--- a/skills/interview-coach/VERSIONS.md
+++ b/skills/interview-coach/VERSIONS.md
@@ -121,6 +121,10 @@ Three new commands for the artifacts candidates build before they ever interview
 
 **Key files**: `SKILL.md` (schema migration rules), `references/commands/kickoff.md` (Interview Intelligence for new users)
 
+### Refinements
+
+- **2026-07-23 (RFC 064)** — `prep` now always opens with a mandatory 8-step company + role research screen (JD-from-source + anti-requirements → business model → people → fit map → risks/landmines → verified/unverified reputation → culture vocab → US comp mechanics). The screen *is* the konspekt's 📖 A–H front-matter — no separate file — runs at full depth even for a 15-minute call, and feeds the unchanged 🗣️ speech sections. Formalizes the depth that was previously produced by hand. Key files: `references/commands/prep.md` (research screen + re-sectioned Output Schema), `SKILL.md` (`prep` registry + State Update Triggers).
+
 ---
 
 ## v4: Interaction Model (planned)

--- a/skills/interview-coach/references/commands/prep.md
+++ b/skills/interview-coach/references/commands/prep.md
@@ -288,19 +288,71 @@ Don't quietly skip these topics — name the boundary so the candidate knows whe
 
 Companies have interviewing cultures that transcend individual JDs. When a known company is specified, apply culture-specific coaching — **but only from verified sources**.
 
-#### Structured Research Step
+#### The 8-step research screen (mandatory — this is the 📖 front-matter)
 
-Before applying company knowledge sourcing tiers, run a targeted search to ground the prep brief in current data:
-1. Search for the company's current careers page and extract their stated values/principles.
-2. Search for recent news (last 6 months) — funding, layoffs, product launches change interview culture.
-3. If the candidate provided interviewer LinkedIn URLs, research each one using the Interviewer Intelligence protocol below.
-4. Cross-reference findings with what the candidate has already told you.
+`prep` **always** opens with a systematic 8-step company + role research
+screen. These 8 steps *are* the 📖 sections of the konspekt (see Output
+Schema → 📖 A–H); there is no separate research file. **All 8 steps always
+run at full depth**, even for a 15-minute coffee chat — the research is what
+tells the candidate whether the call is worth taking at all. Only the 🗣️
+speech sections downstream scale to the round's length and format. (This
+diverges deliberately from the tiered Research Depth Levels in `research.md`:
+`research` is triage, `prep` is commitment.)
 
-Present findings with source attribution: "From their careers page: [finding]" not "This company values [finding]." Follow the Claim Verification Protocol from `references/commands/research.md` — every claim maps to Tier 1, 2, or 3.
+Each step has an input, an output into the konspekt, and a sourcing rule.
+Every claim maps to a Company Knowledge Sourcing tier (below) — a fact is
+either **verified** (cite the source) or **unverified** (label it, and for
+numbers say "don't state").
+
+1. **Pull JD from the primary source.** In: JD URL / ATS id / candidate's
+   pasted copy. Out: canonical JD text in 📖 B. Rule: primary source only —
+   if the page is JS-rendered, hit the ATS API (e.g. Workable
+   `apply.workable.com/api/v2/accounts/<slug>/jobs/<shortcode>`); reconcile
+   against the candidate's copy; **canon = the candidate's copy**; list any
+   divergences (salary band especially) explicitly.
+2. **Requirements + anti-requirements.** In: canonical JD. Out: a requirement
+   list *and* an explicit disqualifier list in 📖 B. Rule: extract
+   disqualifiers, not only requirements — this both removes phantom gaps
+   (something explicitly *not* required, e.g. "Python/ML not needed") and
+   flags any candidate story that trips a disqualifier as a **landmine**
+   (feeds ⚠️ E and story selection in 🗣️ 6).
+3. **Business model.** In: company site, filings, press. Out: product /
+   customer / **how they make money** / why this role is the lever for their
+   economics, in 📖 A. Rule: "how they earn", not "what they do"; add a
+   one-line "how to read it" (e.g. capital-efficient → margin, not
+   growth-at-any-cost) and 1–2 honest "why this genuinely interests you" hooks.
+4. **Reputation recheck.** In: Trustpilot / BBB / Glassdoor / forums. Out: a
+   **verified** table + an **unverified** list marked "don't state", in 📖 F.
+   Rule: keep competitors' claims out of the sources; confirm every negative
+   is about *this* company, not dragged from an adjacent file.
+5. **People.** In: LinkedIn / TheOrg / interviews / press. Out: recruiter +
+   hiring-manager dossier in 📖 C, freshness-checked, with a resonance hook.
+   Rule: press releases go stale — verify the current seat (self-reported
+   LinkedIn title > aggregators); mark hypotheses as hypotheses.
+6. **Fit map.** In: requirements (step 2) + storybank. Out: a requirement →
+   specific-story table in 📖 D with **landmines marked explicitly**. Rule:
+   every claim points to a real storybank story.
+7. **Culture layer.** In: careers video / values / JD language. Out: their
+   exact lexicon + a tie-in to a candidate story, in 📖 G. Rule: mirror the
+   tone, **never quote verbatim**.
+8. **Comp / benefits.** In: JD comp + market. Out: a US-comp mechanics read +
+   a what-to-ask list in 📖 H. Rule: net-to-net; equity-liquidity realism for
+   a private company; flag what the posting omits. Hooks into the `salary`
+   command.
+
+Cross-cutting: sensitive topics (a scandal, a lawsuit) go into ⚠️ E held in
+reserve — surface **only if the interviewer raises it**, note the risk
+symmetry, never lead with it.
+
+If the candidate provided interviewer LinkedIn URLs, run step 5 via the
+Interviewer Intelligence protocol below. Present every finding with source
+attribution: "From their careers page: [finding]", not "This company values
+[finding]." Follow the Claim Verification Protocol from
+`references/commands/research.md`.
 
 #### Company Knowledge Sourcing (Critical)
 
-This is a high-stakes area. Telling a candidate "Stripe values X in interviews" when you're guessing can actively hurt them. Every company-specific claim must be sourced to one of three tiers:
+This is a high-stakes area. Telling a candidate "Stripe values X in interviews" when you're guessing can actively hurt them. This tiering is the **per-claim gate for every one of the 8 research steps above** — no fact reaches the konspekt untagged. Every company-specific claim must be sourced to one of three tiers:
 
 **Tier 1 — Verified (cite the source):**
 Claims based on information you can actually retrieve and point to during this session:
@@ -451,49 +503,66 @@ The recurring failure (caught 2026-05-14 on Ross Burton prep) is to skip Step 7.
 
 ### Output Schema
 
-The prep brief uses a **fixed 10-section narrative structure** with visual markers separating reference material from speaking material. The order is strict — do not reorder sections.
+The prep brief has two parts in a **fixed, strict order — do not reorder**:
+
+1. **📖 A–H research front-matter** — the 8-step company + role screen (see
+   "The 8-step research screen" above). This is the systematic research base,
+   always present, always full-depth.
+2. **Sections 5–10 (🗣️ speech, with 📖 §9 plan inside)** — positioning, Q&A,
+   concerns, questions, plan, cheat sheet. These read from the front-matter and
+   scale to the round.
+
+Visual markers separate reference material from speaking material.
 
 **Section markers (use as prefixes in section headers):**
 
 - **📖 = read once, reference material.** Context the candidate skims before the call to load mental state. Not memorized.
+- **⚠️ = risk / do-not-trip.** Landmines, structural gaps, and sensitive topics the candidate holds in reserve. Read carefully, act defensively.
 - **🗣️ = learn and speak.** Material the candidate actually delivers in the interview. Russian summary of *what to say* + English anchor phrases (1-5 words each) that are short enough to recall under pressure. No long English scripts to read aloud — those break under ESL pressure. See `references/conventions.md` rule 1.
 
 **Header line (always include at the top of the brief):**
 
-> `📖 = справка, читай один раз. 🗣️ = речь, опорный конспект (смысл по-русски + anchor phrases на английском). После любой 🗣️ фразы — пауза, дай интервьюеру среагировать.`
+> `📖 = справка, читай один раз. ⚠️ = риск, не наступи. 🗣️ = речь, опорный конспект (смысл по-русски + anchor phrases на английском). После любой 🗣️ фразы — пауза, дай интервьюеру среагировать.`
 
 (Translate to the candidate's narrative language if not Russian. The header is the orientation device — without it, the markers don't land.)
 
-**The 10 sections in order:**
+**The structure — 📖 A–H research front-matter, then sections 5–10 (🗣️ speech + 📖 §9 plan), strict order:**
 
 ```markdown
 # Prep — [Company] [Round/Stage] — [Interviewer] — [Date]
 
-📖 = справка, читай один раз. 🗣️ = речь, опорный конспект (смысл по-русски + anchor phrases на английском). После любой 🗣️ фразы — пауза, дай интервьюеру среагировать.
+📖 = справка, читай один раз. ⚠️ = риск, не наступи. 🗣️ = речь, опорный конспект (смысл по-русски + anchor phrases на английском). После любой 🗣️ фразы — пауза, дай интервьюеру среагировать.
+
+Файл лежит по абсолютному пути — указать здесь, в шапке.
 
 ---
 
-## 📖 1. Что это за звонок
+## 📖 A. Компания за 60 секунд
 
-Связный параграф (3-5 предложений) — что за раунд, кто на той стороне (имя + роль), где компания в воронке у кандидата, длительность, формат, дата/время. Файл лежит по абсолютному пути — указать в конце параграфа.
+Связный параграф (research step 3 — business model): продукт / клиент / **как они зарабатывают** (не «что делают»), почему именно эта роль — рычаг для их экономики. Одна строка «как это читать» (напр. capital-efficient → маржа, не рост любой ценой) + 1-2 честных хука «почему тебе это реально интересно» — без натяжки.
 
-Не таблица, не bullets — параграф, чтобы кандидат «вошёл в курс» одним чтением.
+Каждый факт — verified (сайт / JD / filings, с источником) или помечен как догадка. Стартовый контекст раунда (что за звонок, где компания в воронке кандидата, длительность, формат, дата/время) — одной фразой в начале параграфа.
 
-## 📖 2. Кто такой [Interviewer Name] и что он на самом деле ищет
+## 📖 B. Роль из первоисточника
 
-Связный параграф про интервьюера — функциональная линза, фон, специализация, что он скорее всего фильтрует. Заканчивается одной чёткой фразой: «Поэтому твоя задача за N минут — Y». То, что раньше было «Critical Reframe», теперь живёт здесь как замыкающая мысль параграфа, не отдельной секцией.
+**JD из первоисточника (step 1).** Канонический текст вакансии — primary source, не пересказ. Если страница JS-рендерится — тянем ATS API (напр. Workable `apply.workable.com/api/v2/accounts/<slug>/jobs/<shortcode>`). Сверить с копией кандидата; **canon = копия кандидата**; расхождения (особенно вилка зарплаты) выписать явно.
 
-Если есть отдельный инсайд от рекрутёра / Paula / кого-то ещё, кто видел этого интервьюера — sub-секция `### Инсайд от [имя]` с прямой цитатой (без редактуры). Цитата стоит больше, чем пересказ.
+**Requirements + anti-requirements (step 2).** Два списка:
 
-Если интервьюера несколько (panel) — отдельный параграф на каждого.
+- **Требования** — что реально нужно.
+- **Anti-requirements / дисквалификаторы** — что вычёркивает кандидата, ИЛИ что явно **НЕ** требуется (снимает фантомный гэп, напр. «Python/ML не нужен»).
 
-## 📖 3. Что мы не знаем про этот раунд
+Дисквалификатор, совпавший с историей кандидата, помечает её как **landmine** — уходит в ⚠️ E и влияет на выбор истории в 🗣️ 6.
 
-Короткий честный список (3-5 буллетов) — реальные unknowns, влияющие на готовность: формат не подтверждён, длительность не подтверждена, конкретный фокус интервьюера, качество историй из storybank, etc. Это **мета-калибровка**, потому стоит в начале, не в конце.
+## 📖 C. Кто такой [Interviewer Name] и что он на самом деле ищет
 
-Не «что я могу узнать» — а «что осталось неизвестным после всей разведки».
+Связный параграф про интервьюера (research step 5) — функциональная линза, фон, специализация, что он скорее всего фильтрует. Заканчивается одной чёткой фразой: «Поэтому твоя задача за N минут — Y». То, что раньше было «Critical Reframe», живёт здесь как замыкающая мысль параграфа.
 
-## 📖 4. Что они оценят и где у тебя гэпы
+**Freshness-check:** пресс-релизы устаревают — подтвердить текущую позицию (self-reported LinkedIn title > агрегаторы вроде The Org); гипотезу помечать как гипотезу. Найти **resonance hook** — естественную общую почву, не натянутую.
+
+Если есть инсайд от рекрутёра / кого-то, кто видел этого интервьюера — sub-секция `### Инсайд от [имя]` с прямой цитатой (без редактуры). Цитата стоит больше пересказа. Panel → отдельный параграф на каждого.
+
+## 📖 D. Карта соответствия (fit map)
 
 Role-Fit Assessment как **bullets / параграф, не таблица**. Прохожу по 5 измерениям:
 
@@ -503,12 +572,37 @@ Role-Fit Assessment как **bullets / параграф, не таблица**. 
 - **Competency Overlap** — карта JD-компетенций на storybank, где сильное, где гэп.
 - **Trajectory Coherence** — логичен ли этот шаг как next career move.
 
-Под каждым — конкретика, не «Strong / Moderate / Weak» вакуумно. После — две короткие подсекции:
+Под каждым — конкретика, не «Strong / Moderate / Weak» вакуумно.
 
-- **Frameable gaps** — что бридж-нарративом покрывается (готовим counter-line в §7).
-- **Structural gaps** — что нарративом не покрыть (называем честно, готовимся к probing).
+Затем таблица **requirement → конкретная история storybank** (research step 6). Каждое требование из §B → реальный S###. **Landmines помечены явно** — истории, с которых НЕ начинать (из anti-requirements §B).
 
 Verdict (Strong Fit / Investable Stretch / Long-Shot Stretch / Weak Fit) — в одну строку в конце.
+
+## ⚠️ E. Риски и landmines
+
+- **Landmines** — истории / темы, которые триггерят дисквалификатор из §B. Не вести с них.
+- **Frameable gaps** — что бридж-нарративом покрывается (counter-line готовим в 🗣️ 7).
+- **Structural gaps** — что нарративом не покрыть; называем честно, готовимся к probing.
+- **Что НЕ гэп** — фантомные требования, снятые в §B. Не извиняться за то, чего не просят.
+- **Чего мы не знаем** — короткий честный список реальных unknowns, влияющих на готовность (формат / длительность / фокус интервьюера не подтверждены, качество историй storybank). Мета-калибровка, не «что могу узнать».
+- **Sensitive topics** — щекотливое (скандал, иск, публичный факап): держать в резерве, поднимать **только если интервьюер сам заговорил**, отметить симметрию риска, никогда не вести с этого.
+
+## 📖 F. Репутация: verified vs unverified
+
+Две группы, разделять жёстко:
+
+- **Verified** (Trustpilot / BBB / Glassdoor — с источником): факты, которые можно называть на звонке.
+- **Unverified** (форумы, заявления конкурентов, маркетинговые цифры): помечены **«не называть»**.
+
+Конкурентов отфильтровать из источников; убедиться, что каждый негатив — про **эту** компанию, а не притянут из соседнего файла.
+
+## 📖 G. Словарь культуры
+
+Их точный лексикон (careers video / values page / язык JD) → зеркалить тон **без дословного цитирования**. Каждый маркер культуры привязать к конкретной истории кандидата (research step 7).
+
+## 📖 H. Комп и бенефиты
+
+US-comp механика под кандидата (research step 8): base net-of-tax, equity в частной компании (реализм ликвидности), PTO, 401k, healthcare. Что **отсутствует** в постинге → в список «спросить на звонке». Считать net-to-net. Хук в команду `salary`.
 
 ## 🗣️ 5. Твоё позиционирование
 
@@ -571,7 +665,7 @@ Headline — это ответ на вопрос «расскажи о себе�
 
 ## 🗣️ 7. Концерны и контры
 
-Топ-3 концерна интервьюера (из §4 Role-Fit или из истории компании). Каждый — блок:
+Топ-3 концерна интервьюера (из 📖 D fit-map / ⚠️ E рисков или из истории компании). Каждый — блок:
 
 ```
 ### Концерн N: [Одна фраза, что его насторожит]
@@ -670,6 +764,6 @@ Adaptive footer — этот пункт встроен сюда как **лог�
 [конец брифа]
 ```
 
-**Section ordering — НЕ переставлять.** Порядок секций (📖 §1-3 → 🗣️ §5-8 с прослойкой 📖 §4 → 📖 §9 → 🗣️ §10) выверен эмпирически: сначала ввод в контекст, потом материал для разговора, потом мета-план, потом cheat sheet как навигация. Любая перестановка ломает «нарратив» брифа.
+**Section ordering — НЕ переставлять.** Порядок (📖 A–H research front-matter → 🗣️ §5–8 → 📖 §9 → 🗣️ §10) выверен эмпирически: сначала систематический ресёрч (8-шаговый screen как справочная база), потом материал для разговора, потом мета-план, потом cheat sheet как навигация. 8-шаговый ресёрч всегда идёт первым и на полной глубине (RFC 064) — именно он говорит кандидату, стоит ли вообще выделять время на звонок. Любая перестановка ломает «нарратив» брифа.
 
-**Когда что-то не применимо:** если у тебя нет данных про §2 (recruiter не дал ничего про интервьюера) — оставь параграф коротким и честно скажи «У нас минимум интел — что знаем: X. Чего не знаем: Y». §3 (unknowns) дублирует это явно. Не выдумывай.
+**Когда что-то не применимо:** если у тебя нет данных про 📖 C (recruiter не дал ничего про интервьюера) — оставь параграф коротким и честно скажи «У нас минимум интел — что знаем: X. Чего не знаем: Y». ⚠️ E (блок «Чего мы не знаем») дублирует это явно. Не выдумывай.

--- a/skills/job-pipeline/SKILL.md
+++ b/skills/job-pipeline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: job-pipeline
-description: "Multi-profile job-search pipeline — scan ATS adapters, validate the pipeline, prepare Inbox jobs (fit scoring, CL gen, Notion push), sync with Notion, check Gmail for responses, and answer application Q&A questions with reuse from a Notion-backed answer bank. Trigger on: /job-pipeline, /job-pipeline scan, /job-pipeline validate, /job-pipeline sync, /job-pipeline prepare, /job-pipeline check, /job-pipeline answer, or when user asks to scan/validate/sync/prepare/check/answer jobs for a specific profile (see the `profiles/` directory for the current list)."
+description: "Multi-profile job-search pipeline — scan ATS adapters, validate the pipeline, prepare Inbox jobs (fit scoring, CL gen, Notion push), sync with Notion, check Gmail for responses, answer application Q&A questions with reuse from a Notion-backed answer bank, and analyze a responded vacancy + its company for a Go/Pass/Conditional decision. Trigger on: /job-pipeline, /job-pipeline scan, /job-pipeline validate, /job-pipeline sync, /job-pipeline prepare, /job-pipeline check, /job-pipeline answer, /job-pipeline analyze, or when user asks to scan/validate/sync/prepare/check/answer/analyze jobs for a specific profile (see the `profiles/` directory for the current list)."
 ---
 
 # job-pipeline — Multi-profile Job Search Pipeline
@@ -16,6 +16,7 @@ Single engine, per-profile data. All commands take `--profile <id>`. Currently s
 - **`/job-pipeline check`** — Two-phase Gmail response check: `--prepare` builds Gmail search batches for Claude MCP, `--apply` consumes Claude-written emails and updates Notion + TSV + logs.
 - **`/job-pipeline indeed-prep`** — Phase 1 of Indeed ingest. Prints scan URLs + JS extraction snippet + filter context for the Claude browser MCP session. Phase 2 (browser fetch) is manual via Chrome MCP. Phase 3 = standard `scan` (the indeed adapter ingests the file Claude wrote).
 - **`/job-pipeline answer`** — Generate or reuse application answers (Why join? / Influences? / Motivation? etc.). Three-phase: search Notion Q&A DB by dedup key → reuse if exact match else generate via Humanizer Rules → push answer back to Notion + write local `.md` backup. Per-profile DB at `profile.notion.application_qa_db_id`.
+- **`/job-pipeline analyze`** — **Post-response decision gate.** For a vacancy where the company has already replied (the candidate's external auto-apply bot applied cold; the conversation has started). Chat-only advisory: fetch the JD + web-research the company, score fit against the candidate's real frames (craft / comp / location / English-load / achievement overlap) and the company as a place to work, then return a **Go / Pass / Conditional** verdict with what to confirm on the call. Writes nothing — no Notion, no TSV, no files.
 
 If no mode is specified, show this help and ask which to run.
 
@@ -808,6 +809,76 @@ Summarize:
 - **`invalid category`** — the draft includes a category not in the canonical 8. Fix to one of: Behavioral, Technical, Culture Fit, Logistics, Salary, Other, Experience, Motivation. The categorize() helper picks a default automatically.
 - **Notion 400 on create** — usually a missing required property or a Category option that doesn't exist in the DB. Categories must already be in the DB schema; do not invent new ones.
 - **Search returns nothing for a clearly recurring question** — the question text drift may exceed the 120-char dedup window. Look at `partials` for near-matches.
+
+---
+
+### analyze
+
+**Post-response decision gate.** Chat-only, Claude-executed, **no CLI phase, no writes**. This mode exists because the candidate's cold applications now go out through an **external auto-apply bot** — by the time a vacancy reaches this skill, the company has already *replied* and a conversation is live. The question is no longer "should we apply?" (the bot already did) but **"is this worth the candidate's time, tokens, and interview energy to pursue?"**
+
+This is the mirror image of `prepare`: `prepare` scores Inbox jobs *before* an application to gate outbound; `analyze` scores a *responded* job *after* first contact to gate how much the candidate invests next. It reuses the same fit basis but adds a **company desirability** read that `prepare` does not do.
+
+**Use when:** the user pastes a vacancy the company has responded to (a job URL, a JD text block, or a recruiter's reply email) and asks to "analyze / разбери / стоит ли идти / go or pass". Also on explicit `/job-pipeline analyze`.
+
+**Do NOT** create Notion pages, touch `applications.tsv`, write files, or run `prepare`/`tailor`/`interview-coach`. This mode ends at a recommendation. On a `Go` verdict, *offer* the next step (interview-coach brief for the role, tailored CV) but execute only if the user says yes.
+
+#### Step 1 — Assemble the vacancy
+
+From whatever the user pasted, resolve three things: **company**, **role title**, **JD text**.
+
+- **URL only** → fetch the page (WebFetch, or firecrawl_scrape if the ATS is JS-heavy) and extract the JD.
+- **Recruiter email only** → extract company + role + any comp/format hints from the message. If the JD itself is not in the email, ask the user for the JD link or fetch it if a URL is present. Do not invent requirements the email/JD does not state.
+- **JD text pasted** → use it directly.
+
+If company or role is still ambiguous after this, ask the user once. Never guess the company name from a slug.
+
+#### Step 2 — Load the fit basis (read-only)
+
+Read from disk under `profiles/<id>/` (there is no `prepare_context.json` in this mode):
+
+1. `fit_profile.md` — the generated achievement digest (RFC 060). This is the fit basis. If missing, fall back to `memory/user_resume_key_points.md`.
+2. `memory/feedback_*.md` — the framing guard-rails (craft-targeting, comp anchors, English-load, US-target, "never co-founder", positioning-from-docs). These are **hard constraints on the verdict**, not style notes.
+3. `filter_rules.json → role_targets` — acceptable tracks + `fit_treatment: "bridge"` treatments.
+
+All positioning claims about the candidate come from these files. Do not improvise a "sweet spot" narrative (see `feedback_positioning_from_jared_docs.md`).
+
+#### Step 3 — Part 1: Fit with the candidate
+
+Score each lens. Be blunt; this is a decision aid, not a pitch.
+
+- **Craft** — is the work conversion / growth / experimentation / the candidate's real craft, or off it? Industry (fintech, health, etc.) is **WHERE, not WHAT** — never downgrade on industry alone (`feedback_fintech_is_where_not_what.md`). State which achievement in `fit_profile.md` the core JD requirement maps onto.
+- **Achievement overlap** — apply the same Strong / Medium / Weak overlap rule as the [Fit Score](#fit-score-domain-fit-only) guard rail (achievement-with-metric = Strong; adjacent = Medium; none = Weak). Level and track never downgrade; bridge tracks can upgrade. Report the level as *context for the verdict*, not as a gate.
+- **Comp** — always **net-to-net** against the candidate's anchors (`user_comp_anchors.md`): W2 break-even and the market target. A US role *below* the market target can still be a real raise — do the net math, don't reject on the sticker number. A non-US / wrong-market role below the floor is a hard walk (`feedback_below_floor_comp_hard_walk.md`). If comp is undisclosed, mark it as the unknown to resolve, do not assume.
+- **Location / work auth** — US role or not. The candidate has full US work authorization (green card), so US roles carry no visa friction; the US market is the target (`user_location_workauth.md`, `feedback_us_target_sell_true_self_not_stretch.md`).
+- **English load** — internal-facing (fine) vs customer-facing / heavy synchronous external calls (real stress, stop-factor). Flag honestly where the role sits (`user_english_calibration.md`, `feedback_english_load_preload_answers.md`). This lens can sink an otherwise-strong fit.
+
+#### Step 4 — Part 2: The company as a place to work
+
+Web-research the company (firecrawl_search / web search + the company's own site, recent news). Report only what you can source; mark anything you cannot confirm as **unknown**, never fill gaps with plausible-sounding invention.
+
+- **Stage & money** — funding stage, last raise + date, headcount band, and any public runway/profitability signal. Flag "could be gone in 2 quarters" risk explicitly.
+- **Recent trajectory** — layoffs, hiring freezes, growth or contraction, leadership churn, is the product shipping and alive.
+- **Employer reputation** — Glassdoor-type signals (rating, recurring complaints), remote/RTO policy, and any red flags (mass-hiring churn, pay-to-play, legal trouble, scam markers).
+
+Cite each material claim with its source so the user can trust or discount it.
+
+#### Step 5 — Part 3: Verdict
+
+One of three, with the reasoning compressed to what actually drove it:
+
+- **Pass** — a hard blocker fires: craft has no real overlap; comp below floor on a non-US / wrong-market role; a customer-facing English-heavy role that would collapse under live load; or a disqualifying company signal (imminent insolvency, mass layoffs, scam markers). Give a clean decline — do **not** propose "practice interviews" to salvage a wrong-market role (`feedback_below_floor_comp_hard_walk.md`, `feedback_reps_only_count_in_english.md`).
+- **Go** — craft overlaps a real achievement (Strong/Medium), comp clears the floor or is a genuine US net raise, English load is manageable (internal-facing), and the company is stable enough to be worth the time. Close with one line on what "invest" concretely means here, and *offer* (don't auto-run) the next step.
+- **Conditional** — promising but one or two load-bearing unknowns (comp undisclosed, remote policy unclear, English exposure ambiguous, funding stale). List **exactly** what to confirm on the call to flip it to Go or Pass.
+
+Always end with **"What to confirm on the call"** — 2–3 concrete questions for the candidate to ask, derived from the unknowns and the flip-factors above.
+
+#### Anti-patterns (analyze-specific)
+
+- **Do not write anything.** No Notion page, no TSV row, no local file. Chat output only.
+- **Do not auto-run downstream skills.** Offer interview-coach / tailor on a `Go`; run them only on explicit yes.
+- **Do not improvise positioning or fabricate company facts.** Candidate claims come from `fit_profile.md` / feedback files; company claims come from cited web sources or are marked unknown.
+- **Do not soften a Pass into a sparring session.** A wrong-market / below-floor / English-collapse role gets a clean walk; the candidate's US search wins that time.
+- **Do not call the candidate a "co-founder" or invent a commercial-model label** (`feedback_never_say_cofounder.md`, `feedback_no_fabricated_commercial_profile.md`).
 
 ---
 

--- a/skills/job-pipeline/SKILL.test.js
+++ b/skills/job-pipeline/SKILL.test.js
@@ -25,6 +25,24 @@ test("SKILL.md documents all five CLI commands", () => {
   }
 });
 
+test("SKILL.md documents the analyze mode (post-response decision gate)", () => {
+  const text = fs.readFileSync(SKILL_PATH, "utf8");
+  // Command listed + a mode section header.
+  assert.match(text, /\/job-pipeline analyze/, "missing /analyze command doc");
+  assert.match(text, /^### analyze$/m, "missing ### analyze section");
+  // Verdict rubric is the contract of this mode.
+  assert.match(text, /Go\s*\/\s*Pass\s*\/\s*Conditional/i, "must document the 3-way verdict");
+  // Chat-only, no writes — the load-bearing scope guarantee.
+  assert.match(
+    text,
+    /no CLI phase, no writes/i,
+    "analyze must be documented as chat-only / non-writing"
+  );
+  // Two analysis halves: fit with the candidate + the company as a workplace.
+  assert.match(text, /Part 1: Fit with the candidate/i);
+  assert.match(text, /Part 2: The company as a place to work/i);
+});
+
 test("SKILL.md warns that sync defaults to dry-run", () => {
   const text = fs.readFileSync(SKILL_PATH, "utf8");
   assert.match(text, /Default = dry-run/i);


### PR DESCRIPTION
Doc-sync follow-up to #80 (RFC 064). No behaviour change.

Updates two README spots so the human-facing docs match the shipped `prep` behaviour:
- **"Enhanced company intelligence"** — now states every `prep` brief always opens with the mandatory 8-step research screen (full depth even for a 15-min call).
- **Command table `prep [company]`** — output column lists the 8-step research front-matter + downstream speaking sections.

Per repo rule: README is living documentation; a user-visible command behaviour change updates it in the same effort. RFC 064's file list scoped the code change; this closes the doc gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)