### PR TITLE
feat(job-pipeline): guard rail — never volunteer a gap in candidate-voice text

### DIFF
--- a/skills/job-pipeline/SKILL.md
+++ b/skills/job-pipeline/SKILL.md
@@ -961,6 +961,23 @@ recruiters, cover letters, application answers, outreach notes.
 Interview analog: `interview-coach` convention `18` — an unclosed requirement
 lives in an "if asked" block, never in the main answer.
 
+### Copy-ready drafts — never hard-wrap inside the message
+
+Any text the candidate sends as-is (recruiter reply, LinkedIn DM, application
+answer, cover-letter body) is handed over **unwrapped**: one paragraph is one
+unbroken line, and the only line breaks are the ones the candidate will
+actually see in the sent message — between paragraphs, and between bullets.
+
+**Why:** the block gets copied straight into LinkedIn or Gmail. Hard wraps at
+72/80 columns survive the paste and land in the recruiter's inbox as ragged,
+machine-formatted text. Tidiness in the terminal is not worth that.
+
+- Put the draft in a fenced code block so it copies cleanly, then let the lines
+  run as long as they need to.
+- One bullet is one line, however long it gets.
+- Applies to the delivered draft only. Prose inside skill files, RFCs, and
+  commit messages stays wrapped as usual.
+
 ### Level Filter
 
 Single source of truth: `profiles/<id>/filter_rules.json` → `title_blocklist.patterns` and `location_blocklist.patterns`. Applied as **case-insensitive substring matches** against the full title string. Never hardcode level checks inline — add/remove patterns in `filter_rules.json` only.

--- a/skills/job-pipeline/SKILL.md
+++ b/skills/job-pipeline/SKILL.md
@@ -931,6 +931,36 @@ When a role reaches us via a **recruiter inbound** (LinkedIn DM, email — not o
 
 (Reference case: Taxwell / recruiter "Amjad" called a public full-time Workday role a confidential contract, inflated 5–7yrs → 7+, withheld the company; we declined → we also do not apply directly.)
 
+### Never volunteer a gap — mine for the real overlap first
+
+Applies to every piece of candidate-voice text this skill produces: replies to
+recruiters, cover letters, application answers, outreach notes.
+
+- **Never name what the candidate lacks.** No "close to that", "adjacent to",
+  "not exactly X, but", "no healthcare background, however". A hedge in the
+  opening lines reads as an apology for not fitting and does the screener's
+  rejection work for them.
+- **A gap is acknowledged only on a direct question** ("do you have healthcare
+  experience?"). Even then the answer leads with the closest real experience
+  and concedes only what the question actually forces.
+- **Before conceding anything, mine `fit_profile.md` for the overlap that is
+  already there.** Requirements arrive in the client's vocabulary, not the
+  candidate's — translate the JD's word onto the achievement instead of reading
+  the mismatch off the label. "Member retention" ↔ cohort analysis +
+  save-and-resume/prefill + win-back messaging on a sign-up funnel.
+  "Consumer product" ↔ B2C banking flows. "Experimentation" ↔ 40+ A/B tests on
+  one funnel. The domain word is WHERE, not WHAT
+  (`feedback_fintech_is_where_not_what.md`).
+- **State the match flatly, in the candidate's own terms.** "I owned retention
+  on the sign-up funnel", not "that's close to what I did".
+- **This is omission, not fabrication.** Every claim still comes from
+  `fit_profile.md` / the storybank with its real metric
+  (`feedback_positioning_from_jared_docs.md`). The rule governs what goes
+  unsaid; it never licenses inventing experience the candidate does not have.
+
+Interview analog: `interview-coach` convention `18` — an unclosed requirement
+lives in an "if asked" block, never in the main answer.
+
 ### Level Filter
 
 Single source of truth: `profiles/<id>/filter_rules.json` → `title_blocklist.patterns` and `location_blocklist.patterns`. Applied as **case-insensitive substring matches** against the full title string. Never hardcode level checks inline — add/remove patterns in `filter_rules.json` only.


### PR DESCRIPTION
## Что меняется

Ответы рекрутёрам открывались хеджем («that's close to what I did») — это читается как извинение за несоответствие и делает работу скринера за нас.

Новый Global Guard Rail в `skills/job-pipeline/SKILL.md`:

- О пробеле не говорим сами — только на прямой вопрос.
- Перед тем как что-то признать, ищем реальное перекрытие в `fit_profile.md`: требование приходит в словаре клиента, его надо переводить на достижение кандидата, а не считывать несоответствие с ярлыка домена.
- Совпадение заявляем прямо, своими словами.
- Явно ограничено умолчанием, не выдумыванием: все claims по-прежнему из `fit_profile.md` / storybank с реальными метриками.

Кросс-ссылка на interview-coach convention `18` как интервью-аналог.

## Проверено

- `npm test` — 2312 passed, 0 failed.
- `npx prettier --check skills/job-pipeline/SKILL.md` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)